### PR TITLE
fix(pipe): use single-quote attr wrappers and filter Executing status…

### DIFF
--- a/chatdragon.py
+++ b/chatdragon.py
@@ -508,6 +508,10 @@ class Pipeline:
                     if event_type == "response.output_text.delta":
                         delta = event.get("delta", "")
                         if delta:
+                            # Filter out SDK "Executing tool..." status lines
+                            stripped = delta.strip()
+                            if stripped.startswith("Executing ") and stripped.endswith("..."):
+                                continue
                             yield delta
 
                     elif event_type == "response.task_started":
@@ -568,13 +572,16 @@ class Pipeline:
                             result_content = f"Result truncated ({chars} chars)"
                         result_content = result_content[:10000]
                         esc_name = html.escape(name)
-                        esc_args = html.escape(args)
-                        esc_result = html.escape(result_content)
+                        # Use single-quote wrappers for arguments and result
+                        # to avoid &quot; inside the value breaking Open WebUI's
+                        # attribute parser.
+                        esc_args = args.replace("'", "&#39;")
+                        esc_result = result_content.replace("'", "&#39;")
                         yield (
                             f'\n\n<details type="tool_calls"'
                             f' name="{esc_name}"'
-                            f' arguments="{esc_args}"'
-                            f' result="{esc_result}"'
+                            f" arguments='{esc_args}'"
+                            f" result='{esc_result}'"
                             f' done="true">\n'
                             f"<summary>Tool: {esc_name}</summary>\n"
                             f"</details>\n\n"

--- a/chatdragon_completions.py
+++ b/chatdragon_completions.py
@@ -282,6 +282,11 @@ class Pipeline:
                         if not chunk:
                             continue
 
+                        # Filter out SDK "Executing tool..." status lines
+                        stripped = chunk.strip()
+                        if stripped.startswith("Executing ") and stripped.endswith("..."):
+                            continue
+
                         if thought_wrapped:
                             if response_tag_sent:
                                 yield chunk
@@ -380,14 +385,14 @@ class Pipeline:
                 result_content = f"Result truncated ({chars} chars)"
             result_content = result_content[:10000]
             esc_name = html.escape(name)
-            esc_args = html.escape(args)
-            # Use single-quote wrapper for result attribute to avoid
+            # Use single-quote wrappers for arguments and result to avoid
             # &quot; inside the value breaking Open WebUI's parser.
+            esc_args = args.replace("'", "&#39;")
             esc_result = result_content.replace("'", "&#39;")
             return (
                 f'\n\n<details type="tool_calls"'
                 f' name="{esc_name}"'
-                f' arguments="{esc_args}"'
+                f" arguments='{esc_args}'"
                 f" result='{esc_result}'"
                 f' done="true">\n'
                 f"<summary>Tool: {esc_name}</summary>\n"


### PR DESCRIPTION
… lines

- Switch arguments attribute from double-quote + html.escape to single-quote wrapper in both chatdragon.py and chatdragon_completions.py. The &quot; entities broke Open WebUI's details tag parser.
- Filter out SDK "Executing mcp__..." status text deltas that leak through as content chunks — users only need tool_result blocks.

https://claude.ai/code/session_014pwWWQJaAJ8P9XGSwT9skA