### PR TITLE
fix(pipe): always render tool results as details blocks including errors

### DIFF
--- a/chatdragon.py
+++ b/chatdragon.py
@@ -561,30 +561,27 @@ class Pipeline:
                             result_content = str(raw_content or "").strip()
                         if not result_content and is_error:
                             result_content = event.get("error", "Tool execution failed")
-                        # SDK overflow: result was too large but tool did succeed.
-                        # Show a short note in the details block instead of the
-                        # full verbose SDK message.
+                        # SDK overflow: shorten the verbose message.
                         if result_content.startswith("Error: result ("):
                             m = re.search(r"\(([0-9,]+) characters?\)", result_content)
                             chars = m.group(1) if m else "large"
                             result_content = f"Result truncated ({chars} chars)"
                         result_content = result_content[:500]
-                        if is_error:
-                            yield f"\n\n**Error** (`{name}`): {result_content}\n\n"
-                        else:
-                            # Escape for HTML attributes
-                            esc_name = html.escape(name)
-                            esc_args = html.escape(args)
-                            esc_result = html.escape(result_content)
-                            yield (
-                                f'\n\n<details type="tool_calls" name="{esc_name}"'
-                                f' arguments="{esc_args}"'
-                                f' result="{esc_result}"'
-                                f' status="complete"'
-                                f' done="true">\n'
-                                f"<summary>Tool: {esc_name}</summary>\n"
-                                f"</details>\n\n"
-                            )
+                        # Always render as a <details> block — errors show
+                        # with status="error" so the UI can style them.
+                        esc_name = html.escape(name)
+                        esc_args = html.escape(args)
+                        esc_result = html.escape(result_content)
+                        status = "error" if is_error else "complete"
+                        yield (
+                            f'\n\n<details type="tool_calls" name="{esc_name}"'
+                            f' arguments="{esc_args}"'
+                            f' result="{esc_result}"'
+                            f' status="{status}"'
+                            f' done="true">\n'
+                            f"<summary>Tool: {esc_name}</summary>\n"
+                            f"</details>\n\n"
+                        )
 
                     elif event_type == "response.completed":
                         completed = True


### PR DESCRIPTION
All tool results (success, error, overflow) now render as <details> blocks consistently. Errors use status="error" for UI styling but remain in the collapsible format like other tool results instead of being shown as plain inline text.

https://claude.ai/code/session_014pwWWQJaAJ8P9XGSwT9skA