### PR TITLE
Add opt-in per-turn usage logging (tokens + tool calls) with admin dashboard

### DIFF
--- a/src/admin_html_usage.py
+++ b/src/admin_html_usage.py
@@ -1,0 +1,159 @@
+"""Admin usage-log tab HTML."""
+
+
+def get_usage_html() -> str:
+    """Return the admin usage tab html."""
+    return """      <!-- Usage Tab -->
+      <div x-show="tab==='usage'" role="tabpanel">
+        <div x-show="usage.enabled === false" class="card" style="text-align:center; padding:2rem">
+          <div class="text-muted">[ USAGE LOGGING OFF ]</div>
+          <div class="text-xs text-dim" style="margin-top:0.5rem">
+            Set <span class="text-mono" style="color:var(--cyan)">USAGE_LOG_DB_URL</span>
+            and restart the gateway to enable per-turn token / tool logging.
+          </div>
+        </div>
+
+        <template x-if="usage.enabled !== false">
+          <div>
+            <div class="flex-between mb-md" style="flex-wrap:wrap; gap:0.5rem">
+              <h3 style="margin:0">Usage</h3>
+              <div class="flex-gap-sm" style="flex-wrap:wrap">
+                <label class="text-xs text-dim" style="display:flex; gap:4px; align-items:center">
+                  WINDOW
+                  <select x-model.number="usageWindow" @change="loadUsage()"
+                    style="padding:4px 8px; font-size:0.75rem">
+                    <option value="1">1d</option>
+                    <option value="7">7d</option>
+                    <option value="30">30d</option>
+                    <option value="90">90d</option>
+                  </select>
+                </label>
+                <button class="btn btn-sm btn-ghost" @click="loadUsage()">[RELOAD]</button>
+              </div>
+            </div>
+
+            <div class="grid-3 mb-lg">
+              <div class="card stat">
+                <div class="value" x-text="usage.summary?.turns_today ?? '-'"></div>
+                <div class="label">TURNS TODAY</div>
+              </div>
+              <div class="card stat">
+                <div class="value" x-text="formatNum(usage.summary?.tokens_today)"></div>
+                <div class="label">TOKENS TODAY</div>
+              </div>
+              <div class="card stat">
+                <div class="value" x-text="usage.summary?.turns_window ?? '-'"></div>
+                <div class="label" x-text="'TURNS ' + usageWindow + 'D'"></div>
+              </div>
+              <div class="card stat">
+                <div class="value" x-text="formatNum((usage.summary?.input_tokens_window ?? 0) + (usage.summary?.output_tokens_window ?? 0))"></div>
+                <div class="label" x-text="'TOKENS ' + usageWindow + 'D'"></div>
+              </div>
+              <div class="card stat">
+                <div class="value" x-text="usage.summary?.users_window ?? '-'"></div>
+                <div class="label" x-text="'USERS ' + usageWindow + 'D'"></div>
+              </div>
+              <div class="card stat">
+                <div class="value" :style="(usage.summary?.errors_window ?? 0) > 0 ? 'color:var(--red)' : ''" x-text="usage.summary?.errors_window ?? '-'"></div>
+                <div class="label">ERROR TURNS</div>
+              </div>
+            </div>
+
+            <div class="card mb-lg">
+              <div class="flex-between mb-md">
+                <h3 style="margin:0">Top users</h3>
+                <span class="text-xs text-dim" x-text="'last ' + usageWindow + 'd'"></span>
+              </div>
+              <div class="table-wrapper">
+                <table>
+                  <thead><tr><th>USER</th><th>CHATS</th><th>TURNS</th><th>TOKENS</th><th>CACHE READ</th><th>TOOL CALLS</th><th>ERRORS</th></tr></thead>
+                  <tbody>
+                    <template x-for="u in (usage.users ?? [])" :key="u.user">
+                      <tr style="cursor:pointer" @click="usageTurnsFilter = u.user; loadUsageTurns()">
+                        <td class="text-mono" style="color:var(--text-bright)" x-text="u.user"></td>
+                        <td class="text-sm" x-text="u.chats"></td>
+                        <td class="text-sm" x-text="u.turns"></td>
+                        <td class="text-sm" style="color:var(--amber)" x-text="formatNum(u.tokens)"></td>
+                        <td class="text-sm" style="color:var(--cyan)" x-text="formatNum(u.cache_read_tokens)"></td>
+                        <td class="text-sm" x-text="u.tool_calls"></td>
+                        <td class="text-sm" :style="(u.tool_errors + u.turn_errors) > 0 ? 'color:var(--red)' : 'color:var(--text-dim)'"
+                          x-text="(u.tool_errors ?? 0) + '/' + (u.turn_errors ?? 0)"></td>
+                      </tr>
+                    </template>
+                  </tbody>
+                </table>
+              </div>
+              <div x-show="(usage.users ?? []).length === 0" class="text-muted" style="padding:1rem; text-align:center">[ NO USERS ]</div>
+              <div class="text-xs text-dim" style="margin-top:0.5rem">// click a user to filter the turns table below</div>
+            </div>
+
+            <div class="card mb-lg">
+              <div class="flex-between mb-md">
+                <h3 style="margin:0">Top tools</h3>
+                <span class="text-xs text-dim" x-text="'last ' + usageWindow + 'd'"></span>
+              </div>
+              <div class="table-wrapper">
+                <table>
+                  <thead><tr><th>TOOL</th><th>CALLS</th><th>ERRORS</th><th>USERS</th><th>TOTAL MS</th><th>AVG MS</th></tr></thead>
+                  <tbody>
+                    <template x-for="t in (usage.tools ?? [])" :key="t.tool_name">
+                      <tr>
+                        <td class="text-mono" style="color:var(--cyan); max-width:360px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap" x-text="t.tool_name"></td>
+                        <td class="text-sm" x-text="t.calls"></td>
+                        <td class="text-sm" :style="(t.errors ?? 0) > 0 ? 'color:var(--red)' : 'color:var(--text-dim)'" x-text="t.errors"></td>
+                        <td class="text-sm" x-text="t.users"></td>
+                        <td class="text-sm" style="color:var(--amber)" x-text="t.total_ms"></td>
+                        <td class="text-sm" style="color:var(--text-dim)" x-text="t.calls > 0 ? Math.round(t.total_ms / t.calls) : '-'"></td>
+                      </tr>
+                    </template>
+                  </tbody>
+                </table>
+              </div>
+              <div x-show="(usage.tools ?? []).length === 0" class="text-muted" style="padding:1rem; text-align:center">[ NO TOOL CALLS ]</div>
+            </div>
+
+            <div class="card">
+              <div class="flex-between mb-md">
+                <h3 style="margin:0">Recent turns</h3>
+                <div class="flex-gap-sm" style="flex-wrap:wrap">
+                  <input type="text" x-model="usageTurnsFilter" placeholder="filter:user"
+                    style="padding:4px 8px; font-size:0.75rem; width:150px"
+                    @input.debounce.300ms="usageTurnsOffset = 0; loadUsageTurns()">
+                  <button class="btn btn-sm btn-ghost" @click="usageTurnsFilter=''; usageTurnsOffset=0; loadUsageTurns()">[CLEAR]</button>
+                </div>
+              </div>
+              <div class="table-wrapper">
+                <table>
+                  <thead><tr><th>TIME</th><th>USER</th><th>SESSION</th><th>TURN</th><th>IN</th><th>OUT</th><th>CACHE R</th><th>MS</th><th>STATUS</th></tr></thead>
+                  <tbody>
+                    <template x-for="r in (usage.turns ?? [])" :key="r.id">
+                      <tr>
+                        <td class="text-xs" style="white-space:nowrap; color:var(--text-dim)" x-text="formatTime(r.ts)"></td>
+                        <td class="text-mono" style="color:var(--text-bright)" x-text="r.user"></td>
+                        <td class="text-mono text-xs" style="color:var(--cyan)" x-text="(r.session_id || '').substring(0,8)"></td>
+                        <td class="text-sm" x-text="r.turn"></td>
+                        <td class="text-sm" x-text="formatNum(r.input_tokens)"></td>
+                        <td class="text-sm" x-text="formatNum(r.output_tokens)"></td>
+                        <td class="text-sm" style="color:var(--cyan)" x-text="formatNum(r.cache_read_tokens)"></td>
+                        <td class="text-sm" style="color:var(--amber)" x-text="r.duration_ms"></td>
+                        <td><span :class="r.status === 'completed' ? 'badge badge-ok' : 'badge badge-err'" x-text="r.status"></span></td>
+                      </tr>
+                    </template>
+                  </tbody>
+                </table>
+              </div>
+              <div x-show="(usage.turns ?? []).length === 0" class="text-muted" style="padding:1rem; text-align:center">[ NO TURNS ]</div>
+              <div style="display:flex; justify-content:center; gap:0.5rem; margin-top:0.75rem">
+                <button class="btn btn-sm btn-ghost"
+                  @click="usageTurnsOffset = Math.max(0, usageTurnsOffset - 50); loadUsageTurns()"
+                  :disabled="usageTurnsOffset === 0">[PREV]</button>
+                <span class="text-xs text-muted" style="padding:4px 8px"
+                  x-text="'OFFSET ' + usageTurnsOffset"></span>
+                <button class="btn btn-sm btn-ghost"
+                  @click="usageTurnsOffset += 50; loadUsageTurns()"
+                  :disabled="(usage.turns ?? []).length < 50">[NEXT]</button>
+              </div>
+            </div>
+          </div>
+        </template>
+      </div>"""

