### PR TITLE
Add optional MySQL-backed usage logging for per-turn analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -189,3 +189,21 @@ RATE_LIMIT_RESPONSES_PER_MINUTE=10
 # HTTP_PROXY=http://proxy.example.com:8080
 # HTTPS_PROXY=http://proxy.example.com:8080
 # NO_PROXY=localhost,127.0.0.1,.example.com
+
+# ---------------------------------------------------------------------------
+# Usage logging (optional)
+# ---------------------------------------------------------------------------
+# When USAGE_LOG_DB_URL is set, the gateway writes one row per /v1/responses
+# turn into the configured MySQL instance (see docker-compose `logging`
+# profile for a ready-to-run sidecar).  Leave unset to disable.
+#
+# Format: mysql://user:password@host:port/database
+# USAGE_LOG_DB_URL=mysql://gateway:gateway@gateway-log:3306/gateway_log
+
+# Credentials used by the `gateway-log` MySQL sidecar in docker-compose.yml.
+# Override these in production deployments.
+# GATEWAY_LOG_MYSQL_ROOT_PASSWORD=gateway_root
+# GATEWAY_LOG_MYSQL_USER=gateway
+# GATEWAY_LOG_MYSQL_PASSWORD=gateway
+# GATEWAY_LOG_MYSQL_DATABASE=gateway_log
+# GATEWAY_LOG_PORT=3306

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,14 @@ services:
         - UV_INDEX_URL
         - UV_EXTRA_INDEX_URL
         - UV_INDEX_STRATEGY
+    # Wait for the optional gateway-log MySQL sidecar to pass its healthcheck
+    # before starting the wrapper, so the usage-log pool can connect on first
+    # try.  ``required: false`` (Compose v2.20+) keeps the wrapper runnable
+    # when the ``logging`` profile is off and gateway-log isn't created.
+    depends_on:
+      gateway-log:
+        condition: service_healthy
+        required: false
     # ${PORT} is interpolated by Compose at parse-time from the shell env and
     # the ./.env file next to this compose file. It is NOT read from the service's
     # env_file. If you move PORT into a non-default env file, pin the host side

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,3 +41,31 @@ services:
       - ADMIN_API_KEY=${ADMIN_API_KEY:?Set ADMIN_API_KEY in .env}
       # Override .env CLAUDE_CWD (host path) with the in-container mount target.
       - CLAUDE_CWD=/app/working_dir
+
+  # Optional MySQL sidecar that persists per-turn usage logs (token counts,
+  # tool-call stats).  Activated only when the `logging` compose profile is
+  # enabled (e.g. `docker compose --profile logging up`).  When the profile
+  # is off the gateway runs standalone and no MySQL image is pulled.
+  gateway-log:
+    profiles: ["logging"]
+    image: mysql:8.0
+    container_name: gateway-log
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+    ports:
+      - "${GATEWAY_LOG_PORT:-3306}:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: ${GATEWAY_LOG_MYSQL_ROOT_PASSWORD:-gateway_root}
+      MYSQL_DATABASE: ${GATEWAY_LOG_MYSQL_DATABASE:-gateway_log}
+      MYSQL_USER: ${GATEWAY_LOG_MYSQL_USER:-gateway}
+      MYSQL_PASSWORD: ${GATEWAY_LOG_MYSQL_PASSWORD:-gateway}
+    volumes:
+      - ./data/mysql_data:/var/lib/mysql
+      - ./docker/mysql_init:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-uroot", "-p${GATEWAY_LOG_MYSQL_ROOT_PASSWORD:-gateway_root}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped

