### PR TITLE
feat: add allowed_tools + MCP pattern support to Responses API

### DIFF
--- a/src/backends/claude/client.py
+++ b/src/backends/claude/client.py
@@ -358,7 +358,34 @@ class ClaudeCodeCLI:
         if output_format:
             options.output_format = output_format
         if mcp_servers:
-            options.mcp_servers = mcp_servers
+            if allowed_tools is not None:
+                # Filter MCP servers to only those matching allowed_tools
+                allowed_set = set(allowed_tools)
+                filtered = {}
+                for name, config in mcp_servers.items():
+                    safe_name = "_".join(name.split("-"))
+                    pattern = f"mcp__{safe_name}__*"
+                    if pattern in allowed_set:
+                        filtered[name] = config
+                if filtered:
+                    options.mcp_servers = filtered
+                    # Ensure MCP patterns are in allowed_tools
+                    if options.allowed_tools is not None:
+                        mcp_patterns = get_mcp_tool_patterns(filtered)
+                        for p in mcp_patterns:
+                            if p not in options.allowed_tools:
+                                options.allowed_tools.append(p)
+                    logger.debug(f"MCP servers filtered to: {list(filtered.keys())}")
+                else:
+                    logger.debug("No MCP servers match allowed_tools, skipping MCP")
+            else:
+                options.mcp_servers = mcp_servers
+                # Add all MCP patterns to allowed_tools
+                mcp_patterns = get_mcp_tool_patterns(mcp_servers)
+                if not options.allowed_tools:
+                    options.allowed_tools = list(DEFAULT_ALLOWED_TOOLS)
+                options.allowed_tools.extend(mcp_patterns)
+                logger.debug(f"MCP tools enabled: {mcp_patterns}")
         from src.runtime_config import get_token_streaming
 
         if get_token_streaming():

--- a/src/response_models.py
+++ b/src/response_models.py
@@ -40,6 +40,10 @@ class ResponseCreateRequest(BaseModel):
     store: Optional[bool] = True
     temperature: Optional[float] = None
     max_output_tokens: Optional[int] = None
+    allowed_tools: Optional[List[str]] = Field(
+        default=None,
+        description="Explicit list of allowed tools. Overrides default tool list.",
+    )
     user: Optional[str] = Field(
         default=None,
         description="Unique user identifier for workspace isolation",

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -294,6 +294,7 @@ async def create_response(
                 model=resolved.provider_model,
                 system_prompt=system_prompt if len(session.messages) == 0 else None,
                 permission_mode=PERMISSION_MODE_BYPASS,
+                allowed_tools=body.allowed_tools,
                 mcp_servers=get_mcp_servers() if resolved.backend == "claude" else None,
                 cwd=workspace_str,
             )


### PR DESCRIPTION
## Summary

- Add `allowed_tools` field to `ResponseCreateRequest` so clients can specify which tools to enable
- Forward `allowed_tools` to `chunk_kwargs` and `create_client` in responses route
- Fix `_build_sdk_options`: when `mcp_servers` provided, add MCP patterns to `allowed_tools` (matching old `_build_options` behavior that was lost during SDK client migration)
- When `allowed_tools` is specified, filter MCP servers to only those matching the patterns

## Problem

After the SDK client migration (`feat/sdk-client-migration`), MCP tools stopped working because:
1. `_build_sdk_options` did not add MCP patterns to `allowed_tools` (unlike the old `_build_options`)
2. `ResponseCreateRequest` had no `allowed_tools` field, so client selections were ignored
3. Responses route did not forward `allowed_tools` to the backend

## Changes

| File | Change |
|------|--------|
| `src/response_models.py` | Add `allowed_tools: Optional[List[str]]` field |
| `src/routes/responses.py` | Forward `body.allowed_tools` to `chunk_kwargs` and `create_client` |
| `src/backends/claude/client.py` | `_build_sdk_options`: add MCP pattern logic with server filtering |

## Test plan

- [ ] MCP tools execute when `allowed_tools` includes their patterns
- [ ] MCP tools are filtered when only specific patterns are in `allowed_tools`
- [ ] Default behavior (no `allowed_tools`) enables all MCP tools
- [ ] `enable_tools=false` still disables all tools

https://claude.ai/code/session_01LCuypBBdLEwAXRYhVnKZ76