### PR TITLE
feat(mcp): add symbolic tool handling and streamable-http transport

### DIFF
--- a/src/backends/claude/client.py
+++ b/src/backends/claude/client.py
@@ -44,7 +44,7 @@ from src.backends.base import ResolvedModel
 from src.constants import DEFAULT_TIMEOUT_MS, PERMISSION_MODE_BYPASS
 from src.message_adapter import MessageAdapter
 from src.image_handler import ImageHandler
-from src.mcp_config import get_mcp_servers
+from src.mcp_config import get_mcp_servers, get_mcp_tool_patterns
 
 logger = logging.getLogger(__name__)
 
@@ -180,10 +180,18 @@ class ClaudeCodeCLI:
             options["permission_mode"] = PERMISSION_MODE_BYPASS
             logger.debug(f"Tools enabled by user request: {DEFAULT_ALLOWED_TOOLS}")
 
-        # Add MCP servers if configured (Claude only)
+        # Add MCP servers if configured (Claude only).
+        # The SDK connects to the servers and resolves tool schemas internally.
+        # We add symbolic tool patterns (mcp__<server>__*) to allowed_tools
+        # so the SDK knows which MCP tools to enable without serializing full
+        # JSON schemas into the API request payload.
         mcp_servers = get_mcp_servers()
         if mcp_servers:
             options["mcp_servers"] = mcp_servers
+            if request.enable_tools:
+                mcp_patterns = get_mcp_tool_patterns(mcp_servers)
+                options.setdefault("allowed_tools", []).extend(mcp_patterns)
+                logger.debug(f"MCP tools enabled symbolically: {mcp_patterns}")
             logger.debug(f"MCP servers enabled: {list(mcp_servers.keys())}")
 
         return options

--- a/src/main.py
+++ b/src/main.py
@@ -5,7 +5,7 @@ import logging
 import secrets
 import string
 import uuid
-from typing import Optional, AsyncGenerator, Dict, Any
+from typing import Optional, AsyncGenerator, Dict, Any, List
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException, Request, Depends
@@ -71,7 +71,7 @@ from src.constants import (
     PERMISSION_MODE_BYPASS,
 )
 from src.backends.claude.constants import DEFAULT_ALLOWED_TOOLS
-from src.mcp_config import get_mcp_servers
+from src.mcp_config import get_mcp_servers, get_mcp_tool_patterns
 from src import streaming_utils
 
 # Note: load_dotenv() is called in constants.py at import time
@@ -611,6 +611,14 @@ async def _stream_chunks(
         logger=logger,
     ):
         yield line
+
+
+def _mcp_allowed_tools() -> Optional[List[str]]:
+    """Return symbolic MCP tool patterns if MCP servers are configured, else None."""
+    servers = get_mcp_servers()
+    if not servers:
+        return None
+    return get_mcp_tool_patterns(servers)
 
 
 def _prepare_stateless_completion(messages: list, claude_options: Dict[str, Any]) -> tuple:
