### PR TITLE
feat(streaming): add SSE keepalive heartbeat to prevent stream drops …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,10 @@ DEFAULT_MODEL=sonnet
 # Enable weaker sandbox for unprivileged Docker containers on Linux (default: false)
 # CLAUDE_SANDBOX_WEAKER_NESTED=false
 
+# SSE keepalive interval in seconds (prevents connection drops during long SDK operations)
+# Set to 0 to disable. Default: 15
+# SSE_KEEPALIVE_INTERVAL=15
+
 # Session Management
 # SESSION_CLEANUP_INTERVAL_MINUTES=5
 # SESSION_MAX_AGE_MINUTES=60

--- a/chatdragon_completions.py
+++ b/chatdragon_completions.py
@@ -72,8 +72,8 @@ class Pipeline:
             description="Claude model to use (e.g. sonnet, opus, haiku)",
         )
         TIMEOUT: int = Field(
-            default=300,
-            description="Request timeout in seconds",
+            default=600,
+            description="Total request timeout in seconds (increase for heavy MCP/search workloads)",
         )
         # Context injection settings
         INJECT_USER_CONTEXT: bool = Field(
@@ -268,7 +268,17 @@ class Pipeline:
                 thought_opened = True
 
             url = f"{self.valves.BASE_URL.rstrip('/')}/v1/chat/completions"
-            with httpx.Client(timeout=httpx.Timeout(self.valves.TIMEOUT)) as client:
+            # Use a generous read timeout — the gateway sends SSE keepalive
+            # comments every ~15s during idle periods (tool execution, context
+            # compaction), so a 60s read timeout catches truly dead connections
+            # while not killing active-but-quiet streams.
+            timeout = httpx.Timeout(
+                connect=30.0,
+                read=60.0,
+                write=30.0,
+                pool=self.valves.TIMEOUT,
+            )
+            with httpx.Client(timeout=timeout) as client:
                 with client.stream("POST", url, json=payload, headers=self._make_headers()) as resp:
                     if resp.status_code != 200:
                         body_text = resp.read().decode()

--- a/open_webui_pipe.py
+++ b/open_webui_pipe.py
@@ -42,8 +42,8 @@ class Pipe:
             description="Claude model to use (e.g. sonnet, opus, haiku)",
         )
         TIMEOUT: int = Field(
-            default=300,
-            description="Request timeout in seconds",
+            default=600,
+            description="Total request timeout in seconds (increase for heavy MCP/search workloads)",
         )
         FALLBACK_TO_CHAT_COMPLETIONS: bool = Field(
             default=False,
@@ -272,7 +272,17 @@ class Pipe:
             list(payload.keys()),
         )
         log.info("[STREAM] previous_response_id=%s", payload.get("previous_response_id"))
-        async with httpx.AsyncClient(timeout=httpx.Timeout(self.valves.TIMEOUT)) as client:
+        # Use a generous read timeout — the gateway sends SSE keepalive
+        # comments every ~15s during idle periods (tool execution, context
+        # compaction), so a 60s read timeout catches truly dead connections
+        # while not killing active-but-quiet streams.
+        timeout = httpx.Timeout(
+            connect=30.0,
+            read=60.0,
+            write=30.0,
+            pool=float(self.valves.TIMEOUT),
+        )
+        async with httpx.AsyncClient(timeout=timeout) as client:
             async with client.stream(
                 "POST", self._responses_url(), json=payload, headers=self._make_headers()
             ) as resp:

--- a/src/constants.py
+++ b/src/constants.py
@@ -52,6 +52,13 @@ RESPONSE_SENTINEL_INSTRUCTION = (
     "Do not include any other text on that line. Begin your answer immediately after."
 )
 
