### PR TITLE
fix(pipe): bypass thought_wrapped buffer for tool call <details> blocks

### DIFF
--- a/chatdragon.py
+++ b/chatdragon.py
@@ -347,6 +347,7 @@ class Pipeline:
         text_buffer = ""
         BUFFER_SIZE = 50
         RESPONSE_TAG = "<response>"
+        TOOL_DETAILS_PREFIX = "\n\n<details "
 
         try:
             if thought_wrapped:
@@ -356,6 +357,15 @@ class Pipeline:
             for chunk in self._stream_responses_raw_sync(chat_id, payload, instructions_hash):
                 if thought_wrapped:
                     if response_tag_sent:
+                        yield chunk
+                    elif chunk.startswith(TOOL_DETAILS_PREFIX):
+                        # Tool call <details> blocks must bypass the buffer
+                        # entirely. The buffer holds back the last 10 chars to
+                        # avoid splitting "<response>", but that also splits
+                        # "</details>" and breaks Open WebUI rendering.
+                        if text_buffer:
+                            yield text_buffer
+                            text_buffer = ""
                         yield chunk
                     else:
                         text_buffer += chunk
@@ -406,6 +416,11 @@ class Pipeline:
                 for chunk in self._stream_responses_raw_sync(chat_id, payload, instructions_hash):
                     if thought_wrapped:
                         if response_tag_sent:
+                            yield chunk
+                        elif chunk.startswith(TOOL_DETAILS_PREFIX):
+                            if text_buffer:
+                                yield text_buffer
+                                text_buffer = ""
                             yield chunk
                         else:
                             text_buffer += chunk
@@ -562,11 +577,7 @@ class Pipeline:
                                 "model": self.valves.MODEL,
                             }
                             log.debug("Chain updated: chat=%s, response_id=%s", chat_id, new_id)
-                        # Yield trailing content to force Open WebUI's streaming
-                        # markdown renderer to do a final re-parse. Without this,
-                        # the last <details> block may not render because the
-                        # marked tokenizer's debounced update never fires.
-                        yield "\n\n\u200b"
+                        yield "\n"
 
                     elif event_type in ("response.failed", "error"):
                         error = event.get("response", {}).get("error", {})


### PR DESCRIPTION
The thought_wrapped buffer holds back the last 10 characters (length of "<response>") to avoid splitting that tag across yields. However, this also splits "</details>" closing tags, causing the last tool call block to render as raw HTML in Open WebUI.

Tool call <details> blocks are now detected by their prefix and yielded directly, bypassing the buffer entirely. The buffer is flushed first to maintain ordering.

Also reverts the zero-width space trailing content fix from the previous commit, as this was the actual root cause.

https://claude.ai/code/session_014pwWWQJaAJ8P9XGSwT9skA