@@ -1191,13 +1199,16 @@ async def anthropic_messages(
         # Run Claude Code - tools enabled by default for Anthropic SDK clients
         # (they're typically using this for agentic workflows)
         mcp_servers = get_mcp_servers() or None
+        allowed_tools = list(DEFAULT_ALLOWED_TOOLS)
+        if mcp_servers:
+            allowed_tools.extend(get_mcp_tool_patterns(mcp_servers))
         chunks = []
         async for chunk in claude_backend.run_completion(
             prompt=prompt,
             system_prompt=system_prompt,
             model=request_body.model,
             max_turns=DEFAULT_MAX_TURNS,
-            allowed_tools=DEFAULT_ALLOWED_TOOLS,
+            allowed_tools=allowed_tools,
             permission_mode=PERMISSION_MODE_BYPASS,
             stream=False,
             mcp_servers=mcp_servers,
@@ -1561,6 +1572,7 @@ async def _responses_streaming_preflight(
             system_prompt=system_prompt if is_new_session else None,
             permission_mode=PERMISSION_MODE_BYPASS,
             mcp_servers=get_mcp_servers() if resolved.backend == "claude" else None,
+            allowed_tools=_mcp_allowed_tools() if resolved.backend == "claude" else None,
             session_id=session_id if is_new_session else None,
             resume=resume_id,
         ),
@@ -1799,6 +1811,7 @@ async def create_response(
                     system_prompt=system_prompt if is_new_session else None,
                     permission_mode=PERMISSION_MODE_BYPASS,
                     mcp_servers=get_mcp_servers() if resolved.backend == "claude" else None,
+                    allowed_tools=_mcp_allowed_tools() if resolved.backend == "claude" else None,
                     session_id=session_id if is_new_session else None,
                     resume=resume_id,
                 ):

--- a/src/mcp_config.py
+++ b/src/mcp_config.py
@@ -6,7 +6,7 @@ Loads server-level MCP config from the MCP_CONFIG environment variable.
 import json
 import logging
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from src.constants import MCP_CONFIG
 
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 McpServersDict = Dict[str, Dict[str, Any]]
 
-ALLOWED_TYPES = {"stdio", "sse", "http"}
+ALLOWED_TYPES = {"stdio", "sse", "http", "streamable-http"}
 
 
 def load_mcp_config() -> McpServersDict:
@@ -56,6 +56,7 @@ def load_mcp_config() -> McpServersDict:
         "stdio": ("command",),
         "sse": ("url",),
         "http": ("url",),
+        "streamable-http": ("url",),
     }
 
     validated: McpServersDict = {}
@@ -80,6 +81,21 @@ def load_mcp_config() -> McpServersDict:
         logger.info(f"Loaded {len(validated)} MCP server(s): {list(validated.keys())}")
 
     return validated
+
+
+def get_mcp_tool_patterns(servers: McpServersDict) -> List[str]:
+    """Return symbolic MCP tool patterns for allowed_tools.
+
+    The Claude Agent SDK resolves MCP tools using the naming convention
+    ``mcp__<server_name>__*``.  By adding these patterns to ``allowed_tools``
+    the SDK manages tool schemas internally — the gateway never needs to
+    serialize full MCP tool JSON schemas into the API request payload.
+
+    This avoids bloating the request body with large tool schemas that can
+    cause compatibility issues with non-Claude models behind LiteLLM or
+    other proxies.
+    """
+    return [f"mcp__{'_'.join(name.split('-'))}__*" for name in servers]
 
 
 _server_mcp_config: McpServersDict = load_mcp_config()

--- a/tests/test_backend_contract.py
+++ b/tests/test_backend_contract.py
@@ -242,6 +242,26 @@ class TestBuildOptions:
         options = mock_claude_cli.build_options(req, resolved, overrides={"max_turns": 5})
         assert options["max_turns"] == 5
 
+    def test_claude_build_options_mcp_tools_added_when_enabled(self, mock_claude_cli):
+        """MCP tool patterns are added to allowed_tools when tools are enabled."""
+        servers = {"my-router": {"type": "stdio", "command": "echo"}}
+        with patch("src.backends.claude.client.get_mcp_servers", return_value=servers):
+            req = self._make_request(enable_tools=True)
+            resolved = ResolvedModel(public_model="opus", backend="claude", provider_model="opus")
+            options = mock_claude_cli.build_options(req, resolved)
+            assert "mcp__my_router__*" in options["allowed_tools"]
+            assert "mcp_servers" in options
+
+    def test_claude_build_options_mcp_tools_not_added_when_disabled(self, mock_claude_cli):
+        """MCP tool patterns are not added when tools are disabled."""
+        servers = {"my-router": {"type": "stdio", "command": "echo"}}
+        with patch("src.backends.claude.client.get_mcp_servers", return_value=servers):
+            req = self._make_request(enable_tools=False)
+            resolved = ResolvedModel(public_model="opus", backend="claude", provider_model="opus")
+            options = mock_claude_cli.build_options(req, resolved)
+            assert "allowed_tools" not in options
+            assert "mcp_servers" in options
+
     def test_codex_build_options_tools_enabled(self, mock_codex_cli):
         req = self._make_request(enable_tools=True, model="codex")
         resolved = ResolvedModel(public_model="codex", backend="codex", provider_model="gpt-5.4")

--- a/tests/test_main_api_unit.py
+++ b/tests/test_main_api_unit.py
@@ -258,7 +258,7 @@ def test_anthropic_messages_success():
     assert body["content"][0]["text"] == "Anthropic answer"
     assert body["stop_reason"] == "end_turn"
     assert run_calls[0]["prompt"] == "Assistant: Earlier reply\n\nWhat now?"
-    assert run_calls[0]["allowed_tools"] == main.DEFAULT_ALLOWED_TOOLS
+    assert run_calls[0]["allowed_tools"] == main.DEFAULT_ALLOWED_TOOLS + ["mcp__demo__*"]
     assert run_calls[0]["permission_mode"] == main.PERMISSION_MODE_BYPASS
     assert run_calls[0]["mcp_servers"] == {"demo": {"type": "stdio"}}
 

--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -5,7 +5,7 @@ Unit tests for src/mcp_config.py
 
 import json
 from unittest.mock import patch
-from src.mcp_config import load_mcp_config, get_mcp_servers
+from src.mcp_config import load_mcp_config, get_mcp_servers, get_mcp_tool_patterns
 
 
 class TestLoadMcpConfig:
@@ -124,6 +124,60 @@ class TestLoadMcpConfig:
         with patch("src.mcp_config.MCP_CONFIG", json.dumps(config)):
             result = load_mcp_config()
             assert "empty-cmd" not in result
+
+
+class TestStreamableHttpSupport:
+    """Test streamable-http transport type support."""
+
+    def test_streamable_http_with_url_is_accepted(self):
+        """streamable-http server with 'url' field is accepted."""
+        config = {
+            "mcpServers": {
+                "sh-server": {"type": "streamable-http", "url": "http://localhost:3000/mcp"}
+            }
+        }
+        with patch("src.mcp_config.MCP_CONFIG", json.dumps(config)):
+            result = load_mcp_config()
+            assert "sh-server" in result
+
+    def test_streamable_http_missing_url_is_skipped(self):
+        """streamable-http server without 'url' field is rejected."""
+        config = {"mcpServers": {"bad-sh": {"type": "streamable-http"}}}
+        with patch("src.mcp_config.MCP_CONFIG", json.dumps(config)):
+            result = load_mcp_config()
+            assert "bad-sh" not in result
+
+
+class TestGetMcpToolPatterns:
+    """Test get_mcp_tool_patterns() symbolic tool name generation."""
+
+    def test_empty_servers_returns_empty(self):
+        assert get_mcp_tool_patterns({}) == []
+
+    def test_single_server_pattern(self):
+        servers = {"my-router": {"type": "stdio", "command": "echo"}}
+        patterns = get_mcp_tool_patterns(servers)
+        assert patterns == ["mcp__my_router__*"]
+
+    def test_multiple_servers_patterns(self):
+        servers = {
+            "docs": {"type": "stdio", "command": "echo"},
+            "mcp-router": {"type": "sse", "url": "http://localhost:3000"},
+        }
+        patterns = get_mcp_tool_patterns(servers)
+        assert len(patterns) == 2
+        assert "mcp__docs__*" in patterns
+        assert "mcp__mcp_router__*" in patterns
+
+    def test_hyphenated_names_converted_to_underscores(self):
+        servers = {"my-cool-server": {"type": "stdio", "command": "echo"}}
+        patterns = get_mcp_tool_patterns(servers)
+        assert patterns == ["mcp__my_cool_server__*"]
+
+    def test_underscore_names_preserved(self):
+        servers = {"my_server": {"type": "stdio", "command": "echo"}}
+        patterns = get_mcp_tool_patterns(servers)
+        assert patterns == ["mcp__my_server__*"]
 
 
 class TestGetMcpServers:


### PR DESCRIPTION
Pass MCP tool names symbolically (mcp__<server>__*) via allowed_tools instead of relying on full JSON schema pass-through. The SDK resolves tool schemas internally, avoiding payload bloat that causes compatibility issues with non-Claude models behind LiteLLM or other proxies.

Also adds streamable-http as a supported MCP transport type alongside stdio, sse, and http.

https://claude.ai/code/session_014pwWWQJaAJ8P9XGSwT9skA