### PR TITLE
fix: resolve open responses and admin issues

### DIFF
--- a/src/admin_js.py
+++ b/src/admin_js.py
@@ -120,9 +120,13 @@ def get_admin_js() -> str:
       this.loading.sessions = true;
       try {
         const r = await this.api('/admin/api/summary');
-        if (r.ok) this.summary = await r.json();
+        if (r.ok) { this.summary = await r.json(); this._summaryFailCount = 0; }
         else if (r.status === 401) { this.authenticated = false; this.stopPolling(); }
-      } catch(e) { console.error('Failed to load summary', e); this.showToast('Failed to load summary', 'err'); } finally { this.loading.sessions = false; }
+      } catch(e) {
+        console.error('Failed to load summary', e);
+        this._summaryFailCount = (this._summaryFailCount || 0) + 1;
+        if (this._summaryFailCount === 1) this.showToast('Failed to load summary', 'err');
+      } finally { this.loading.sessions = false; }
     },
 
     async loadMetrics() {
@@ -234,8 +238,12 @@ def get_admin_js() -> str:
         if (this.logsFilter.endpoint) url += '&endpoint=' + encodeURIComponent(this.logsFilter.endpoint);
         if (this.logsFilter.status) url += '&status=' + this.logsFilter.status;
         const r = await this.api(url);
-        if (r.ok) this.logs = await r.json();
-      } catch(e) { console.error('Failed to load logs', e); this.showToast('Failed to load logs', 'err'); } finally { this.loading.logs = false; }
+        if (r.ok) { this.logs = await r.json(); this._logsFailCount = 0; }
+      } catch(e) {
+        console.error('Failed to load logs', e);
+        this._logsFailCount = (this._logsFailCount || 0) + 1;
+        if (this._logsFailCount === 1) this.showToast('Failed to load logs', 'err');
+      } finally { this.loading.logs = false; }
     },
     toggleLogsPolling() {
       if (this.logsPollTimer) { clearInterval(this.logsPollTimer); this.logsPollTimer = null; }

--- a/src/admin_js.py
+++ b/src/admin_js.py
@@ -69,7 +69,7 @@ def get_admin_js() -> str:
         this.loading.dashboard = true;
         const r = await this.api('/admin/api/summary');
         if (r.ok) { this.authenticated = true; this.summary = await r.json(); this.loadBackends(); this.loadMcpServers(); this.loadMetrics(); this.startPolling(); }
-      } catch(e) {} finally { this.loading.dashboard = false; }
+      } catch(e) { console.error('Failed to load summary', e); this.loginError = 'Failed to load summary'; this.showToast('Failed to load summary', 'err'); } finally { this.loading.dashboard = false; }
     },
 
     getFileIcon(path) {
@@ -122,40 +122,40 @@ def get_admin_js() -> str:
         const r = await this.api('/admin/api/summary');
         if (r.ok) this.summary = await r.json();
         else if (r.status === 401) { this.authenticated = false; this.stopPolling(); }
-      } catch(e) {} finally { this.loading.sessions = false; }
+      } catch(e) { console.error('Failed to load summary', e); this.showToast('Failed to load summary', 'err'); } finally { this.loading.sessions = false; }
     },
 
     async loadMetrics() {
       try {
         const r = await this.api('/admin/api/metrics');
         if (r.ok) this.metrics = await r.json();
-      } catch(e) {}
+      } catch(e) { console.error('Failed to load metrics', e); this.showToast('Failed to load metrics', 'err'); }
     },
     async loadBackends() {
       try {
         const r = await this.api('/admin/api/backends');
         if (r.ok) { const d = await r.json(); this.backendsDetail = d.backends || []; }
-      } catch(e) {}
+      } catch(e) { console.error('Failed to load backends', e); this.showToast('Failed to load backends', 'err'); }
     },
     async loadMcpServers() {
       try {
         const r = await this.api('/admin/api/mcp-servers');
         if (r.ok) { const d = await r.json(); this.mcpServers = d.servers || []; }
-      } catch(e) {}
+      } catch(e) { console.error('Failed to load MCP servers', e); this.showToast('Failed to load MCP servers', 'err'); }
     },
 
     async loadFiles() {
       try {
         const r = await this.api('/admin/api/files');
         if (r.ok) { const d = await r.json(); this.files = d.files || []; }
-      } catch(e) {}
+      } catch(e) { console.error('Failed to load files', e); this.showToast('Failed to load files', 'err'); }
     },
 
     async loadConfig() {
       try {
         const r = await this.api('/admin/api/config');
         if (r.ok) this.config = await r.json();
-      } catch(e) {}
+      } catch(e) { console.error('Failed to load config', e); this.showToast('Failed to load config', 'err'); }
     },
 
     async openFile(path) {
@@ -235,7 +235,7 @@ def get_admin_js() -> str:
         if (this.logsFilter.status) url += '&status=' + this.logsFilter.status;
         const r = await this.api(url);
         if (r.ok) this.logs = await r.json();
-      } catch(e) {} finally { this.loading.logs = false; }
+      } catch(e) { console.error('Failed to load logs', e); this.showToast('Failed to load logs', 'err'); } finally { this.loading.logs = false; }
     },
     toggleLogsPolling() {
       if (this.logsPollTimer) { clearInterval(this.logsPollTimer); this.logsPollTimer = null; }
@@ -246,28 +246,28 @@ def get_admin_js() -> str:
       try {
         const r = await this.api('/admin/api/rate-limits');
         if (r.ok) this.rateLimits = await r.json();
-      } catch(e) {}
+      } catch(e) { console.error('Failed to load rate limits', e); this.showToast('Failed to load rate limits', 'err'); }
     },
 
     async loadSandbox() {
       try {
         const r = await this.api('/admin/api/sandbox');
         if (r.ok) this.sandboxConfig = await r.json();
-      } catch(e) {}
+      } catch(e) { console.error('Failed to load sandbox config', e); this.showToast('Failed to load sandbox config', 'err'); }
     },
 
     async loadTools() {
       try {
         const r = await this.api('/admin/api/tools');
         if (r.ok) this.toolsRegistry = await r.json();
-      } catch(e) {}
+      } catch(e) { console.error('Failed to load tools', e); this.showToast('Failed to load tools', 'err'); }
     },
 
     async loadRuntimeConfig() {
       try {
         const r = await this.api('/admin/api/runtime-config');
         if (r.ok) { const d = await r.json(); this.runtimeConfig = d.settings || {}; }
-      } catch(e) {}
+      } catch(e) { console.error('Failed to load runtime config', e); this.showToast('Failed to load runtime config', 'err'); }
     },
     async updateRuntimeConfig(key, value) {
       try {
@@ -283,14 +283,14 @@ def get_admin_js() -> str:
       try {
         const r = await this.api('/admin/api/runtime-config/reset?key=' + encodeURIComponent(key), { method: 'POST' });
         if (r.ok) { this.showToast('RESET: ' + key, 'ok'); await this.loadRuntimeConfig(); }
-      } catch(e) {}
+      } catch(e) { console.error('Failed to reset setting', e); this.showToast('Failed to reset setting', 'err'); }
     },
     async resetAllRuntimeConfig() {
       if (!confirm('Reset all runtime settings to startup defaults?')) return;
       try {
         const r = await this.api('/admin/api/runtime-config/reset', { method: 'POST' });
         if (r.ok) { this.showToast('ALL SETTINGS RESET', 'ok'); await this.loadRuntimeConfig(); }
-      } catch(e) {}
+      } catch(e) { console.error('Failed to reset all settings', e); this.showToast('Failed to reset all settings', 'err'); }
     },
 
     async loadSystemPrompt() {
@@ -440,7 +440,7 @@ def get_admin_js() -> str:
       try {
         const r = await this.api('/admin/api/system-prompt', { method: 'DELETE' });
         if (r.ok) { this.showToast('PRESET ACTIVATED', 'ok'); await this.loadSystemPrompt(); }
-      } catch(e) {}
+      } catch(e) { console.error('Failed to activate preset', e); this.showToast('Failed to activate preset', 'err'); }
     },
     forkFromPreset() {
       this.promptView = 'new';
@@ -662,7 +662,7 @@ Skill description here.
             if (idx >= 0) { this.sessionMessages.messages[idx] = full; }
           }
         }
