### PR TITLE
fix(pipe): yield trailing zero-width space to force final markdown re…

### DIFF
--- a/chatdragon.py
+++ b/chatdragon.py
@@ -562,7 +562,11 @@ class Pipeline:
                                 "model": self.valves.MODEL,
                             }
                             log.debug("Chain updated: chat=%s, response_id=%s", chat_id, new_id)
-                        yield "\n"
+                        # Yield trailing content to force Open WebUI's streaming
+                        # markdown renderer to do a final re-parse. Without this,
+                        # the last <details> block may not render because the
+                        # marked tokenizer's debounced update never fires.
+                        yield "\n\n\u200b"
 
                     elif event_type in ("response.failed", "error"):
                         error = event.get("response", {}).get("error", {})


### PR DESCRIPTION
…-parse

Open WebUI's streaming markdown renderer debounces updates and doesn't always trigger a final re-parse when the stream ends. This causes the last <details type="tool_calls"> block to render as raw HTML instead of being processed by the custom detailsTokenizer.

Yield a zero-width space after newlines on response.completed to force the renderer to do one more parse cycle.

https://claude.ai/code/session_014pwWWQJaAJ8P9XGSwT9skA