+# SSE keepalive interval (seconds).  During long SDK operations (tool
+# execution, context compaction) no events flow to the client.  Emitting
+# an SSE comment (`: keepalive\n\n`) on this interval prevents HTTP
+# proxies, load balancers, and client-side timeouts from closing the
+# connection.  Set to 0 to disable.
+SSE_KEEPALIVE_INTERVAL = int(os.getenv("SSE_KEEPALIVE_INTERVAL", "15"))
+
 # Rate Limiting defaults (requests per minute)
 # These are used by rate_limiter.py as the single source of truth
 RATE_LIMITS = {

--- a/src/streaming_utils.py
+++ b/src/streaming_utils.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import re
@@ -6,7 +7,7 @@ from typing import Any, AsyncGenerator, Dict, Optional
 
 from claude_agent_sdk.types import ToolResultBlock, ToolUseBlock
 
-from src.constants import RESPONSE_SENTINEL, WRAP_INTERMEDIATE_THINKING
+from src.constants import RESPONSE_SENTINEL, SSE_KEEPALIVE_INTERVAL, WRAP_INTERMEDIATE_THINKING
 from src.message_adapter import MessageAdapter
 from src.models import ChatCompletionRequest, ChatCompletionStreamResponse, StreamChoice
 from src.response_models import (
@@ -711,6 +712,46 @@ def format_chunk_content(chunk: Dict[str, Any], content_sent: bool) -> Optional[
 
 
 # ---------------------------------------------------------------------------
+# SSE keepalive
+# ---------------------------------------------------------------------------
+
+# SSE comment line — compliant clients silently ignore these.
+_SSE_KEEPALIVE = ": keepalive\n\n"
+
+_SENTINEL = object()
+
+
+async def _keepalive_wrapper(
+    source: AsyncGenerator,
+    interval: int,
+) -> AsyncGenerator:
+    """Wrap *source* to yield ``_SSE_KEEPALIVE`` during idle periods.
+
+    When the underlying async generator produces no item for *interval*
+    seconds, a keepalive SSE comment is yielded instead.  This prevents
+    HTTP intermediaries and client-side read timeouts from killing the
+    connection while the SDK is busy (tool execution, context compaction).
+
+    If *interval* is ``<= 0`` keepalives are disabled and the source is
+    yielded through unchanged.
+    """
+    if interval <= 0:
+        async for item in source:
+            yield item
+        return
+
+    ait = source.__aiter__()
+    while True:
+        try:
+            item = await asyncio.wait_for(ait.__anext__(), timeout=interval)
+            yield item
+        except asyncio.TimeoutError:
+            yield _SSE_KEEPALIVE
+        except StopAsyncIteration:
+            break
+
+
+# ---------------------------------------------------------------------------
 # Chat Completions streaming (/v1/chat/completions)
 # ---------------------------------------------------------------------------
 
@@ -758,7 +799,12 @@ async def stream_chunks(
             return _emit_sse("<think>\n")
         return []
 
-    async for chunk in chunk_source:
+    async for chunk in _keepalive_wrapper(chunk_source, SSE_KEEPALIVE_INTERVAL):
+        # Keepalive SSE comments — forward directly to the client
+        if chunk is _SSE_KEEPALIVE:
+            yield _SSE_KEEPALIVE
+            continue
+
         # Handle AssistantMessage.error (auth failures, rate limits, etc.)
         if chunk.get("type") == "assistant" and chunk.get("error"):
             chunks_buffer.append(chunk)
@@ -1047,7 +1093,12 @@ async def stream_response_chunks(
     # --- Main streaming loop ---
 
     try:
-        async for chunk in chunk_source:
+        async for chunk in _keepalive_wrapper(chunk_source, SSE_KEEPALIVE_INTERVAL):
+            # Keepalive SSE comments — forward directly to the client
+            if chunk is _SSE_KEEPALIVE:
+                yield _SSE_KEEPALIVE
+                continue
+
             # Detect SDK in-band error chunks
             if isinstance(chunk, dict) and chunk.get("is_error"):
                 error_msg = chunk.get("error_message", "Unknown SDK error")


### PR DESCRIPTION
…during long SDK operations

When the SDK is busy with tool execution or context compaction, no SSE events flow to the client. HTTP intermediaries, load balancers, and client-side read timeouts interpret this silence as a dead connection and kill the stream.

- Add _keepalive_wrapper() that emits SSE comment lines (`: keepalive`) every 15s (configurable via SSE_KEEPALIVE_INTERVAL env var) during idle periods in both stream_chunks() and stream_response_chunks()
- SSE comments are ignored by spec-compliant clients, so no downstream parsing changes are needed
- Update chatdragon_completions.py and open_webui_pipe.py to use split httpx timeouts (read=60s) instead of a single flat timeout, so the keepalive bytes prevent read timeout while still catching dead streams
- Increase default pipe TIMEOUT from 300s to 600s

https://claude.ai/code/session_01WBMTJ8i8XEQvS8YjYS9ey7