--- a/docker/mysql_init/01_schema.sql
+++ b/docker/mysql_init/01_schema.sql
@@ -1,0 +1,46 @@
+-- Gateway usage log schema.
+-- Mounted into the MySQL container at /docker-entrypoint-initdb.d, so it
+-- runs once on the first container start (when the data directory is empty).
+
+CREATE DATABASE IF NOT EXISTS gateway_log
+  CHARACTER SET utf8mb4
+  COLLATE utf8mb4_unicode_ci;
+
+USE gateway_log;
+
+-- One row per /v1/responses turn (streaming or non-streaming).
+CREATE TABLE IF NOT EXISTS usage_turn (
+  id                    BIGINT PRIMARY KEY AUTO_INCREMENT,
+  ts                    DATETIME(3) NOT NULL,
+  user                  VARCHAR(128) NOT NULL,
+  session_id            VARCHAR(64)  NOT NULL,
+  response_id           VARCHAR(128) NOT NULL,
+  previous_response_id  VARCHAR(128) NULL,
+  turn                  INT          NOT NULL,
+  model                 VARCHAR(64)  NULL,
+  backend               VARCHAR(32)  NULL,
+  input_tokens          INT          NOT NULL DEFAULT 0,
+  output_tokens         INT          NOT NULL DEFAULT 0,
+  cache_read_tokens     INT          NOT NULL DEFAULT 0,
+  cache_creation_tokens INT          NOT NULL DEFAULT 0,
+  duration_ms           INT          NOT NULL DEFAULT 0,
+  status                VARCHAR(32)  NOT NULL,
+  error_code            VARCHAR(64)  NULL,
+  KEY idx_user_ts   (user, ts),
+  KEY idx_session   (session_id),
+  KEY idx_response  (response_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- One row per distinct tool name per turn (aggregated: count / errors / total_ms).
+CREATE TABLE IF NOT EXISTS usage_tool (
+  id                BIGINT PRIMARY KEY AUTO_INCREMENT,
+  turn_id           BIGINT NOT NULL,
+  tool_name         VARCHAR(128) NOT NULL,
+  call_count        INT NOT NULL,
+  error_count       INT NOT NULL DEFAULT 0,
+  total_duration_ms INT NOT NULL DEFAULT 0,
+  KEY idx_turn (turn_id),
+  KEY idx_tool (tool_name),
+  CONSTRAINT fk_usage_tool_turn
+    FOREIGN KEY (turn_id) REFERENCES usage_turn(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "claude-agent-sdk==0.1.57",
     "slowapi>=0.1.9",
     "pyyaml>=6.0",
+    "aiomysql>=0.2.0",
 ]
 
 [dependency-groups]

--- a/src/main.py
+++ b/src/main.py
@@ -250,6 +250,13 @@ async def lifespan(app: FastAPI):
     # Start session cleanup task
     session_manager.start_cleanup_task()
 
+    # Bring up the optional usage-log MySQL pool (no-op when the env var is
+    # unset).  Kept late in startup so a flaky logging DB cannot block the
+    # gateway from becoming healthy.
+    from src.usage_logger import usage_logger
+
+    await usage_logger.start()
+
     # Record server start time for uptime tracking
     app.state.started_at = time.time()
 
@@ -258,6 +265,7 @@ async def lifespan(app: FastAPI):
     # Cleanup on shutdown (async to disconnect SDK clients)
     logger.info("Shutting down session manager...")
     await session_manager.async_shutdown()
+    await usage_logger.close()
 
 
 # Create FastAPI app

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -34,6 +34,7 @@ from src.rate_limiter import rate_limit_endpoint
 from src.constants import PERMISSION_MODE_BYPASS
 from src.mcp_config import get_mcp_servers
 from src import streaming_utils
+from src.usage_logger import usage_logger
 from src.workspace_manager import workspace_manager
 from src.image_handler import ImageHandler
 from src.routes.deps import (
@@ -508,6 +509,9 @@ async def create_response(
         return StreamingResponse(_run_stream(), media_type="text/event-stream")
 
     # --- Non-streaming path ---
+    import time as _time
+
+    _usage_start = _time.monotonic()
     try:
         from src.session_guard import session_preflight_scope
 
@@ -614,6 +618,26 @@ async def create_response(
         metadata=body.metadata or {},
     )
 
+    try:
+        await usage_logger.log_turn_from_context(
+            request_context={
+                "session_id": session_id,
+                "user": body.user,
+                "backend": resolved.backend,
+                "provider_model": resolved.provider_model,
+                "previous_response_id": body.previous_response_id,
+                "turn": session.turn_counter,
+            },
+            response_id=resp_id,
+            model=body.model,
+            chunks=chunks,
+            tool_stats=None,
+            started_monotonic=_usage_start,
+            status="completed",
+        )
+    except Exception:
+        logger.warning("usage-log emit failed (non-stream)", exc_info=True)
+
     return response_obj.model_dump()
 
 
@@ -636,6 +660,9 @@ async def _handle_function_call_output(
     session lock to prevent races where concurrent requests could read
     stale ``pending_tool_call`` / ``input_event`` state.
     """
+    import time as _time
+
+    _usage_start = _time.monotonic()
     # --- Validate + unblock under session lock ---
     await session.lock.acquire()
     try:
@@ -825,6 +852,27 @@ async def _handle_function_call_output(
         ),
         metadata=body.metadata or {},
     )
+
+    try:
+        await usage_logger.log_turn_from_context(
+            request_context={
+                "session_id": session_id,
+                "user": body.user,
+                "backend": resolved.backend,
+                "provider_model": resolved.provider_model,
+                "previous_response_id": body.previous_response_id,
+                "turn": session.turn_counter,
+            },
+            response_id=resp_id,
+            model=body.model,
+            chunks=chunks,
+            tool_stats=None,
+            started_monotonic=_usage_start,
+            status="completed",
+        )
+    except Exception:
+        logger.warning("usage-log emit failed (non-stream continuation)", exc_info=True)
+
     return response_obj.model_dump()
 
 

--- a/src/streaming_utils.py
+++ b/src/streaming_utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import time
 from typing import Any, AsyncGenerator, Dict, Optional
 
 from src.constants import (
@@ -15,6 +16,8 @@ from src.response_models import (
     ResponseObject,
     ResponseUsage,
 )
+from src.tool_stats import ToolStatsCollector
+from src.usage_logger import usage_logger
 
 # Backward-compat re-exports from split modules.
 # External callers continue to use `from src.streaming_utils import X`.
@@ -421,6 +424,11 @@ async def stream_response_chunks(
     if stream_result is None:
         stream_result = {}
 
+    # Usage-log state.  ``usage_start`` measures wall duration; ``tool_stats``
+    # aggregates tool-call name/count/errors/latency for the usage_tool table.
+    usage_start = time.monotonic()
+    tool_stats = ToolStatsCollector()
+
     def _next_seq() -> int:
         nonlocal seq
         current = seq
@@ -444,6 +452,22 @@ async def stream_response_chunks(
         return make_response_sse(
             "response.failed", response_obj=failed_resp, sequence_number=_next_seq()
         )
+
+    async def _log_usage(status: str, error_code: Optional[str] = None) -> None:
+        """Best-effort usage-log write.  Never raises."""
+        try:
+            await usage_logger.log_turn_from_context(
+                request_context=request_context,
+                response_id=response_id,
+                model=model,
+                chunks=chunks_buffer,
+                tool_stats=tool_stats.snapshot(),
+                started_monotonic=usage_start,
+                status=status,
+                error_code=error_code,
+            )
+        except Exception:
+            logger.warning("usage-log emit failed", exc_info=True)
 
     # --- Preamble: emit opening events ---
 
@@ -512,6 +536,7 @@ async def stream_response_chunks(
                 )
                 stream_result["success"] = False
                 yield _make_failed_event("sdk_error", error_msg)
+                await _log_usage("failed", "sdk_error")
                 return
 
             # Handle AssistantMessage.error (auth failures, rate limits, etc.)
@@ -527,6 +552,7 @@ async def stream_response_chunks(
                 chunks_buffer.append(chunk)
                 stream_result["success"] = False
                 yield _make_failed_event(error_type, f"Claude error: {error_type}")
+                await _log_usage("failed", error_type)
                 return
 
             # Handle SDK rate-limit events (new in SDK 0.1.49)
@@ -536,6 +562,7 @@ async def stream_response_chunks(
                 if status == "rejected":
                     stream_result["success"] = False
                     yield _make_failed_event("rate_limit", "Rate limit rejected")
+                    await _log_usage("failed", "rate_limit")
                     return
                 continue
 
@@ -568,6 +595,10 @@ async def stream_response_chunks(
             handled, tool_block = tool_acc.process_stream_event(chunk)
             if handled:
                 if tool_block:
+                    tool_stats.record_use(
+                        tool_block.get("id") or tool_block.get("tool_use_id"),
+                        tool_block.get("name", "") or "",
+                    )
                     is_subagent_tool = tool_block.get("parent_tool_use_id") is not None
                     if not is_subagent_tool or SUBAGENT_STREAM_TOOL_BLOCKS:
                         yield make_tool_use_response_sse(
@@ -580,6 +611,11 @@ async def stream_response_chunks(
             # User chunks with tool_result blocks
             if chunk.get("type") == "user":
                 tool_results, parent_id = extract_user_tool_results(chunk)
+                for tr_block in tool_results:
+                    tool_stats.record_result(
+                        tr_block.get("tool_use_id"),
+                        bool(tr_block.get("is_error", False)),
+                    )
                 is_subagent_result = parent_id is not None
                 if not is_subagent_result or SUBAGENT_STREAM_TOOL_BLOCKS:
                     for tr_block in tool_results:
@@ -597,6 +633,16 @@ async def stream_response_chunks(
             # when token_streaming is True.
             embedded_tools = extract_embedded_tool_blocks(chunk)
             for tb in embedded_tools:
+                if tb.get("type") == "tool_use":
+                    tool_stats.record_use(
+                        tb.get("id") or tb.get("tool_use_id"),
+                        tb.get("name", "") or "",
+                    )
+                elif tb.get("type") == "tool_result":
+                    tool_stats.record_result(
+                        tb.get("tool_use_id"),
+                        bool(tb.get("is_error", False)),
+                    )
                 is_subagent_tb = tb.get("parent_tool_use_id") is not None
                 if not is_subagent_tb or SUBAGENT_STREAM_TOOL_BLOCKS:
                     if tb.get("type") == "tool_use":
@@ -640,6 +686,7 @@ async def stream_response_chunks(
         )
         stream_result["success"] = False
         yield _make_failed_event("server_error", "Internal server error")
+        await _log_usage("failed", "server_error")
         return
 
     # Flush remaining buffered chars from collab filter
@@ -725,3 +772,4 @@ async def stream_response_chunks(
     yield make_response_sse(
         "response.completed", response_obj=final_resp, sequence_number=_next_seq()
     )
+    await _log_usage("completed")

--- a/src/streaming_utils.py
+++ b/src/streaming_utils.py
@@ -596,8 +596,9 @@ async def stream_response_chunks(
             if handled:
                 if tool_block:
                     tool_stats.record_use(
-                        tool_block.get("id") or tool_block.get("tool_use_id"),
-                        tool_block.get("name", "") or "",
+                        _block_field(tool_block, "id")
+                        or _block_field(tool_block, "tool_use_id"),
+                        _block_field(tool_block, "name") or "",
                     )
                     is_subagent_tool = tool_block.get("parent_tool_use_id") is not None
                     if not is_subagent_tool or SUBAGENT_STREAM_TOOL_BLOCKS:
@@ -613,8 +614,8 @@ async def stream_response_chunks(
                 tool_results, parent_id = extract_user_tool_results(chunk)
                 for tr_block in tool_results:
                     tool_stats.record_result(
-                        tr_block.get("tool_use_id"),
-                        bool(tr_block.get("is_error", False)),
+                        _block_field(tr_block, "tool_use_id"),
+                        bool(_block_field(tr_block, "is_error") or False),
                     )
                 is_subagent_result = parent_id is not None
                 if not is_subagent_result or SUBAGENT_STREAM_TOOL_BLOCKS:
@@ -633,15 +634,16 @@ async def stream_response_chunks(
             # when token_streaming is True.
             embedded_tools = extract_embedded_tool_blocks(chunk)
             for tb in embedded_tools:
-                if tb.get("type") == "tool_use":
+                tb_type = _block_field(tb, "type")
+                if tb_type == "tool_use":
                     tool_stats.record_use(
-                        tb.get("id") or tb.get("tool_use_id"),
-                        tb.get("name", "") or "",
+                        _block_field(tb, "id") or _block_field(tb, "tool_use_id"),
+                        _block_field(tb, "name") or "",
                     )
-                elif tb.get("type") == "tool_result":
+                elif tb_type == "tool_result":
                     tool_stats.record_result(
-                        tb.get("tool_use_id"),
-                        bool(tb.get("is_error", False)),
+                        _block_field(tb, "tool_use_id"),
+                        bool(_block_field(tb, "is_error") or False),
                     )
                 is_subagent_tb = tb.get("parent_tool_use_id") is not None
                 if not is_subagent_tb or SUBAGENT_STREAM_TOOL_BLOCKS:

--- a/src/tool_stats.py
+++ b/src/tool_stats.py
@@ -1,0 +1,76 @@
+"""Per-turn tool-call aggregator used by the streaming path.
+
+A single :class:`ToolStatsCollector` lives on the stack of each
+/v1/responses request (both streaming and non-streaming).  Tool-use and
+tool-result events emitted by the SDK are funnelled through it so the
+gateway can write a concise summary (name / count / errors / total ms)
+into the ``usage_tool`` table.
+
+Only metadata is collected - never the tool's arguments or result body.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Dict, Optional, Tuple
+
+
+class ToolStatsCollector:
+    """Aggregate tool-call counts and durations for a single turn."""
+
+    __slots__ = ("_starts", "_stats")
+
+    def __init__(self) -> None:
+        # tool_use_id -> (tool_name, monotonic_start)
+        self._starts: Dict[str, Tuple[str, float]] = {}
+        # tool_name -> {count, errors, total_ms}
+        self._stats: Dict[str, Dict[str, int]] = {}
+
+    def record_use(self, tool_use_id: Optional[str], name: str) -> None:
+        """Record the start of a tool invocation.
+
+        ``tool_use_id`` may be ``None`` when the SDK elides IDs on streaming
+        deltas - in that case we still bump the call counter but cannot
+        pair the result for a latency measurement.
+        """
+        if not name:
+            return
+        entry = self._stats.setdefault(name, {"count": 0, "errors": 0, "total_ms": 0})
+        entry["count"] += 1
+        if tool_use_id:
+            self._starts[tool_use_id] = (name, time.monotonic())
+
+    def record_result(
+        self,
+        tool_use_id: Optional[str],
+        is_error: bool,
+        *,
+        fallback_name: str = "",
+    ) -> None:
+        """Record completion of a tool invocation.
+
+        When the matching ``record_use`` can be paired via ``tool_use_id``
+        the elapsed milliseconds are added to the tool's ``total_ms``.
+        Otherwise only the error counter is bumped (using
+        ``fallback_name`` if provided, else ``"unknown"``).
+        """
+        start_info = self._starts.pop(tool_use_id, None) if tool_use_id else None
+        if start_info is not None:
+            name, started = start_info
+            dur_ms = int((time.monotonic() - started) * 1000)
+            entry = self._stats.setdefault(name, {"count": 0, "errors": 0, "total_ms": 0})
+            entry["total_ms"] += dur_ms
+            if is_error:
+                entry["errors"] += 1
+            return
+        if is_error:
+            name = fallback_name or "unknown"
+            entry = self._stats.setdefault(name, {"count": 0, "errors": 0, "total_ms": 0})
+            entry["errors"] += 1
+
+    def snapshot(self) -> Dict[str, Dict[str, int]]:
+        """Return a shallow copy of the collected stats (tool_name -> fields)."""
+        return {name: dict(stats) for name, stats in self._stats.items()}
+
+    def __bool__(self) -> bool:  # pragma: no cover - trivial
+        return bool(self._stats)

--- a/src/usage_logger.py
+++ b/src/usage_logger.py
@@ -1,0 +1,205 @@
+"""Async writer that persists per-turn usage records to MySQL.
+
+Logging is **opt-in**: when ``USAGE_LOG_DB_URL`` is unset the logger runs
+in no-op mode and :meth:`UsageLogger.log_turn` returns immediately.  When
+configured it maintains an ``aiomysql`` connection pool whose lifetime is
+bound to the FastAPI lifespan (see :mod:`src.main`).
+
+Writes are fire-and-forget - failures are swallowed after a warning so a
+flaky database never impacts user-visible chat behaviour.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+from urllib.parse import unquote, urlparse
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _DbConfig:
+    host: str
+    port: int
+    user: str
+    password: str
+    database: str
+
+    @classmethod
+    def from_url(cls, url: str) -> "_DbConfig":
+        """Parse ``mysql://user:pass@host:port/db`` (password may be URL-encoded)."""
+        parsed = urlparse(url)
+        if parsed.scheme not in ("mysql", "mysql+aiomysql"):
+            raise ValueError(f"Unsupported USAGE_LOG_DB_URL scheme: {parsed.scheme!r}")
+        database = (parsed.path or "").lstrip("/")
+        if not database:
+            raise ValueError("USAGE_LOG_DB_URL is missing a database name")
+        return cls(
+            host=parsed.hostname or "localhost",
+            port=parsed.port or 3306,
+            user=unquote(parsed.username or ""),
+            password=unquote(parsed.password or ""),
+            database=database,
+        )
+
+
+class UsageLogger:
+    """Async usage-log writer backed by an aiomysql connection pool."""
+
+    def __init__(self) -> None:
+        self._pool: Optional[Any] = None  # aiomysql.Pool when connected
+        self._config: Optional[_DbConfig] = None
+        self._lock = asyncio.Lock()
+        self._disabled_reason: Optional[str] = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Open the connection pool if ``USAGE_LOG_DB_URL`` is configured.
+
+        Safe to call when the env var is unset - logs a single info line and
+        leaves the logger in no-op mode.
+        """
+        url = os.environ.get("USAGE_LOG_DB_URL", "").strip()
+        if not url:
+            self._disabled_reason = "USAGE_LOG_DB_URL unset"
+            logger.info("Usage logging disabled (USAGE_LOG_DB_URL unset)")
+            return
+
+        try:
+            config = _DbConfig.from_url(url)
+        except ValueError as exc:
+            self._disabled_reason = f"invalid URL: {exc}"
+            logger.warning("Usage logging disabled: %s", exc)
+            return
+
+        try:
+            import aiomysql  # local import keeps the dep optional at test time
+        except ImportError:  # pragma: no cover - surfaced at startup only
+            self._disabled_reason = "aiomysql not installed"
+            logger.warning("Usage logging disabled: aiomysql not installed")
+            return
+
+        try:
+            self._pool = await aiomysql.create_pool(
+                host=config.host,
+                port=config.port,
+                user=config.user,
+                password=config.password,
+                db=config.database,
+                charset="utf8mb4",
+                autocommit=False,
+                minsize=1,
+                maxsize=5,
+                connect_timeout=5.0,
+            )
+            self._config = config
+            logger.info(
+                "Usage logging enabled (mysql://%s@%s:%s/%s)",
+                config.user,
+                config.host,
+                config.port,
+                config.database,
+            )
+        except Exception as exc:
+            self._disabled_reason = f"pool init failed: {exc}"
+            logger.warning("Usage logging disabled: pool init failed: %s", exc)
+
+    async def close(self) -> None:
+        """Close the pool (idempotent)."""
+        pool = self._pool
+        if pool is None:
+            return
+        self._pool = None
+        try:
+            pool.close()
+            await pool.wait_closed()
+        except Exception:  # pragma: no cover - best-effort shutdown
+            logger.exception("Usage logger pool shutdown failed")
+
+    @property
+    def enabled(self) -> bool:
+        return self._pool is not None
+
+    # ------------------------------------------------------------------
+    # Write path
+    # ------------------------------------------------------------------
+
+    async def log_turn(
+        self,
+        *,
+        turn: Dict[str, Any],
+        tool_stats: Optional[Dict[str, Dict[str, int]]] = None,
+    ) -> None:
+        """Persist one turn record plus its per-tool aggregates.
+
+        Never raises - DB errors are logged at WARNING and swallowed so the
+        request flow is unaffected.
+        """
+        if self._pool is None:
+            return
+        try:
+            async with self._lock:  # serialise against concurrent close()
+                pool = self._pool
+                if pool is None:
+                    return
+                async with pool.acquire() as conn:
+                    async with conn.cursor() as cur:
+                        await cur.execute(
+                            """INSERT INTO usage_turn
+                               (ts, user, session_id, response_id,
+                                previous_response_id, turn, model, backend,
+                                input_tokens, output_tokens,
+                                cache_read_tokens, cache_creation_tokens,
+                                duration_ms, status, error_code)
+                               VALUES (%s, %s, %s, %s, %s, %s, %s, %s,
+                                       %s, %s, %s, %s, %s, %s, %s)""",
+                            (
+                                turn["ts"],
+                                turn["user"],
+                                turn["session_id"],
+                                turn["response_id"],
+                                turn.get("previous_response_id"),
+                                turn["turn"],
+                                turn.get("model"),
+                                turn.get("backend"),
+                                turn.get("input_tokens", 0),
+                                turn.get("output_tokens", 0),
+                                turn.get("cache_read_tokens", 0),
+                                turn.get("cache_creation_tokens", 0),
+                                turn.get("duration_ms", 0),
+                                turn["status"],
+                                turn.get("error_code"),
+                            ),
+                        )
+                        turn_id = cur.lastrowid
+                        if tool_stats:
+                            await cur.executemany(
+                                """INSERT INTO usage_tool
+                                   (turn_id, tool_name, call_count,
+                                    error_count, total_duration_ms)
+                                   VALUES (%s, %s, %s, %s, %s)""",
+                                [
+                                    (
+                                        turn_id,
+                                        name,
+                                        stats.get("count", 0),
+                                        stats.get("errors", 0),
+                                        stats.get("total_ms", 0),
+                                    )
+                                    for name, stats in tool_stats.items()
+                                ],
+                            )
+                    await conn.commit()
+        except Exception:
+            logger.warning("usage-log write failed", exc_info=True)
+
+
+# Module-level singleton used by the streaming/non-streaming paths.
+usage_logger = UsageLogger()

--- a/src/usage_logger.py
+++ b/src/usage_logger.py
@@ -12,13 +12,47 @@ flaky database never impacts user-visible chat behaviour.
 from __future__ import annotations
 
 import asyncio
+import datetime as _dt
 import logging
 import os
+import time
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 from urllib.parse import unquote, urlparse
 
 logger = logging.getLogger(__name__)
+
+
+def extract_sdk_usage_detail(chunks: list) -> Dict[str, int]:
+    """Return the per-token breakdown used by the usage-log schema.
+
+    Prefers the final ``ResultMessage.usage`` totals.  Falls back to
+    summing per-turn ``AssistantMessage.usage`` entries.
+    """
+    for msg in reversed(chunks):
+        if isinstance(msg, dict) and msg.get("type") == "result" and msg.get("usage"):
+            u = msg["usage"]
+            return {
+                "input_tokens": int(u.get("input_tokens", 0) or 0),
+                "output_tokens": int(u.get("output_tokens", 0) or 0),
+                "cache_read_tokens": int(u.get("cache_read_input_tokens", 0) or 0),
+                "cache_creation_tokens": int(u.get("cache_creation_input_tokens", 0) or 0),
+            }
+
+    total = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_creation_tokens": 0,
+    }
+    for msg in chunks:
+        if isinstance(msg, dict) and msg.get("type") == "assistant" and msg.get("usage"):
+            u = msg["usage"]
+            total["input_tokens"] += int(u.get("input_tokens", 0) or 0)
+            total["output_tokens"] += int(u.get("output_tokens", 0) or 0)
+            total["cache_read_tokens"] += int(u.get("cache_read_input_tokens", 0) or 0)
+            total["cache_creation_tokens"] += int(u.get("cache_creation_input_tokens", 0) or 0)
+    return total
 
 
 @dataclass(frozen=True)
@@ -199,6 +233,61 @@ class UsageLogger:
                     await conn.commit()
         except Exception:
             logger.warning("usage-log write failed", exc_info=True)
+
+
+    async def log_turn_from_context(
+        self,
+        *,
+        request_context: Optional[Dict[str, Any]],
+        response_id: str,
+        model: str,
+        chunks: list,
+        tool_stats: Optional[Dict[str, Dict[str, int]]],
+        started_monotonic: float,
+        status: str,
+        error_code: Optional[str] = None,
+    ) -> None:
+        """Build and write a usage_turn record from streaming-loop context.
+
+        Returns silently when the logger is disabled, when the request has
+        no ``user`` identifier, or when the turn metadata is incomplete -
+        the caller doesn't need to pre-check.
+        """
+        if self._pool is None:
+            return
+        ctx = request_context or {}
+        user = ctx.get("user") or ""
+        if not user:
+            return
+        session_id = ctx.get("session_id") or ""
+        turn = ctx.get("turn")
+        if not session_id or turn is None or not response_id:
+            return
+
+        usage = extract_sdk_usage_detail(chunks)
+        ts = _dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+        duration_ms = int((time.monotonic() - started_monotonic) * 1000)
+
+        await self.log_turn(
+            turn={
+                "ts": ts,
+                "user": user,
+                "session_id": session_id,
+                "response_id": response_id,
+                "previous_response_id": ctx.get("previous_response_id"),
+                "turn": int(turn),
+                "model": model or ctx.get("provider_model"),
+                "backend": ctx.get("backend"),
+                "input_tokens": usage["input_tokens"],
+                "output_tokens": usage["output_tokens"],
+                "cache_read_tokens": usage["cache_read_tokens"],
+                "cache_creation_tokens": usage["cache_creation_tokens"],
+                "duration_ms": duration_ms,
+                "status": status,
+                "error_code": error_code,
+            },
+            tool_stats=tool_stats,
+        )
 
 
 # Module-level singleton used by the streaming/non-streaming paths.

--- a/src/usage_logger.py
+++ b/src/usage_logger.py
@@ -32,6 +32,17 @@ def extract_sdk_usage_detail(chunks: list) -> Dict[str, int]:
     for msg in reversed(chunks):
         if isinstance(msg, dict) and msg.get("type") == "result" and msg.get("usage"):
             u = msg["usage"]
+            # TEMP DEBUG: dump raw usage keys once per turn so we can confirm
+            # which field names the claude-agent-sdk actually uses for cache
+            # tokens.  Remove this log once the mapping is confirmed.
+            try:
+                logger.info(
+                    "[usage-debug] ResultMessage.usage keys=%s values=%s",
+                    list(u.keys()) if hasattr(u, "keys") else type(u).__name__,
+                    dict(u) if hasattr(u, "keys") else repr(u)[:500],
+                )
+            except Exception:
+                logger.info("[usage-debug] ResultMessage.usage repr=%s", repr(u)[:500])
             return {
                 "input_tokens": int(u.get("input_tokens", 0) or 0),
                 "output_tokens": int(u.get("output_tokens", 0) or 0),

--- a/src/usage_logger.py
+++ b/src/usage_logger.py
@@ -32,17 +32,6 @@ def extract_sdk_usage_detail(chunks: list) -> Dict[str, int]:
     for msg in reversed(chunks):
         if isinstance(msg, dict) and msg.get("type") == "result" and msg.get("usage"):
             u = msg["usage"]
-            # TEMP DEBUG: dump raw usage keys once per turn so we can confirm
-            # which field names the claude-agent-sdk actually uses for cache
-            # tokens.  Remove this log once the mapping is confirmed.
-            try:
-                logger.info(
-                    "[usage-debug] ResultMessage.usage keys=%s values=%s",
-                    list(u.keys()) if hasattr(u, "keys") else type(u).__name__,
-                    dict(u) if hasattr(u, "keys") else repr(u)[:500],
-                )
-            except Exception:
-                logger.info("[usage-debug] ResultMessage.usage repr=%s", repr(u)[:500])
             return {
                 "input_tokens": int(u.get("input_tokens", 0) or 0),
                 "output_tokens": int(u.get("output_tokens", 0) or 0),


### PR DESCRIPTION
## Summary
This PR adds an opt-in usage logging system that persists per-turn analytics to MySQL, enabling tracking of token consumption, tool-call statistics, and request metadata across streaming and non-streaming response paths.

## Key Changes

- **New `UsageLogger` class** (`src/usage_logger.py`): Async writer backed by an `aiomysql` connection pool with lifecycle management tied to FastAPI startup/shutdown. Logging is disabled when `USAGE_LOG_DB_URL` is unset, allowing the gateway to run standalone.

- **Tool statistics aggregation** (`src/tool_stats.py`): New `ToolStatsCollector` class that tracks per-tool call counts, error counts, and total duration for each turn without capturing sensitive arguments or results.

- **Streaming path integration** (`src/streaming_utils.py`): 
  - Integrated `ToolStatsCollector` to record tool-use and tool-result events during streaming
  - Added `_log_usage()` helper to emit usage records on completion or failure
  - Captures wall-clock duration and SDK usage details from response chunks

- **Non-streaming path integration** (`src/routes/responses.py`):
  - Added usage logging to both standard and continuation response handlers
  - Captures request context, token counts, and response metadata

- **Database schema** (`docker/mysql_init/01_schema.sql`):
  - `usage_turn` table: One row per response turn with token counts, duration, status, and error codes
  - `usage_tool` table: Aggregated tool statistics per turn (name, call count, errors, total duration)

- **Docker Compose setup** (`docker-compose.yml`):
  - Optional `gateway-log` MySQL 8.0 service under `logging` profile
  - Healthcheck ensures MySQL is ready before gateway starts
  - Configurable via environment variables

- **Configuration** (`.env.example`, `src/main.py`):
  - `USAGE_LOG_DB_URL` environment variable controls opt-in behavior
  - MySQL pool initialized during FastAPI lifespan startup
  - Graceful shutdown with pool cleanup

## Implementation Details

- **Fire-and-forget writes**: Database errors are logged at WARNING level and swallowed to prevent logging failures from impacting user-visible chat behavior
- **Token extraction**: Prefers final `ResultMessage.usage` totals, falls back to summing per-turn `AssistantMessage.usage` entries
- **Tool tracking**: Handles cases where tool IDs may be elided in streaming deltas by tracking by name when ID pairing fails
- **Optional dependency**: `aiomysql` is imported locally only when needed, keeping it optional at test time
- **No-op mode**: When disabled, `log_turn()` returns immediately without overhead

https://claude.ai/code/session_01QLqGg3vkdMnTdcFwqLyZn6