### PR TITLE
fix(client): inject CLAUDE.md into custom system prompts

### DIFF
--- a/src/backends/claude/client.py
+++ b/src/backends/claude/client.py
@@ -211,6 +211,23 @@ class ClaudeCodeCLI:
     # SDK option helpers
     # ------------------------------------------------------------------
 
+    def _read_claude_md(self) -> Optional[str]:
+        """Read CLAUDE.md from cwd, returning its contents or None."""
+        if not self.cwd:
+            return None
+        path = os.path.join(self.cwd, "CLAUDE.md")
+        try:
+            with open(path) as f:
+                content = f.read().strip()
+            if content:
+                logger.info("Injecting CLAUDE.md (%d chars) into system prompt", len(content))
+                return content
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            logger.warning("Failed to read %s: %s", path, exc)
+        return None
+
     def _configure_thinking(self, options: ClaudeAgentOptions) -> None:
         """Apply thinking-mode configuration to *options*."""
         if THINKING_MODE == "adaptive":
@@ -309,13 +326,24 @@ class ClaudeCodeCLI:
         if model:
             options.model = model
         if system_prompt:
+            # A custom system_prompt replaces the claude_code preset, which
+            # means the SDK won't inject CLAUDE.md automatically.  Append the
+            # file contents so project instructions are still honoured.
+            claude_md = self._read_claude_md()
+            if claude_md:
+                system_prompt = system_prompt + "\n\n" + claude_md
             if WRAP_INTERMEDIATE_THINKING:
                 system_prompt = system_prompt + RESPONSE_SENTINEL_INSTRUCTION
             options.system_prompt = {"type": "text", "text": system_prompt}
         elif WRAP_INTERMEDIATE_THINKING:
             # Can't append to a preset, so use the instruction as a standalone
             # system prompt. The SDK still applies its built-in behaviour.
-            options.system_prompt = {"type": "text", "text": RESPONSE_SENTINEL_INSTRUCTION.strip()}
+            parts = []
+            claude_md = self._read_claude_md()
+            if claude_md:
+                parts.append(claude_md)
+            parts.append(RESPONSE_SENTINEL_INSTRUCTION.strip())
+            options.system_prompt = {"type": "text", "text": "\n\n".join(parts)}
         else:
             options.system_prompt = {"type": "preset", "preset": "claude_code"}
         if permission_mode:
@@ -487,6 +515,15 @@ class ClaudeCodeCLI:
                     resume=resume,
                 )
 
+                logger.info(
+                    "SDK query options: cwd=%s, setting_sources=%s, "
+                    "system_prompt=%s, permission_mode=%s, model=%s",
+                    options.cwd,
+                    options.setting_sources,
+                    options.system_prompt,
+                    options.permission_mode,
+                    options.model,
+                )
                 async for message in query(prompt=prompt, options=options):
                     logger.debug(f"Raw SDK message type: {type(message)}")
                     logger.debug(f"Raw SDK message: {message}")


### PR DESCRIPTION
When a custom system_prompt is provided (from request system messages) or WRAP_INTERMEDIATE_THINKING is enabled, the SDK receives a raw text system prompt instead of the claude_code preset. This bypasses the SDK's automatic CLAUDE.md loading via setting_sources=["project"].

Read CLAUDE.md from cwd and append it to the system prompt so project instructions are honoured regardless of how the prompt is configured.

https://claude.ai/code/session_014pwWWQJaAJ8P9XGSwT9skA