### PR TITLE
fix(image): fall back to temp dir when cwd is read-only

### DIFF
--- a/src/image_handler.py
+++ b/src/image_handler.py
@@ -10,6 +10,7 @@ Only synchronous operations — no remote URL fetching (SSRF-free).
 import base64
 import hashlib
 import logging
+import tempfile
 import time
 from pathlib import Path
 from typing import Tuple
@@ -31,7 +32,16 @@ class ImageHandler:
 
     def __init__(self, base_dir: Path):
         self.image_dir = base_dir / ".claude_images"
-        self.image_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            self.image_dir.mkdir(parents=True, exist_ok=True)
+        except PermissionError:
+            fallback = Path(tempfile.mkdtemp(prefix="claude_images_"))
+            logger.warning(
+                "Cannot create %s (read-only?). Using fallback: %s",
+                self.image_dir,
+                fallback,
+            )
+            self.image_dir = fallback
 
     # ------------------------------------------------------------------
     # Core: decode + save

--- a/tests/test_image_handler.py
+++ b/tests/test_image_handler.py
@@ -3,6 +3,7 @@
 import base64
 import os
 import time
+from pathlib import Path
 
 import pytest
 
@@ -161,3 +162,25 @@ def test_image_dir_created(tmp_path):
     assert not target.exists()
     ImageHandler(target)
     assert (target / ".claude_images").is_dir()
+
+
+def test_readonly_base_dir_falls_back_to_temp(tmp_path, monkeypatch):
+    """When base_dir mkdir raises PermissionError, ImageHandler falls back to temp."""
+    from unittest.mock import patch
+
+    original_mkdir = Path.mkdir
+
+    def _fail_mkdir(self, *args, **kwargs):
+        if ".claude_images" in str(self):
+            raise PermissionError("read-only filesystem")
+        return original_mkdir(self, *args, **kwargs)
+
+    with patch.object(Path, "mkdir", _fail_mkdir):
+        handler = ImageHandler(tmp_path)
+
+    # Should have fallen back — image_dir is NOT under tmp_path
+    assert handler.image_dir != tmp_path / ".claude_images"
+    assert handler.image_dir.exists()
+    # Saving should still work
+    path = handler.save_base64_image(TINY_PNG, "image/png")
+    assert path.exists()


### PR DESCRIPTION
When CLAUDE_CWD points to a read-only mount (e.g. for CLAUDE.md), ImageHandler now catches PermissionError on .claude_images creation and falls back to a writable temp directory instead of crashing.

https://claude.ai/code/session_014pwWWQJaAJ8P9XGSwT9skA