### PR TITLE
feat(pipe): add VQA_IMAGE_REPORT_DIR for host-path reporting to MCP tool

### DIFF
--- a/chatdragon_completions.py
+++ b/chatdragon_completions.py
@@ -116,6 +116,12 @@ class Pipeline:
             default="/app/shared_images",
             description="Shared directory for saving uploaded images (must be mounted in both Open WebUI and gateway containers)",
         )
+        VQA_IMAGE_REPORT_DIR: str = Field(
+            default="",
+            description="Path prefix to use when reporting image paths to the gateway/MCP tool. "
+            "If empty, VQA_IMAGE_DIR is used as-is. Set this to the host path "
+            "(e.g. /home/webui_data/serving_images) when the MCP tool runs outside the container.",
+        )
 
         @field_validator("TOOL_DISPLAY", mode="before")
         @classmethod
@@ -268,8 +274,14 @@ class Pipeline:
                                     filename = f"{uuid4().hex}.{ext}"
                                     filepath = image_dir / filename
                                     filepath.write_bytes(base64.b64decode(encoded))
-                                    saved_paths.append(str(filepath))
-                                    log.info("[IMAGE] saved image part[%d] -> %s", j, filepath)
+                                    # Report the path the MCP tool should use
+                                    report_dir = self.valves.VQA_IMAGE_REPORT_DIR
+                                    if report_dir:
+                                        report_path = str(Path(report_dir) / filename)
+                                    else:
+                                        report_path = str(filepath)
+                                    saved_paths.append(report_path)
+                                    log.info("[IMAGE] saved image part[%d] -> %s (report: %s)", j, filepath, report_path)
                                 except Exception:
                                     log.exception("[IMAGE] failed to save image part[%d]", j)
                                     new_content.append(part)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     volumes:
       - ~/.claude:/root/.claude
       # Shared image directory for VQA — must match the Open WebUI container mount
-      - shared_images:/app/shared_images
+      - /home/webui_data/serving_images:/app/shared_images
       # Optional: Mount a specific workspace directory
       # Uncomment and modify the line below to use a custom workspace
       # - ./workspace:/workspace
@@ -16,6 +16,3 @@ services:
       # Optional: Set Claude's working directory (defaults to isolated temp dir)
       # Uncomment and modify the line below to set a custom working directory
       # - CLAUDE_CWD=/workspace
-
-volumes:
-  shared_images:


### PR DESCRIPTION
When the MCP/VQA tool runs outside the container, it needs the host path rather than the container-internal path. VQA_IMAGE_REPORT_DIR lets the pipe save images to VQA_IMAGE_DIR (container path) but report them using the host path so the external MCP tool can read the files.

Also switch docker-compose shared_images from named volume to bind mount.

https://claude.ai/code/session_01LSKjtPaSiUGHMnVPJ1iw1B