### PR TITLE
fix: remove VQA_IMAGE_REPORT_DIR and fix tuple return bug

### DIFF
--- a/chatdragon_completions.py
+++ b/chatdragon_completions.py
@@ -116,12 +116,7 @@ class Pipeline:
             default="/app/shared_images",
             description="Shared directory for saving uploaded images (must be mounted in both Open WebUI and gateway containers)",
         )
-        VQA_IMAGE_REPORT_DIR: str = Field(
-            default="",
-            description="Path prefix to use when reporting image paths to the gateway/MCP tool. "
-            "If empty, VQA_IMAGE_DIR is used as-is. Set this to the host path "
-            "(e.g. /home/webui_data/serving_images) when the MCP tool runs outside the container.",
-        )
+
 
         @field_validator("TOOL_DISPLAY", mode="before")
         @classmethod
@@ -274,14 +269,8 @@ class Pipeline:
                                     filename = f"{uuid4().hex}.{ext}"
                                     filepath = image_dir / filename
                                     filepath.write_bytes(base64.b64decode(encoded))
-                                    # Report the path the MCP tool should use
-                                    report_dir = self.valves.VQA_IMAGE_REPORT_DIR
-                                    if report_dir:
-                                        report_path = str(Path(report_dir) / filename)
-                                    else:
-                                        report_path = str(filepath)
-                                    saved_paths.append(report_path)
-                                    log.info("[IMAGE] saved image part[%d] -> %s (report: %s)", j, filepath, report_path)
+                                    saved_paths.append(str(filepath))
+                                    log.info("[IMAGE] saved image part[%d] -> %s", j, filepath)
                                 except Exception:
                                     log.exception("[IMAGE] failed to save image part[%d]", j)
                                     new_content.append(part)
@@ -576,7 +565,7 @@ class Pipeline:
             esc_name = html.escape(name)
 
             if self.valves.MCP_TOOL_ONLY and not name.startswith("mcp__"):
-                return None, 0
+                return None
 
             if not self.valves.TOOL_DISPLAY:
                 friendly = self._friendly_tool_notification(name, is_error)


### PR DESCRIPTION
- Remove VQA_IMAGE_REPORT_DIR valve; use VQA_IMAGE_DIR directly for image paths reported to the gateway
- Fix _render_system_event returning (None, 0) tuple instead of None when MCP_TOOL_ONLY filters a built-in tool, which caused the truthy tuple to be yielded into the stream

https://claude.ai/code/session_01LSKjtPaSiUGHMnVPJ1iw1B