### PR TITLE
Fix SDK generator cleanup to prevent cancel scope errors

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -868,8 +868,15 @@ async def generate_streaming_response(
 
         # Stream chunks using shared SSE logic
         chunks_buffer = []
-        async for sse_line in _stream_chunks(chunk_source, request, request_id, chunks_buffer):
-            yield sse_line
+        try:
+            async for sse_line in _stream_chunks(chunk_source, request, request_id, chunks_buffer):
+                yield sse_line
+        finally:
+            # Close the SDK generator in the same task that iterated it.
+            # The SDK uses anyio cancel scopes internally; closing from a
+            # different task (e.g. Starlette response teardown) causes
+            # "Attempted to exit cancel scope in a different task".
+            await chunk_source.aclose()
 
         # Capture provider session id (e.g. Codex thread_id) from meta-events
         if session is not None:
@@ -1666,18 +1673,25 @@ async def create_response(
             try:
                 chunks_buffer = []
                 chunk_source = backend.run_completion(**preflight["chunk_kwargs"])
-                async for line in streaming_utils.stream_response_chunks(
-                    chunk_source=chunk_source,
-                    model=body.model,
-                    response_id=resp_id,
-                    output_item_id=output_item_id,
-                    chunks_buffer=chunks_buffer,
-                    logger=logger,
-                    prompt_text=prompt,
-                    metadata=body.metadata or {},
-                    stream_result=stream_result,
-                ):
-                    yield line
+                try:
+                    async for line in streaming_utils.stream_response_chunks(
+                        chunk_source=chunk_source,
+                        model=body.model,
+                        response_id=resp_id,
+                        output_item_id=output_item_id,
+                        chunks_buffer=chunks_buffer,
+                        logger=logger,
+                        prompt_text=prompt,
+                        metadata=body.metadata or {},
+                        stream_result=stream_result,
+                    ):
+                        yield line
+                finally:
+                    # Close the SDK generator in the same task that iterated it.
+                    # The SDK uses anyio cancel scopes internally; closing from a
+                    # different task (e.g. Starlette response teardown) causes
+                    # "Attempted to exit cancel scope in a different task".
+                    await chunk_source.aclose()
 
                 # ALWAYS capture provider_session_id (even on failure).
                 # On failure, this is internal-only: no response_id is committed for the


### PR DESCRIPTION
## Summary
This PR fixes a critical issue where SDK generators were not being properly closed, causing "Attempted to exit cancel scope in a different task" errors when Starlette's response teardown tried to clean up resources from a different async task.

## Key Changes
- Added `try/finally` blocks around async iteration of SDK chunk sources in two streaming response handlers
- Ensured `chunk_source.aclose()` is called in the same task that iterated the generator, preventing cross-task cancel scope violations
- Applied the fix to both `generate_streaming_response()` and `_run_stream()` functions

## Implementation Details
The SDK uses anyio cancel scopes internally, which are task-specific. When a generator is not explicitly closed and cleanup happens in a different task (such as during Starlette's response teardown), it triggers a cancel scope error. By wrapping the async iteration in a try/finally block and explicitly closing the generator in the same task that iterated it, we ensure proper resource cleanup and prevent these errors.

https://claude.ai/code/session_01BYvbzuX4W19tiprchvkxqo