-      } catch(e) {}
+      } catch(e) { console.error('Failed to load full message', e); this.showToast('Failed to load full message', 'err'); }
     },
 
     startPolling() { this.pollTimer = setInterval(() => this.loadSummary(), 15000); },

--- a/src/admin_page.py
+++ b/src/admin_page.py
@@ -30,13 +30,13 @@ def build_admin_page() -> str:
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>GATEWAY CTRL // Admin Terminal</title>
-<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.8/dist/cdn.min.js"></script>
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/codemirror@5.65.18/lib/codemirror.min.css">
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/codemirror@5.65.18/theme/material-darker.min.css">
-<script src="https://cdn.jsdelivr.net/npm/codemirror@5.65.18/lib/codemirror.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/codemirror@5.65.18/mode/markdown/markdown.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/codemirror@5.65.18/mode/javascript/javascript.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/codemirror@5.65.18/mode/yaml/yaml.min.js"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.8/dist/cdn.min.js" integrity="sha384-X9kJyAubVxnP0hcA+AMMs21U445qsnqhnUF8EBlEpP3a42Kh/JwWjlv2ZcvGfphb" crossorigin="anonymous"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/codemirror@5.65.18/lib/codemirror.min.css" integrity="sha384-EAMaqTIrSR3wOlf2EQj7Kkx5ZCHPjHmlYJsFof5IB8dzXMASyR8eIwXgp+IGz/rs" crossorigin="anonymous">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/codemirror@5.65.18/theme/material-darker.min.css" integrity="sha384-/7IRGUZjrVsGRxRmWYycW70x8/46N5NLfEElIMgl+k0aOfmvzAMSg6Or2NG3a6tp" crossorigin="anonymous">
+<script src="https://cdn.jsdelivr.net/npm/codemirror@5.65.18/lib/codemirror.min.js" integrity="sha384-t/C99Ss9npjVCqOGZhNjaRnafXAhKyPyhSP+cSSP0CWoFTfMXG4+impqZ6WfgO0a" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/codemirror@5.65.18/mode/markdown/markdown.min.js" integrity="sha384-n04h9Gi6L8HyI+Xs9bOsNBdP9/Oo6HtQ6x+a7KFxgoZ267JCOoEZzP2YEAanxMTX" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/codemirror@5.65.18/mode/javascript/javascript.min.js" integrity="sha384-9WXBgfPaWP2zA74XYJo/qmYSaQuy6wy1FyptaVjcRrEdBZagvms/3mIBuPWPqsgg" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/codemirror@5.65.18/mode/yaml/yaml.min.js" integrity="sha384-131Ong53rCgUDHHluJOESiyk8FRC3j7cL7INdfB2n4SVkOoI87gNHb0B23LKlrMp" crossorigin="anonymous"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 <style>