--- a/src/admin_js.py
+++ b/src/admin_js.py
@@ -55,7 +55,11 @@ def get_admin_js() -> str:
     newPromptNameError: '',
     newPromptNameWarning: '',
     newPromptContent: '',
-    loading: { dashboard: false, logs: false, sessions: false },
+    loading: { dashboard: false, logs: false, sessions: false, usage: false },
+    usage: { enabled: null, summary: null, users: [], tools: [], turns: [] },
+    usageWindow: 7,
+    usageTurnsFilter: '',
+    usageTurnsOffset: 0,
 
     async init() {
       document.addEventListener('keydown', (e) => {
@@ -249,6 +253,50 @@ def get_admin_js() -> str:
     toggleLogsPolling() {
       if (this.logsPollTimer) { clearInterval(this.logsPollTimer); this.logsPollTimer = null; }
       if (this.logsAutoRefresh) { this.logsPollTimer = setInterval(() => this.loadLogs(), 5000); }
+    },
+
+    async loadUsage() {
+      this.loading.usage = true;
+      try {
+        const w = 'window_days=' + this.usageWindow;
+        const [sumR, userR, toolR] = await Promise.all([
+          this.api('/admin/api/usage/summary?' + w),
+          this.api('/admin/api/usage/users?' + w + '&limit=20'),
+          this.api('/admin/api/usage/tools?' + w + '&limit=30'),
+        ]);
+        if (sumR.ok) {
+          const s = await sumR.json();
+          this.usage.enabled = s.enabled;
+          this.usage.summary = s.summary || null;
+        }
+        if (userR.ok) {
+          const u = await userR.json();
+          this.usage.users = u.items || [];
+        }
+        if (toolR.ok) {
+          const t = await toolR.json();
+          this.usage.tools = t.items || [];
+        }
+        await this.loadUsageTurns();
+      } catch(e) {
+        console.error('Failed to load usage', e);
+        this.showToast('Failed to load usage', 'err');
+      } finally { this.loading.usage = false; }
+    },
+
+    async loadUsageTurns() {
+      try {
+        let url = '/admin/api/usage/turns?limit=50&offset=' + this.usageTurnsOffset;
+        if (this.usageTurnsFilter) url += '&user=' + encodeURIComponent(this.usageTurnsFilter);
+        const r = await this.api(url);
+        if (r.ok) {
+          const j = await r.json();
+          this.usage.turns = j.items || [];
+          if (this.usage.enabled === null) this.usage.enabled = j.enabled;
+        }
+      } catch(e) {
+        console.error('Failed to load usage turns', e);
+      }
     },
 
     async loadRateLimits() {
@@ -694,6 +742,15 @@ Skill description here.
       if (!t) return '-';
       try { return new Date(t).toLocaleString('ko-KR', { hour12: false }); }
       catch(e) { return t; }
+    },
+
+    formatNum(n) {
+      if (n === null || n === undefined) return '-';
+      const v = Number(n);
+      if (!isFinite(v)) return String(n);
+      if (v >= 1e6) return (v / 1e6).toFixed(1) + 'M';
+      if (v >= 1e3) return (v / 1e3).toFixed(1) + 'k';
+      return String(v);
     }
   };
 }"""

--- a/src/admin_page.py
+++ b/src/admin_page.py
@@ -13,6 +13,7 @@ from src.admin_html_logs import get_logs_html
 from src.admin_html_ratelimits import get_ratelimits_html
 from src.admin_html_sessions import get_sessions_html
 from src.admin_html_skills import get_skills_html
+from src.admin_html_usage import get_usage_html
 from src.admin_js import get_admin_js
 from src.admin_styles import get_admin_css
 
@@ -116,6 +117,7 @@ def build_admin_page() -> str:
         <button role="tab" :aria-selected="tab === 'dashboard'" @click="tab='dashboard'">DASH</button>
         <button role="tab" :aria-selected="tab === 'sessions'" @click="tab='sessions'; loadSummary()">SESSIONS</button>
         <button role="tab" :aria-selected="tab === 'logs'" @click="tab='logs'; loadLogs()">LOGS</button>
+        <button role="tab" :aria-selected="tab === 'usage'" @click="tab='usage'; loadUsage()">USAGE</button>
         <button role="tab" :aria-selected="tab === 'ratelimits'" @click="tab='ratelimits'; loadRateLimits()">LIMITS</button>
         <button role="tab" :aria-selected="tab === 'files'" @click="tab='files'; loadFiles()">FILES</button>
         <button role="tab" :aria-selected="tab === 'skills'" @click="tab='skills'; loadSkills()">SKILLS</button>
@@ -127,6 +129,8 @@ def build_admin_page() -> str:
         + get_dashboard_html()
         + "\n\n"
         + get_logs_html()
+        + "\n\n"
+        + get_usage_html()
         + "\n\n"
         + get_ratelimits_html()
         + "\n\n"

--- a/src/routes/admin.py
+++ b/src/routes/admin.py
@@ -815,3 +815,78 @@ async def list_marketplaces_endpoint(_=Depends(require_admin)):
     from src.plugin_service import list_marketplaces
 
     return {"marketplaces": list_marketplaces()}
+
+
+# ---------------------------------------------------------------------------
+# Usage-log dashboard (MySQL-backed analytics)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/usage/summary")
+async def usage_summary_endpoint(
+    window_days: int = 7,
+    _=Depends(require_admin),
+):
+    """Overview counters for the usage tab."""
+    from src.usage_queries import get_summary
+
+    data = await get_summary(window_days=max(1, min(window_days, 90)))
+    if data is None:
+        return {"enabled": False}
+    return {"enabled": True, "window_days": window_days, "summary": data}
+
+
+@router.get("/api/usage/users")
+async def usage_users_endpoint(
+    window_days: int = 7,
+    limit: int = 20,
+    _=Depends(require_admin),
+):
+    """Top users by token usage in the rolling window."""
+    from src.usage_queries import get_top_users
+
+    rows = await get_top_users(
+        window_days=max(1, min(window_days, 90)),
+        limit=max(1, min(limit, 500)),
+    )
+    if rows is None:
+        return {"enabled": False, "items": []}
+    return {"enabled": True, "items": rows}
+
+
+@router.get("/api/usage/tools")
+async def usage_tools_endpoint(
+    window_days: int = 7,
+    limit: int = 30,
+    _=Depends(require_admin),
+):
+    """Top tools by call count in the rolling window."""
+    from src.usage_queries import get_top_tools
+
+    rows = await get_top_tools(
+        window_days=max(1, min(window_days, 90)),
+        limit=max(1, min(limit, 500)),
+    )
+    if rows is None:
+        return {"enabled": False, "items": []}
+    return {"enabled": True, "items": rows}
+
+
+@router.get("/api/usage/turns")
+async def usage_turns_endpoint(
+    user: Optional[str] = None,
+    limit: int = 50,
+    offset: int = 0,
+    _=Depends(require_admin),
+):
+    """Recent turns (newest first), optionally filtered by user."""
+    from src.usage_queries import get_recent_turns
+
+    rows = await get_recent_turns(
+        user=user,
+        limit=max(1, min(limit, 500)),
+        offset=max(0, offset),
+    )
+    if rows is None:
+        return {"enabled": False, "items": []}
+    return {"enabled": True, "items": rows}

--- a/src/usage_logger.py
+++ b/src/usage_logger.py
@@ -161,6 +161,29 @@ class UsageLogger:
     def enabled(self) -> bool:
         return self._pool is not None
 
+    async def fetch_rows(self, sql: str, params: tuple = ()) -> Optional[list]:
+        """Execute a read-only SELECT and return ``list[dict]`` (DictCursor).
+
+        Returns ``None`` when the pool is not configured or the query fails -
+        callers should treat that as "usage logging is not available".
+        Intended only for admin-side analytics queries; callers must supply
+        the full parameterised SQL (no automatic quoting).
+        """
+        if self._pool is None:
+            return None
+        try:
+            import aiomysql  # local import - optional dep
+        except ImportError:
+            return None
+        try:
+            async with self._pool.acquire() as conn:
+                async with conn.cursor(aiomysql.DictCursor) as cur:
+                    await cur.execute(sql, params)
+                    return list(await cur.fetchall())
+        except Exception:
+            logger.warning("usage-log read failed: %s", sql[:120], exc_info=True)
+            return None
+
     # ------------------------------------------------------------------
     # Write path
     # ------------------------------------------------------------------

--- a/src/usage_queries.py
+++ b/src/usage_queries.py
@@ -1,0 +1,129 @@
+"""Read-side analytics queries for the admin usage dashboard.
+
+All functions return plain Python values (lists of dicts / dicts) or ``None``
+when the usage-log pool is disabled / unavailable.  The calling endpoints in
+``src.routes.admin`` translate ``None`` into an empty response so the UI can
+render a "usage logging off" hint without treating it as an error.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from src.usage_logger import usage_logger
+
+
+async def get_summary(window_days: int = 7) -> Optional[Dict[str, Any]]:
+    """Overview counters for the given rolling window and today (00:00 KST-ish)."""
+    if not usage_logger.enabled:
+        return None
+    rows = await usage_logger.fetch_rows(
+        """
+        SELECT
+          COUNT(*) AS turns_window,
+          COUNT(DISTINCT user) AS users_window,
+          COUNT(DISTINCT session_id) AS chats_window,
+          COALESCE(SUM(input_tokens), 0) AS input_tokens_window,
+          COALESCE(SUM(output_tokens), 0) AS output_tokens_window,
+          COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens_window,
+          COALESCE(SUM(cache_creation_tokens), 0) AS cache_creation_tokens_window,
+          SUM(status <> 'completed') AS errors_window
+        FROM usage_turn
+        WHERE ts >= NOW() - INTERVAL %s DAY
+        """,
+        (int(window_days),),
+    )
+    today_rows = await usage_logger.fetch_rows(
+        """
+        SELECT
+          COUNT(*) AS turns_today,
+          COALESCE(SUM(input_tokens + output_tokens), 0) AS tokens_today
+        FROM usage_turn
+        WHERE ts >= CURDATE()
+        """,
+    )
+    if rows is None or today_rows is None:
+        return None
+    out = dict(rows[0]) if rows else {}
+    out.update(today_rows[0] if today_rows else {})
+    return out
+
+
+async def get_top_users(window_days: int = 7, limit: int = 20) -> Optional[List[Dict[str, Any]]]:
+    if not usage_logger.enabled:
+        return None
+    rows = await usage_logger.fetch_rows(
+        """
+        SELECT
+          u.user,
+          COUNT(DISTINCT u.session_id) AS chats,
+          COUNT(*) AS turns,
+          COALESCE(SUM(u.input_tokens + u.output_tokens), 0) AS tokens,
+          COALESCE(SUM(u.cache_read_tokens), 0) AS cache_read_tokens,
+          COALESCE(SUM(t.call_count), 0) AS tool_calls,
+          COALESCE(SUM(t.error_count), 0) AS tool_errors,
+          SUM(u.status <> 'completed') AS turn_errors
+        FROM usage_turn u
+        LEFT JOIN usage_tool t ON t.turn_id = u.id
+        WHERE u.ts >= NOW() - INTERVAL %s DAY
+        GROUP BY u.user
+        ORDER BY tokens DESC
+        LIMIT %s
+        """,
+        (int(window_days), int(limit)),
+    )
+    return rows
+
+
+async def get_top_tools(window_days: int = 7, limit: int = 30) -> Optional[List[Dict[str, Any]]]:
+    if not usage_logger.enabled:
+        return None
+    rows = await usage_logger.fetch_rows(
+        """
+        SELECT
+          t.tool_name,
+          SUM(t.call_count) AS calls,
+          SUM(t.error_count) AS errors,
+          SUM(t.total_duration_ms) AS total_ms,
+          COUNT(DISTINCT u.user) AS users
+        FROM usage_tool t
+        JOIN usage_turn u ON u.id = t.turn_id
+        WHERE u.ts >= NOW() - INTERVAL %s DAY
+        GROUP BY t.tool_name
+        ORDER BY calls DESC
+        LIMIT %s
+        """,
+        (int(window_days), int(limit)),
+    )
+    return rows
+
+
+async def get_recent_turns(
+    user: Optional[str] = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> Optional[List[Dict[str, Any]]]:
+    if not usage_logger.enabled:
+        return None
+    params: list = []
+    where = ""
+    if user:
+        where = "WHERE user = %s"
+        params.append(user)
+    params.extend([int(limit), int(offset)])
+    rows = await usage_logger.fetch_rows(
+        f"""
+        SELECT
+          id, ts, user, session_id, response_id, previous_response_id,
+          turn, model, backend,
+          input_tokens, output_tokens,
+          cache_read_tokens, cache_creation_tokens,
+          duration_ms, status, error_code
+        FROM usage_turn
+        {where}
+        ORDER BY id DESC
+        LIMIT %s OFFSET %s
+        """,
+        tuple(params),
+    )
+    return rows


### PR DESCRIPTION
## Summary

Adds opt-in per-user usage logging to the gateway. When `USAGE_LOG_DB_URL` is set, every `/v1/responses` turn (streaming and non-streaming) is persisted to a MySQL instance with token breakdown and per-tool call stats; a companion admin tab visualises the data. Everything is **off by default** so existing deployments are unaffected.

## What gets logged

### `usage_turn` — one row per `/v1/responses` turn

| column | description |
|---|---|
| `ts`, `user`, `session_id`, `response_id`, `previous_response_id`, `turn`, `model`, `backend` | request metadata |
| `input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_creation_tokens` | from `ResultMessage.usage` |
| `duration_ms`, `status`, `error_code` | outcome |

### `usage_tool` — one row per distinct tool name per turn

| column | description |
|---|---|
| `turn_id` (FK `usage_turn.id` ON DELETE CASCADE) | |
| `tool_name`, `call_count`, `error_count`, `total_duration_ms` | aggregated per turn |

**Intentionally not logged**: prompts / completions / tool args / tool results (PII & auth-token risk).

## How to enable

1. Uncomment `USAGE_LOG_DB_URL=mysql://gateway:gateway@...:3306/gateway_log` in `.env`
2. Bring up the bundled sidecar: `docker compose --profile logging up -d`

The sidecar (`gateway-log`, mysql:8.0) self-initialises the schema from `docker/mysql_init/01_schema.sql` on first start. `claude-wrapper` now `depends_on` the sidecar's healthcheck so startup is race-free.

When `USAGE_LOG_DB_URL` is unset or the pool fails to open, the logger stays in no-op mode; all DB errors are logged at WARNING and swallowed — usage logging never blocks chat traffic.

## Admin dashboard

New **USAGE** tab on `/admin`:

- 6 summary cards (turns today / 7d, tokens today / 7d, active users, error turns)
- Top-users table with cache read tokens and tool-error counts; click a row to filter turns below
- Top-tools table with calls / errors / users / avg ms
- Recent turns table with user filter + pagination

Backing endpoints:

- `GET /admin/api/usage/summary?window_days=`
- `GET /admin/api/usage/users?window_days=&limit=`
- `GET /admin/api/usage/tools?window_days=&limit=`
- `GET /admin/api/usage/turns?user=&limit=&offset=`

All require admin authentication and return `{"enabled": false}` when the log pool isn't configured, so the UI can show a friendly "usage logging off" card.

## File-level overview

| file | change |
|---|---|
| `pyproject.toml`, `.env.example` | + `aiomysql`, opt-in env vars |
| `docker-compose.yml` | `gateway-log` service behind `logging` profile, `depends_on` healthcheck |
| `docker/mysql_init/01_schema.sql` | schema |
| `src/tool_stats.py` | per-turn `ToolStatsCollector` |
| `src/usage_logger.py` | async `UsageLogger` + `fetch_rows` + `extract_sdk_usage_detail` |
| `src/usage_queries.py` | analytics SELECTs used by admin endpoints |
| `src/main.py` | pool start/close in FastAPI lifespan |
| `src/streaming_utils.py` | hook `ToolStatsCollector` into all tool-event sources, emit usage at every stream exit |
| `src/routes/responses.py` | log completed non-stream turns (main handler + function_call_output continuation) |
| `src/routes/admin.py` | `/admin/api/usage/*` endpoints |
| `src/admin_html_usage.py`, `src/admin_page.py`, `src/admin_js.py` | USAGE tab markup, wiring, JS loaders |

## Test plan

- [ ] `docker compose --profile logging up -d` brings up both containers; gateway logs `Usage logging enabled (...)` (regression: was hitting init race before the `depends_on` / `service_healthy` wait)
- [ ] Send a request with `body.user` set — one row lands in `usage_turn` and matching `usage_tool` rows for any tool calls
- [ ] Send follow-up using `previous_response_id` — `session_id` reused, `turn` increments
- [ ] Admin `/admin` → USAGE tab renders cards + all three tables; user-row click filters recent turns
- [ ] Unset `USAGE_LOG_DB_URL`, restart — gateway still starts cleanly, admin tab shows "USAGE LOGGING OFF"
- [ ] Failure paths (SDK error, rate limit, empty response) log with appropriate `status` / `error_code`

## Notes / known limitations

- `claude-agent-sdk==0.1.57` does not currently set `cache_control` on Anthropic requests in this flow, so `cache_read_tokens` and `cache_creation_tokens` are always 0 — the column mapping is correct, the upstream SDK just isn't requesting caching. Out of scope for this PR.
- Non-streaming turns log tokens but `tool_stats` is empty (no per-event timestamps available post-hoc).
- Dashboard is read-only; no charts yet. Adding time-series / charts is easy to layer on once the tables are populated in production.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QLqGg3vkdMnTdcFwqLyZn6)_