### PR TITLE
feat(openwebui): map X-OpenWebUI-Chat-Id header to session_id for mul…

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -69,6 +69,8 @@ from src.constants import (
     DEFAULT_MAX_TURNS,
     MAX_REQUEST_SIZE,
     PERMISSION_MODE_BYPASS,
+    RESPONSE_SENTINEL,
+    WRAP_INTERMEDIATE_THINKING,
 )
 from src.backends.claude.constants import DEFAULT_ALLOWED_TOOLS
 from src.mcp_config import get_mcp_servers, get_mcp_tool_patterns
@@ -1833,6 +1835,11 @@ async def create_response(
             assistant_text = backend.parse_message(chunks)
             if not assistant_text:
                 raise HTTPException(status_code=502, detail="No response from backend")
+
+            # Apply thinking wrapper for non-streaming responses
+            if WRAP_INTERMEDIATE_THINKING and RESPONSE_SENTINEL in assistant_text:
+                parts = assistant_text.split(RESPONSE_SENTINEL, 1)
+                assistant_text = f"<think>\n{parts[0]}\n</think>\n{parts[1]}"
 
             # SUCCESS-ONLY: commit turn counter and session messages
             session.turn_counter = next_turn

--- a/src/streaming_utils.py
+++ b/src/streaming_utils.py
@@ -970,6 +970,11 @@ async def stream_response_chunks(
     if stream_result is None:
         stream_result = {}
 
+    # WRAP_INTERMEDIATE_THINKING support — same sentinel logic as chat completions.
+    wrap_thinking = WRAP_INTERMEDIATE_THINKING
+    think_opened = False
+    sentinel_filter = SentinelStreamFilter(RESPONSE_SENTINEL, replacement="\n</think>\n")
+
     def _next_seq() -> int:
         nonlocal seq
         current = seq
@@ -1067,15 +1072,33 @@ async def stream_response_chunks(
             text_delta, in_thinking = extract_stream_event_delta(chunk, in_thinking)
             if text_delta is not None:
                 token_streaming = True
-                # Suppress thinking content in Responses API
-                if was_thinking or in_thinking or text_delta in ("<think>", "</think>"):
-                    continue
-                if text_delta:
-                    cleaned = collab_filter.feed(text_delta)
-                    if cleaned:
-                        yield _emit_delta(cleaned)
-                        full_text.append(cleaned)
-                        content_sent = True
+                if wrap_thinking:
+                    # Same logic as chat completions: wrap intermediate
+                    # thinking in <think> tags, use sentinel to close.
+                    if text_delta in ("<think>", "</think>"):
+                        continue
+                    if text_delta:
+                        cleaned = collab_filter.feed(text_delta)
+                        if cleaned:
+                            if not think_opened:
+                                think_opened = True
+                                yield _emit_delta("<think>\n")
+                                full_text.append("<think>\n")
+                            filtered, _triggered = sentinel_filter.feed(cleaned)
+                            if filtered:
+                                yield _emit_delta(filtered)
+                                full_text.append(filtered)
+                                content_sent = True
+                else:
+                    # Default: suppress thinking content in Responses API
+                    if was_thinking or in_thinking or text_delta in ("<think>", "</think>"):
+                        continue
+                    if text_delta:
+                        cleaned = collab_filter.feed(text_delta)
+                        if cleaned:
+                            yield _emit_delta(cleaned)
+                            full_text.append(cleaned)
+                            content_sent = True
                 continue
 
             # Accumulate tool_use blocks from stream events
@@ -1129,9 +1152,20 @@ async def stream_response_chunks(
             chunks_buffer.append(chunk)
             text = format_chunk_content(chunk, content_sent)
             if text:
-                yield _emit_delta(text)
-                full_text.append(text)
-                content_sent = True
+                if wrap_thinking:
+                    if not think_opened:
+                        think_opened = True
+                        yield _emit_delta("<think>\n")
+                        full_text.append("<think>\n")
+                    filtered, _triggered = sentinel_filter.feed(text)
+                    if filtered:
+                        yield _emit_delta(filtered)
+                        full_text.append(filtered)
+                        content_sent = True
+                else:
+                    yield _emit_delta(text)
+                    full_text.append(text)
+                    content_sent = True
 
     except Exception as e:
         logger.error("Responses stream: unexpected error: %s", e, exc_info=True)
@@ -1140,11 +1174,31 @@ async def stream_response_chunks(
         return
 
     # Flush any remaining buffered text from the collab filter
-    remaining = collab_filter.flush()
-    if remaining:
-        yield _emit_delta(remaining)
-        full_text.append(remaining)
-        content_sent = True
+    remaining_collab = collab_filter.flush()
+    if remaining_collab:
+        if wrap_thinking:
+            filtered, _triggered = sentinel_filter.feed(remaining_collab)
+            if filtered:
+                yield _emit_delta(filtered)
+                full_text.append(filtered)
+                content_sent = True
+        else:
+            yield _emit_delta(remaining_collab)
+            full_text.append(remaining_collab)
+            content_sent = True
+
+    # Flush sentinel filter buffer
+    if wrap_thinking:
+        remaining_sentinel = sentinel_filter.flush()
+        if remaining_sentinel:
+            yield _emit_delta(remaining_sentinel)
+            full_text.append(remaining_sentinel)
+            content_sent = True
+
+        # If think was opened but sentinel never fired, close it at stream end
+        if think_opened and not sentinel_filter.triggered:
+            yield _emit_delta("\n</think>\n")
+            full_text.append("\n</think>\n")
 
     if tool_acc.has_incomplete:
         logger.warning("Incomplete tool_use blocks at stream end: %s", tool_acc.incomplete_keys)

--- a/tests/test_streaming_utils_unit.py
+++ b/tests/test_streaming_utils_unit.py
@@ -1625,3 +1625,227 @@ async def test_stream_chunks_wrap_thinking_suppresses_sdk_think_tags():
     # Only ONE pair of think tags (our wrapper), no nested SDK ones
     assert all_content.count("<think>") == 1
     assert all_content.count("</think>") == 1
+
+
+# ---------------------------------------------------------------------------
+# WRAP_INTERMEDIATE_THINKING tests for stream_response_chunks (/v1/responses)
+# ---------------------------------------------------------------------------
+
+
+def _collect_response_deltas(lines):
+    """Extract concatenated text from response.output_text.delta SSE lines."""
+    text = ""
+    for line in lines:
+        event_type, data = _parse_response_sse(line)
+        if event_type == "response.output_text.delta":
+            text += data.get("delta", "")
+    return text
+
+
+@pytest.mark.asyncio
+async def test_response_stream_wrap_thinking_sentinel():
+    """stream_response_chunks wraps thinking and splits on sentinel when enabled."""
+
+    async def source():
+        yield {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "Thinking about it..."},
+            },
+        }
+        yield {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "<response>"},
+            },
+        }
+        yield {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "Here is the answer."},
+            },
+        }
+
+    chunks_buffer = []
+    stream_result = {}
+
+    with patch("src.streaming_utils.WRAP_INTERMEDIATE_THINKING", True):
+        lines = [
+            line
+            async for line in stream_response_chunks(
+                chunk_source=source(),
+                model="claude-test",
+                response_id="resp-wrap-1",
+                output_item_id="msg-wrap-1",
+                chunks_buffer=chunks_buffer,
+                logger=logging.getLogger("test-resp-wrap"),
+                stream_result=stream_result,
+            )
+        ]
+
+    all_text = _collect_response_deltas(lines)
+    assert "<think>" in all_text
+    assert "</think>" in all_text
+    assert "<response>" not in all_text
+    think_end = all_text.index("</think>")
+    inside = all_text[:think_end]
+    outside = all_text[think_end + len("</think>"):]
+    assert "Thinking about it..." in inside
+    assert "Here is the answer." in outside
+    assert stream_result.get("success") is True
+
+
+@pytest.mark.asyncio
+async def test_response_stream_wrap_thinking_disabled_suppresses():
+    """When disabled, thinking content is suppressed (default Responses API behavior)."""
+
+    async def source():
+        yield {
+            "type": "stream_event",
+            "event": {"type": "content_block_start", "content_block": {"type": "thinking"}},
+        }
+        yield {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "thinking_delta", "thinking": "hidden thinking"},
+            },
+        }
+        yield {
+            "type": "stream_event",
+            "event": {"type": "content_block_stop"},
+        }
+        yield {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "Visible answer"},
+            },
+        }
+
+    chunks_buffer = []
+    stream_result = {}
+
+    with patch("src.streaming_utils.WRAP_INTERMEDIATE_THINKING", False):
+        lines = [
+            line
+            async for line in stream_response_chunks(
+                chunk_source=source(),
+                model="claude-test",
+                response_id="resp-nowrap-1",
+                output_item_id="msg-nowrap-1",
+                chunks_buffer=chunks_buffer,
+                logger=logging.getLogger("test-resp-nowrap"),
+                stream_result=stream_result,
+            )
+        ]
+
+    all_text = _collect_response_deltas(lines)
+    assert "<think>" not in all_text
+    assert "hidden thinking" not in all_text
+    assert "Visible answer" in all_text
+
+
+@pytest.mark.asyncio
+async def test_response_stream_wrap_thinking_no_sentinel_closes_at_end():
+    """If model never emits sentinel, think tag is closed at stream end."""
+
+    async def source():
+        yield {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "Working on it..."},
+            },
+        }
+
+    chunks_buffer = []
+    stream_result = {}
+
+    with patch("src.streaming_utils.WRAP_INTERMEDIATE_THINKING", True):
+        lines = [
+            line
+            async for line in stream_response_chunks(
+                chunk_source=source(),
+                model="claude-test",
+                response_id="resp-nosent-1",
+                output_item_id="msg-nosent-1",
+                chunks_buffer=chunks_buffer,
+                logger=logging.getLogger("test-resp-nosent"),
+                stream_result=stream_result,
+            )
+        ]
+
+    all_text = _collect_response_deltas(lines)
+    assert "<think>" in all_text
+    assert "</think>" in all_text
+    assert "Working on it..." in all_text
+
+
+@pytest.mark.asyncio
+async def test_response_stream_wrap_thinking_suppresses_sdk_think_tags():
+    """SDK-native think tags are suppressed when wrapping is on."""
+
+    async def source():
+        yield {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "<think>"},
+            },
+        }
+        yield {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "inner reasoning"},
+            },
+        }
+        yield {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "</think>"},
+            },
+        }
+        yield {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "<response>"},
+            },
+        }
+        yield {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "Final answer"},
+            },
+        }
+
+    chunks_buffer = []
+    stream_result = {}
+
+    with patch("src.streaming_utils.WRAP_INTERMEDIATE_THINKING", True):
+        lines = [
+            line
+            async for line in stream_response_chunks(
+                chunk_source=source(),
+                model="claude-test",
+                response_id="resp-sdktag-1",
+                output_item_id="msg-sdktag-1",
+                chunks_buffer=chunks_buffer,
+                logger=logging.getLogger("test-resp-sdktag"),
+                stream_result=stream_result,
+            )
+        ]
+
+    all_text = _collect_response_deltas(lines)
+    # Only our wrapper tags, not SDK ones
+    assert all_text.count("<think>") == 1
+    assert all_text.count("</think>") == 1
+    assert "inner reasoning" in all_text
+    assert "Final answer" in all_text


### PR DESCRIPTION
…ti-turn continuity

When CD_OPENWEBUI=true, the gateway extracts the X-OpenWebUI-Chat-Id header from incoming /v1/chat/completions requests and uses it as the session_id. This enables automatic conversation continuity across turns when Open WebUI has ENABLE_FORWARD_USER_INFO_HEADERS=true.

Explicit session_id in the request body takes precedence over the header.

https://claude.ai/code/session_014pwWWQJaAJ8P9XGSwT9skA