--- a/src/image_handler.py
+++ b/src/image_handler.py
@@ -8,6 +8,7 @@ Only synchronous operations — no remote URL fetching (SSRF-free).
 """
 
 import base64
+import binascii
 import hashlib
 import logging
 import tempfile
@@ -55,7 +56,11 @@ class ImageHandler:
                 f"Supported: {', '.join(sorted(SUPPORTED_MEDIA_TYPES))}"
             )
 
-        image_bytes = base64.b64decode(data)
+        try:
+            image_bytes = base64.b64decode(data, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise ValueError("Malformed image base64 payload") from exc
+
         if len(image_bytes) > MAX_IMAGE_SIZE:
             raise ValueError(
                 f"Image size {len(image_bytes)} bytes exceeds {MAX_IMAGE_SIZE} byte limit"

--- a/src/main.py
+++ b/src/main.py
@@ -55,6 +55,20 @@ logger = logging.getLogger(__name__)
 runtime_api_key = None
 
 
+def _sanitize_validation_errors(errors: list[dict]) -> list[dict[str, str]]:
+    """Strip raw input payloads from validation errors for logging and responses."""
+    sanitized = []
+    for error in errors:
+        sanitized.append(
+            {
+                "field": " -> ".join(str(loc) for loc in error.get("loc", [])),
+                "message": error.get("msg", "Unknown validation error"),
+                "type": error.get("type", "validation_error"),
+            }
+        )
+    return sanitized
+
+
 def generate_secure_token(length: int = 32) -> str:
     """Generate a secure random token for API authentication."""
     alphabet = string.ascii_letters + string.digits + "-_"
@@ -305,9 +319,7 @@ class DebugLoggingMiddleware(BaseHTTPMiddleware):
                             parsed_body = json.loads(body.decode())
                             # Truncate base64 image data in logged body
                             logged_body = truncate_image_data(parsed_body)
-                            logger.debug(
-                                f"🔍 Request body: {json.dumps(logged_body, indent=2)}"
-                            )
+                            logger.debug(f"🔍 Request body: {json.dumps(logged_body, indent=2)}")
                             body_logged = True
                         except Exception:
                             logger.debug(f"🔍 Request body (raw): {body.decode()[:500]}...")
@@ -376,10 +388,12 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
                                 resolved = resolve_model(model)
                                 if resolved:
                                     backend = resolved.backend
-                            except Exception:
-                                pass
-            except Exception:
-                pass
+                            except Exception as exc:
+                                logger.debug(
+                                    "Could not resolve backend for request logging: %s", exc
+                                )
+            except Exception as exc:
+                logger.debug("Could not inspect request body for request logging: %s", exc)
 
         status_code = 500
         try:
@@ -422,41 +436,20 @@ app.add_middleware(RequestLoggingMiddleware)
 # Custom exception handler for 422 validation errors
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
-    """Handle request validation errors with detailed debugging information."""
+    """Handle request validation errors with sanitized field-level details."""
+
+    sanitized_errors = _sanitize_validation_errors(exc.errors())
 
     # Log the validation error details
     logger.error(f"❌ Request validation failed for {request.method} {request.url}")
-    logger.error(f"❌ Validation errors: {exc.errors()}")
-
-    # Create detailed error response
-    error_details = []
-    for error in exc.errors():
-        location = " -> ".join(str(loc) for loc in error.get("loc", []))
-        error_details.append(
-            {
-                "field": location,
-                "message": error.get("msg", "Unknown validation error"),
-                "type": error.get("type", "validation_error"),
-                "input": error.get("input"),
-            }
-        )
-
-    # If debug mode is enabled, include the raw request body
-    debug_info = {}
-    if DEBUG_MODE or VERBOSE:
-        try:
-            body = await request.body()
-            if body:
-                debug_info["raw_request_body"] = body.decode()
-        except Exception:
-            debug_info["raw_request_body"] = "Could not read request body"
+    logger.error("❌ Validation errors: %s", sanitized_errors)
 
     error_response = {
         "error": {
             "message": "Request validation failed - the request body doesn't match the expected format",
             "type": "validation_error",
             "code": "invalid_request_error",
-            "details": error_details,
+            "details": sanitized_errors,
             "help": {
                 "common_issues": [
                     "Missing required fields (model, input)",
@@ -468,10 +461,6 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
             },
         }
     }
-
-    # Add debug info if available
-    if debug_info:
-        error_response["error"]["debug"] = debug_info
 
     return JSONResponse(status_code=422, content=error_response)
 

--- a/src/main.py
+++ b/src/main.py
@@ -322,7 +322,14 @@ class DebugLoggingMiddleware(BaseHTTPMiddleware):
                             logger.debug(f"🔍 Request body: {json.dumps(logged_body, indent=2)}")
                             body_logged = True
                         except Exception:
-                            logger.debug(f"🔍 Request body (raw): {body.decode()[:500]}...")
+                            # Do not log raw bytes: a malformed JSON body may
+                            # contain Bearer tokens, API keys, or PII. Log only
+                            # metadata useful for debugging.
+                            logger.debug(
+                                "🔍 Request body: [non-JSON, %d bytes, content-type: %s]",
+                                len(body),
+                                request.headers.get("content-type", "unknown"),
+                            )
                             body_logged = True
             except Exception as e:
                 logger.debug(f"🔍 Could not read request body: {e}")

--- a/src/message_adapter.py
+++ b/src/message_adapter.py
@@ -152,14 +152,21 @@ class MessageAdapter:
                 # content is list of content parts, e.g. [{"type": "input_text", "text": "..."}]
                 text_parts = []
                 for part in content:
-                    if isinstance(part, dict) and part.get("text"):
-                        text_parts.append(part["text"])
-                    elif (
-                        isinstance(part, dict)
-                        and part.get("type") == "input_image"
-                        and image_handler
-                    ):
-                        image_url = part.get("image_url", "")
+                    ptype = (
+                        part.get("type") if isinstance(part, dict) else getattr(part, "type", None)
+                    )
+                    text_part = (
+                        part.get("text") if isinstance(part, dict) else getattr(part, "text", "")
+                    )
+
+                    if text_part:
+                        text_parts.append(text_part)
+                    elif ptype == "input_image" and image_handler:
+                        image_url = (
+                            part.get("image_url", "")
+                            if isinstance(part, dict)
+                            else getattr(part, "image_url", "")
+                        )
                         if image_url:
                             path = image_handler.save_responses_image(image_url)
                             text_parts.append(f'<attached_image path="{path}" />')

--- a/src/response_models.py
+++ b/src/response_models.py
@@ -54,7 +54,7 @@ ResponseInputContentPart = Annotated[
 class ResponseInputItem(BaseModel):
     """A single item in the input array (message format)."""
 
-    role: str
+    role: Literal["user", "assistant", "system", "developer"]
     content: Union[str, List[ResponseInputContentPart]] = ""
 
 

--- a/src/response_models.py
+++ b/src/response_models.py
@@ -3,7 +3,7 @@
 import time
 from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Discriminator, Field, Tag
 
 
 class ResponseInputTextPart(BaseModel):
@@ -21,9 +21,33 @@ class ResponseInputImagePart(BaseModel):
     detail: Optional[str] = None
 
 
+def _response_input_part_discriminator(v: Any) -> str:
+    """Route content parts by ``type``; unknown types fall through to ``unknown``.
+
+    Known types (``input_text`` / ``input_image``) get strict pydantic validation.
+    Unknown types are accepted as raw dicts so the Responses API surface stays
+    forward-compatible with evolving OpenAI part types (e.g., ``input_file``,
+    ``input_audio``). Downstream code already tolerates both pydantic models
+    and dicts via ``isinstance`` / ``getattr`` forks.
+    """
+    if isinstance(v, dict):
+        t = v.get("type")
+    else:
+        t = getattr(v, "type", None)
+    if t == "input_text":
+        return "input_text"
+    if t == "input_image":
+        return "input_image"
+    return "unknown"
+
+
 ResponseInputContentPart = Annotated[
-    Union[ResponseInputTextPart, ResponseInputImagePart],
-    Field(discriminator="type"),
+    Union[
+        Annotated[ResponseInputTextPart, Tag("input_text")],
+        Annotated[ResponseInputImagePart, Tag("input_image")],
+        Annotated[Dict[str, Any], Tag("unknown")],
+    ],
+    Discriminator(_response_input_part_discriminator),
 ]
 
 

--- a/src/response_models.py
+++ b/src/response_models.py
@@ -1,16 +1,37 @@
 """Pydantic models for OpenAI Responses API compatibility."""
 
 import time
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, Field
+
+
+class ResponseInputTextPart(BaseModel):
+    """A text content part within a Responses API input item."""
+
+    type: Literal["input_text"] = "input_text"
+    text: str = ""
+
+
+class ResponseInputImagePart(BaseModel):
+    """An image content part within a Responses API input item."""
+
+    type: Literal["input_image"] = "input_image"
+    image_url: str
+    detail: Optional[str] = None
+
+
+ResponseInputContentPart = Annotated[
+    Union[ResponseInputTextPart, ResponseInputImagePart],
+    Field(discriminator="type"),
+]
 
 
 class ResponseInputItem(BaseModel):
     """A single item in the input array (message format)."""
 
     role: str
-    content: Union[str, List[Dict[str, Any]]] = ""
+    content: Union[str, List[ResponseInputContentPart]] = ""
 
 
 class FunctionCallOutputInput(BaseModel):

--- a/src/routes/deps.py
+++ b/src/routes/deps.py
@@ -68,11 +68,9 @@ def request_has_images(request: Any) -> bool:
             if isinstance(content, list):
                 for part in content:
                     ptype = (
-                        part.get("type")
-                        if isinstance(part, dict)
-                        else getattr(part, "type", None)
+                        part.get("type") if isinstance(part, dict) else getattr(part, "type", None)
                     )
-                    if ptype in ("image_url", "input_image", "image"):
+                    if ptype == "input_image":
                         return True
     return False
 

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -500,6 +500,10 @@ async def create_response(
             # Check for backend errors (run_completion wraps exceptions as error chunks)
             for chunk in chunks:
                 if isinstance(chunk, dict) and chunk.get("is_error"):
+                    # ``error_message`` here is SDK-curated (rate-limit, auth,
+                    # etc.) — not a raw Python exception string — so it is
+                    # safe to surface to clients. Raw ``except Exception``
+                    # leaks are redacted at the catch-all below.
                     error_msg = chunk.get("error_message", "Unknown backend error")
                     raise HTTPException(status_code=502, detail=f"Backend error: {error_msg}")
 
@@ -724,6 +728,9 @@ async def _handle_function_call_output(
 
         for chunk in chunks:
             if isinstance(chunk, dict) and chunk.get("is_error"):
+                # ``error_message`` here is SDK-curated (rate-limit, auth,
+                # etc.) — not a raw Python exception string — so it is safe
+                # to surface to clients.
                 error_msg = chunk.get("error_message", "Unknown backend error")
                 raise HTTPException(status_code=502, detail=f"Backend error: {error_msg}")
 

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -527,8 +527,11 @@ async def create_response(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Responses API: Backend error: {e}", exc_info=True)
-        raise HTTPException(status_code=502, detail=f"Backend error: {e}")
+        # Do not echo raw exception strings to clients — they can contain
+        # file paths, subprocess commands, or other backend internals.
+        # Full details go to logs for operators; response stays generic.
+        logger.error("Responses API: Backend error: %s", e, exc_info=True)
+        raise HTTPException(status_code=502, detail="Backend error") from e
 
     # Token usage (prefer real SDK values)
     prompt_tokens, completion_tokens = streaming_utils.resolve_token_usage(

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -306,7 +306,9 @@ async def create_response(
                     system_prompt = content
                 elif isinstance(content, list):
                     system_prompt = "\n".join(
-                        p["text"] for p in content if isinstance(p, dict) and p.get("text")
+                        p.get("text") if isinstance(p, dict) else getattr(p, "text", "")
+                        for p in content
+                        if (p.get("text") if isinstance(p, dict) else getattr(p, "text", ""))
                     )
             else:
                 user_items.append(item)
@@ -315,7 +317,12 @@ async def create_response(
     # Convert input to prompt
     # Per-request ImageHandler pointing to user workspace
     image_handler = ImageHandler(workspace)
-    prompt = MessageAdapter.response_input_to_prompt(input_for_prompt, image_handler=image_handler)
+    try:
+        prompt = MessageAdapter.response_input_to_prompt(
+            input_for_prompt, image_handler=image_handler
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
     prompt = MessageAdapter.filter_content(prompt)
 
     # ------------------------------------------------------------------
@@ -346,10 +353,7 @@ async def create_response(
             )
             session.client = None
 
-    use_sdk_client = (
-        session.client is not None
-        and hasattr(backend, "run_completion_with_client")
-    )
+    use_sdk_client = session.client is not None and hasattr(backend, "run_completion_with_client")
 
     if body.stream:
         # Run preflight BEFORE StreamingResponse so HTTPExceptions produce

--- a/tests/test_admin_routes_coverage.py
+++ b/tests/test_admin_routes_coverage.py
@@ -1,6 +1,7 @@
 """Coverage tests for admin routes — fills gaps in endpoint testing."""
 
 import os
+import re
 from unittest.mock import patch
 
 import pytest
@@ -35,6 +36,20 @@ class TestAdminPage:
         assert r.text.count('crossorigin="anonymous"') >= 7
         assert "https://cdn.jsdelivr.net/npm/alpinejs@3.14.8/dist/cdn.min.js" in r.text
         assert "https://cdn.jsdelivr.net/npm/codemirror@5.65.18/lib/codemirror.min.js" in r.text
+
+    def test_admin_page_script_has_no_empty_catch_blocks(self, admin_client):
+        r = admin_client.get("/admin")
+
+        assert r.status_code == 200
+        assert re.search(r"catch\\s*\\(e\\)\\s*\\{\\s*\\}", r.text) is None
+
+    def test_admin_page_script_uses_visible_error_handling_for_async_loads(self, admin_client):
+        r = admin_client.get("/admin")
+
+        assert r.status_code == 200
+        assert "Failed to load summary" in r.text
+        assert "Failed to load metrics" in r.text
+        assert "Failed to load full message" in r.text
 
 
 class TestAdminAuth:

--- a/tests/test_admin_routes_coverage.py
+++ b/tests/test_admin_routes_coverage.py
@@ -27,6 +27,15 @@ class TestAdminPage:
         assert "text/html" in r.headers["content-type"]
         assert "CLAUDE CODE GATEWAY" in r.text
 
+    def test_get_admin_page_includes_integrity_and_crossorigin_for_cdn_assets(self, admin_client):
+        r = admin_client.get("/admin")
+
+        assert r.status_code == 200
+        assert r.text.count('integrity="sha384-') >= 7
+        assert r.text.count('crossorigin="anonymous"') >= 7
+        assert "https://cdn.jsdelivr.net/npm/alpinejs@3.14.8/dist/cdn.min.js" in r.text
+        assert "https://cdn.jsdelivr.net/npm/codemirror@5.65.18/lib/codemirror.min.js" in r.text
+
 
 class TestAdminAuth:
     def test_logout(self, admin_client):

--- a/tests/test_admin_routes_coverage.py
+++ b/tests/test_admin_routes_coverage.py
@@ -41,7 +41,7 @@ class TestAdminPage:
         r = admin_client.get("/admin")
 
         assert r.status_code == 200
-        assert re.search(r"catch\\s*\\(e\\)\\s*\\{\\s*\\}", r.text) is None
+        assert re.search(r"catch\s*\(e\)\s*\{\s*\}", r.text) is None
 
     def test_admin_page_script_uses_visible_error_handling_for_async_loads(self, admin_client):
         r = admin_client.get("/admin")

--- a/tests/test_image_endpoints.py
+++ b/tests/test_image_endpoints.py
@@ -172,14 +172,97 @@ class TestValidateImageRequest:
 
     def test_validate_image_request_no_images_always_passes(self):
         """No error when request contains no images, regardless of backend support."""
-        text_input = [
-            {"role": "user", "content": [{"type": "input_text", "text": "no image"}]}
-        ]
+        text_input = [{"role": "user", "content": [{"type": "input_text", "text": "no image"}]}]
         req = _FakeRequest(input=text_input)
         backend = MagicMock(spec=[])  # no image_handler
 
         # Should not raise because there are no images
         _validate_image_request(req, backend)
+
+
+class TestResponsesImageErrors:
+    def test_create_response_returns_400_for_remote_image_url(self):
+        with client_context() as (client, _mock_cli):
+            response = client.post(
+                "/v1/responses",
+                json={
+                    "model": "sonnet",
+                    "input": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {
+                                    "type": "input_image",
+                                    "image_url": "https://example.com/image.png",
+                                }
+                            ],
+                        }
+                    ],
+                },
+            )
+
+        assert response.status_code == 400
+        assert "Only data: URLs are supported" in response.json()["error"]["message"]
+
+    def test_create_response_returns_400_for_malformed_image_data_url(self):
+        with client_context() as (client, _mock_cli):
+            response = client.post(
+                "/v1/responses",
+                json={
+                    "model": "sonnet",
+                    "input": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "input_image", "image_url": "data:image/png;base64"}
+                            ],
+                        }
+                    ],
+                },
+            )
+
+        assert response.status_code == 400
+        assert "Malformed data URL" in response.json()["error"]["message"]
+
+    def test_create_response_returns_400_for_unsupported_image_media_type(self):
+        bad_data_url = "data:image/bmp;base64,Qk0="
+
+        with client_context() as (client, _mock_cli):
+            response = client.post(
+                "/v1/responses",
+                json={
+                    "model": "sonnet",
+                    "input": [
+                        {
+                            "role": "user",
+                            "content": [{"type": "input_image", "image_url": bad_data_url}],
+                        }
+                    ],
+                },
+            )
+
+        assert response.status_code == 400
+        assert "Unsupported image type" in response.json()["error"]["message"]
+
+    def test_create_response_returns_400_for_invalid_image_base64(self):
+        with client_context() as (client, _mock_cli):
+            response = client.post(
+                "/v1/responses",
+                json={
+                    "model": "sonnet",
+                    "input": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "input_image", "image_url": "data:image/png;base64,!!!!"}
+                            ],
+                        }
+                    ],
+                },
+            )
+
+        assert response.status_code == 400
+        assert "Malformed image base64 payload" in response.json()["error"]["message"]
 
 
 # ===========================================================================

--- a/tests/test_main_api_unit.py
+++ b/tests/test_main_api_unit.py
@@ -65,7 +65,6 @@ def test_health_endpoint_returns_request_id_header():
     assert response.headers["x-request-id"]
 
 
-
 def test_returns_503_when_auth_is_invalid():
     _auth_exc = HTTPException(
         status_code=503,
@@ -137,7 +136,6 @@ def test_list_mcp_servers_filters_safe_fields():
     assert "token" not in body["servers"][1]["config"]
 
 
-
 def test_auth_status_endpoint_uses_runtime_key_source():
     original_main_key = getattr(main, "runtime_api_key", None)
     main.runtime_api_key = "runtime-key"
@@ -160,6 +158,45 @@ def test_auth_status_endpoint_uses_runtime_key_source():
     finally:
         auth_manager.runtime_api_key = original_runtime_key
         main.runtime_api_key = original_main_key
+
+
+def test_validation_error_preserves_field_details_without_echoing_raw_input():
+    with client_context() as (client, _mock_cli):
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": DEFAULT_MODEL,
+                "input": [{"content": "Hi"}],
+            },
+        )
+
+    body = response.json()
+    assert response.status_code == 422
+    assert body["error"]["type"] == "validation_error"
+    assert body["error"]["code"] == "invalid_request_error"
+    assert body["error"]["details"]
+    assert body["error"]["details"][0]["field"]
+    assert body["error"]["details"][0]["message"]
+    assert body["error"]["details"][0]["type"]
+    assert "input" not in body["error"]["details"][0]
+    assert "debug" not in body["error"]
+
+
+def test_validation_error_omits_raw_request_body_even_in_debug_mode():
+    main.DEBUG_MODE = True
+
+    with client_context() as (client, _mock_cli):
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": DEFAULT_MODEL,
+                "input": [{"content": "Hi"}],
+            },
+        )
+
+    body = response.json()
+    assert response.status_code == 422
+    assert "debug" not in body["error"]
 
 
 def test_session_endpoints_and_http_exception_handler():

--- a/tests/test_main_api_unit.py
+++ b/tests/test_main_api_unit.py
@@ -535,7 +535,10 @@ def test_create_response_returns_502_when_claude_sdk_raises():
         )
 
     assert response.status_code == 502
-    assert response.json()["error"]["message"] == "Backend error: boom"
+    body = response.json()
+    assert body["error"]["message"] == "Backend error"
+    # Raw exception text must not leak to clients
+    assert "boom" not in body["error"]["message"]
 
 
 def test_create_response_returns_502_when_sdk_emits_error_chunk():
@@ -554,6 +557,8 @@ def test_create_response_returns_502_when_sdk_emits_error_chunk():
         )
 
     assert response.status_code == 502
+    # SDK-emitted error_message is structured (e.g., rate_limit) and
+    # intentionally surfaced to clients, unlike raw Python exceptions.
     assert response.json()["error"]["message"] == "Backend error: sdk failed"
 
 

--- a/tests/test_main_coverage_unit.py
+++ b/tests/test_main_coverage_unit.py
@@ -531,6 +531,40 @@ class TestValidationHandlerBodyReadException:
             loop.close()
 
         body = json.loads(result.body)
-        assert body["error"]["debug"]["raw_request_body"] == "Could not read request body"
+        assert body["error"]["details"][0]["field"] == "body -> messages"
+        assert "debug" not in body["error"]
 
+    def test_validation_handler_logs_sanitized_errors(self, caplog):
+        from fastapi.exceptions import RequestValidationError
 
+        mock_request = MagicMock()
+        mock_request.method = "POST"
+        mock_request.url = "http://localhost/v1/responses"
+
+        exc = RequestValidationError(
+            errors=[
+                {
+                    "loc": ("body", "input", 0, "content", 0, "image_url"),
+                    "msg": "Input should be a valid string",
+                    "type": "string_type",
+                    "input": {"secret": "top-secret"},
+                }
+            ]
+        )
+
+        import asyncio
+        import logging
+
+        loop = asyncio.new_event_loop()
+        try:
+            with caplog.at_level(logging.ERROR):
+                result = loop.run_until_complete(
+                    main.validation_exception_handler(mock_request, exc)
+                )
+        finally:
+            loop.close()
+
+        body = json.loads(result.body)
+        assert body["error"]["details"][0]["type"] == "string_type"
+        assert "top-secret" not in caplog.text
+        assert "string_type" in caplog.text

--- a/tests/test_main_helpers_unit.py
+++ b/tests/test_main_helpers_unit.py
@@ -248,13 +248,13 @@ def test_run_server_reraises_unrelated_oserror():
 
 
 @pytest.mark.asyncio
-async def test_debug_logging_middleware_logs_raw_body_when_json_parse_fails(caplog):
+async def test_debug_logging_middleware_redacts_body_when_json_parse_fails(caplog):
     middleware = main.DebugLoggingMiddleware(app=main.app)
     request = MagicMock()
     request.state = SimpleNamespace(request_id="req-debug-raw")
     request.method = "POST"
     request.url = SimpleNamespace(path="/v1/responses")
-    request.headers = {"content-length": "8"}
+    request.headers = {"content-length": "8", "content-type": "application/octet-stream"}
     request.body = AsyncMock(return_value=b"not-json")
     response = MagicMock(status_code=200)
     call_next = AsyncMock(return_value=response)
@@ -270,6 +270,7 @@ async def test_debug_logging_middleware_logs_raw_body_when_json_parse_fails(capl
     # Raw body is never echoed to logs; only metadata is logged.
     assert "not-json" not in caplog.text
     assert "Request body: [non-JSON, 8 bytes" in caplog.text
+    assert "application/octet-stream" in caplog.text
     assert "Response: 200 in" in caplog.text
 
 

--- a/tests/test_main_helpers_unit.py
+++ b/tests/test_main_helpers_unit.py
@@ -267,7 +267,9 @@ async def test_debug_logging_middleware_logs_raw_body_when_json_parse_fails(capl
         result = await middleware.dispatch(request, call_next)
 
     assert result is response
-    assert "Request body (raw): not-json..." in caplog.text
+    # Raw body is never echoed to logs; only metadata is logged.
+    assert "not-json" not in caplog.text
+    assert "Request body: [non-JSON, 8 bytes" in caplog.text
     assert "Response: 200 in" in caplog.text
 
 

--- a/tests/test_main_helpers_unit.py
+++ b/tests/test_main_helpers_unit.py
@@ -295,6 +295,47 @@ async def test_debug_logging_middleware_handles_body_read_and_downstream_failure
     assert "Request failed after" in caplog.text
 
 
+@pytest.mark.asyncio
+async def test_request_logging_middleware_logs_parse_failures(caplog):
+    middleware = main.RequestLoggingMiddleware(app=main.app)
+    request = MagicMock()
+    request.method = "POST"
+    request.url = SimpleNamespace(path="/v1/responses")
+    request.headers = {"content-length": "8"}
+    request.body = AsyncMock(side_effect=RuntimeError("read failed"))
+    request.client = SimpleNamespace(host="127.0.0.1")
+    response = MagicMock(status_code=200)
+    call_next = AsyncMock(return_value=response)
+
+    with caplog.at_level(logging.DEBUG):
+        result = await middleware.dispatch(request, call_next)
+
+    assert result is response
+    assert "Could not inspect request body for request logging: read failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_request_logging_middleware_logs_backend_resolution_failures(caplog):
+    middleware = main.RequestLoggingMiddleware(app=main.app)
+    request = MagicMock()
+    request.method = "POST"
+    request.url = SimpleNamespace(path="/v1/responses")
+    request.headers = {"content-length": "32"}
+    request.body = AsyncMock(return_value=b'{"model":"sonnet"}')
+    request.client = SimpleNamespace(host="127.0.0.1")
+    response = MagicMock(status_code=200)
+    call_next = AsyncMock(return_value=response)
+
+    with (
+        patch("src.backends.resolve_model", side_effect=RuntimeError("resolver boom")),
+        caplog.at_level(logging.DEBUG),
+    ):
+        result = await middleware.dispatch(request, call_next)
+
+    assert result is response
+    assert "Could not resolve backend for request logging: resolver boom" in caplog.text
+
+
 def test_response_id_helpers_round_trip():
     session_id = str(uuid.uuid4())
 

--- a/tests/test_response_models.py
+++ b/tests/test_response_models.py
@@ -88,3 +88,27 @@ def test_response_create_request_rejects_non_string_input_image_url():
                 }
             ],
         )
+
+
+def test_response_create_request_accepts_unknown_part_type_as_dict():
+    """Forward-compat: unknown part types (e.g., input_file) are kept as dicts."""
+    req = ResponseCreateRequest(
+        model="sonnet",
+        input=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "see file"},
+                    {"type": "input_file", "file_id": "file_abc123"},
+                ],
+            }
+        ],
+    )
+
+    text_part = req.input[0].content[0]
+    unknown_part = req.input[0].content[1]
+    assert text_part.type == "input_text"
+    assert text_part.text == "see file"
+    assert isinstance(unknown_part, dict)
+    assert unknown_part["type"] == "input_file"
+    assert unknown_part["file_id"] == "file_abc123"

--- a/tests/test_response_models.py
+++ b/tests/test_response_models.py
@@ -1,8 +1,12 @@
 """Tests for function_call output models in response_models.py."""
 
+import pytest
+from pydantic import ValidationError
+
 from src.response_models import (
     FunctionCallOutputItem,
     FunctionCallOutputInput,
+    ResponseCreateRequest,
     ResponseObject,
     OutputItem,
     ResponseContentPart,
@@ -47,3 +51,40 @@ def test_response_object_accepts_function_call_output():
 def test_response_object_requires_action_status():
     resp = ResponseObject(id="resp_test", model="sonnet", status="requires_action")
     assert resp.status == "requires_action"
+
+
+def test_response_create_request_accepts_input_image_part():
+    req = ResponseCreateRequest(
+        model="sonnet",
+        input=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "describe"},
+                    {"type": "input_image", "image_url": "data:image/png;base64,abc123"},
+                ],
+            }
+        ],
+    )
+
+    part = req.input[0].content[1]
+    assert part.type == "input_image"
+    assert part.image_url == "data:image/png;base64,abc123"
+
+
+def test_response_create_request_rejects_non_string_input_image_url():
+    with pytest.raises(ValidationError):
+        ResponseCreateRequest(
+            model="sonnet",
+            input=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "input_image",
+                            "image_url": {"url": "data:image/png;base64,abc123"},
+                        }
+                    ],
+                }
+            ],
+        )


### PR DESCRIPTION
## Summary
- type Responses image input parts and return 400 for invalid image payloads instead of surfacing backend-facing failures
- sanitize validation error responses and logs so raw request input is no longer echoed back or logged verbatim
- harden the admin dashboard by adding SRI/crossorigin to CDN assets and replacing silent JS error handling with visible failures

## Review follow-ups (review pass 2)
- `test(admin)`: the empty-catch guard regex was vacuous (doubled backslashes in a raw string). Fixed to actually match `catch(e) {}` patterns.
- `fix(responses)`: the new discriminated content-part union only accepted `input_text`/`input_image` and returned 422 for any other `type` value, regressing forward-compat with evolving OpenAI Responses API parts (e.g., `input_file`, `input_audio`). A callable discriminator now routes unknown types to a `Dict[str, Any]` variant while keeping strict validation for known types.
- `fix(admin)`: polled loaders (`loadSummary` every 15s, `loadLogs` every 5s) could spam an error toast per tick during outages. Added a per-endpoint consecutive-failure counter so the toast fires once per streak; console logging remains unconditional.

## Review follow-ups (review pass 3)
- `fix(main)`: the JSON-parse fallback in `DebugLoggingMiddleware` wrote the first 500 bytes of the raw request body to debug logs. A malformed request carrying a Bearer token, API key, or PII would be logged verbatim under `DEBUG_MODE`/`VERBOSE`. Now logs only safe metadata (byte count + content-type).
- `fix(responses)`: `ResponseInputItem.role` was a bare `str`, making the contract opaque and accepting arbitrary values. Constrained to `Literal["user", "assistant", "system", "developer"]` matching the OpenAI Responses API.
- `fix(responses)`: the `except Exception as e` catch-all re-raised the exception string to clients via `detail=f"Backend error: {e}"`. Python exceptions can include file paths, subprocess commands, or SDK internals — now returns a generic `"Backend error"` detail; full exception is logged with `exc_info=True`. Structured SDK error chunks (`is_error=True, error_message=...`) still pass through since those are curated (rate limits, auth errors).

## Breaking / contract changes
- **Validation error envelope** (`POST /v1/*` 422 responses):
  - `error.details[].input` is no longer returned (was echoing raw user payloads — info-leak surface).
  - `error.debug.raw_request_body` is no longer returned, even when `DEBUG_MODE`/`VERBOSE` is set.
  - `error.details[].field|message|type` remain (derived from pydantic, no user data).
  - Any client or monitor that consumed `error.details[].input` or `error.debug` must switch to `error.details[].field` + `type`.
- **Responses API image parts** (`POST /v1/responses`):
  - `input_image` parts now return **400** for remote URLs, malformed `data:` URLs, unsupported media types, and malformed base64 (previously surfaced as 500 / backend errors).
  - Unknown content-part `type` values (other than `input_text` / `input_image`) are accepted as raw dicts for forward-compat; downstream code already tolerates both typed models and dicts.
- **Responses API input role**:
  - `role` in input items is now restricted to `user | assistant | system | developer`. Unknown roles fail with 422 at pydantic validation instead of flowing through the handler.
- **Responses API backend errors** (`POST /v1/responses` 502 responses):
  - Raw Python exceptions from the backend no longer appear in the client response. The response is a generic `"Backend error"` message; the full exception is logged server-side with `exc_info=True`.
  - SDK-emitted structured errors (e.g., rate-limit, auth failure) still surface as `"Backend error: <reason>"` since those messages are curated.

## Verification
- `uv run pytest tests/` — 1083 passed, 2 skipped, 4 deselected
- `uv run ruff check src tests` — all checks passed
- SRI hashes cross-verified against live jsDelivr CDN (all 7 match)