### PR TITLE
Add opt-in per-turn usage logging + USAGE admin dashboard with charts

### DIFF
--- a/src/admin_html_usage.py
+++ b/src/admin_html_usage.py
@@ -75,7 +75,6 @@ def get_usage_html() -> str:
                     <template x-for="chart in [
                       {key:'turns', label:'QUERIES', color:'var(--green)'},
                       {key:'users', label:'USERS', color:'var(--cyan)'},
-                      {key:'tool_calls', label:'TOOL CALLS', color:'var(--amber)'},
                       {key:'tokens', label:'TOKENS', color:'var(--red)'}
                     ]" :key="'row-' + chart.key">
                       <tr>
@@ -99,6 +98,45 @@ def get_usage_html() -> str:
                         </template>
                       </tr>
                     </template>
+                    <tr>
+                      <td class="text-xs text-dim" style="vertical-align:middle; letter-spacing:0.08em">TOOL CALLS</td>
+                      <template x-for="g in ['day','week','month']" :key="'tool-cell-' + g">
+                        <td style="vertical-align:middle; padding:8px">
+                          <template x-if="(usage.toolsSeries?.[g]?.buckets ?? []).length === 0">
+                            <div class="text-muted text-xs" style="padding:1rem; text-align:center">-</div>
+                          </template>
+                          <template x-if="(usage.toolsSeries?.[g]?.buckets ?? []).length > 0">
+                            <div>
+                              <div style="display:flex; gap:6px; align-items:flex-end; height:90px; border-bottom:1px solid var(--border-dim)">
+                                <template x-for="bucket in (usage.toolsSeries?.[g]?.buckets ?? [])" :key="g + 'b-' + bucket.bucket">
+                                  <div style="flex:1; display:flex; flex-direction:column; align-items:center; gap:2px; min-width:0">
+                                    <div style="display:flex; gap:1px; align-items:flex-end; width:100%; height:80px; justify-content:center">
+                                      <template x-for="(tool, idx) in (usage.toolsSeries?.[g]?.tools ?? [])" :key="g + bucket.bucket + tool">
+                                        <div :style="'flex:1; min-width:3px; max-width:14px; background:' + toolColor(idx) + '; height:' + ((Number((bucket.values || {})[tool] || 0) / toolSeriesMax(g)) * 100) + '%; min-height:2px; transition:height 0.3s'"
+                                          :title="tool + ': ' + ((bucket.values || {})[tool] || 0) + '회'"></div>
+                                      </template>
+                                    </div>
+                                  </div>
+                                </template>
+                              </div>
+                              <div style="display:flex; gap:6px; padding-top:4px">
+                                <template x-for="bucket in (usage.toolsSeries?.[g]?.buckets ?? [])" :key="g + bucket.bucket + '-lbl'">
+                                  <div class="text-xs text-dim" style="flex:1; text-align:center; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; font-size:0.6rem" x-text="bucket.bucket"></div>
+                                </template>
+                              </div>
+                              <div style="display:flex; flex-wrap:wrap; gap:4px 8px; padding-top:6px">
+                                <template x-for="(tool, idx) in (usage.toolsSeries?.[g]?.tools ?? [])" :key="g + 'leg-' + tool">
+                                  <div style="display:flex; gap:3px; align-items:center; font-size:0.6rem; color:var(--text-dim)">
+                                    <span :style="'width:8px; height:8px; background:' + toolColor(idx) + '; display:inline-block'"></span>
+                                    <span class="text-mono" style="max-width:120px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap" x-text="tool"></span>
+                                  </div>
+                                </template>
+                              </div>
+                            </div>
+                          </template>
+                        </td>
+                      </template>
+                    </tr>
                     <tr>
                       <td class="text-xs text-dim" style="vertical-align:top; letter-spacing:0.08em; padding-top:12px">TOP TOOLS</td>
                       <template x-for="g in ['day','week','month']" :key="'tools-' + g">

--- a/src/admin_html_usage.py
+++ b/src/admin_html_usage.py
@@ -75,6 +75,7 @@ def get_usage_html() -> str:
                     <template x-for="chart in [
                       {key:'turns', label:'QUERIES', color:'var(--green)'},
                       {key:'users', label:'USERS', color:'var(--cyan)'},
+                      {key:'tool_calls', label:'TOOL CALLS', color:'var(--amber)'},
                       {key:'tokens', label:'TOKENS', color:'var(--red)'}
                     ]" :key="'row-' + chart.key">
                       <tr>
@@ -99,7 +100,7 @@ def get_usage_html() -> str:
                       </tr>
                     </template>
                     <tr>
-                      <td class="text-xs text-dim" style="vertical-align:top; letter-spacing:0.08em; padding-top:12px">TOOL CALLS</td>
+                      <td class="text-xs text-dim" style="vertical-align:top; letter-spacing:0.08em; padding-top:12px">TOP TOOLS</td>
                       <template x-for="g in ['day','week','month']" :key="'tools-' + g">
                         <td style="vertical-align:top; padding:8px">
                           <div x-show="(usage.toolsByGran?.[g] ?? []).length === 0" class="text-muted text-xs">-</div>

--- a/src/admin_html_usage.py
+++ b/src/admin_html_usage.py
@@ -32,6 +32,47 @@ def get_usage_html() -> str:
               </div>
             </div>
 
+            <div class="card mb-lg">
+              <div class="flex-between mb-md">
+                <h3 style="margin:0">Trends</h3>
+                <div class="flex-gap-sm">
+                  <template x-for="g in ['day','week','month']" :key="g">
+                    <button class="btn btn-sm"
+                      :class="usageGran === g ? 'btn-primary' : 'btn-ghost'"
+                      @click="usageGran = g; loadUsageSeries()"
+                      x-text="g.toUpperCase()"></button>
+                  </template>
+                </div>
+              </div>
+              <div x-show="(usage.series ?? []).length === 0" class="text-muted" style="padding:1rem; text-align:center">[ NO DATA ]</div>
+              <div x-show="(usage.series ?? []).length > 0"
+                style="display:grid; grid-template-columns:repeat(auto-fit, minmax(260px, 1fr)); gap:1rem">
+                <template x-for="chart in [
+                  {key:'turns', label:'QUERIES', color:'var(--green)'},
+                  {key:'users', label:'USERS', color:'var(--cyan)'},
+                  {key:'tool_calls', label:'TOOL CALLS', color:'var(--amber)'},
+                  {key:'tokens', label:'TOKENS (IN+OUT)', color:'var(--red)'}
+                ]" :key="chart.key">
+                  <div>
+                    <div class="text-xs text-dim" style="margin-bottom:4px" x-text="chart.label"></div>
+                    <div style="display:flex; gap:6px; align-items:flex-end; height:140px; padding:4px 4px 0; border-bottom:1px solid var(--border-dim)">
+                      <template x-for="b in seriesForChart(chart.key)" :key="b.label + chart.key">
+                        <div style="flex:1; display:flex; flex-direction:column; align-items:center; gap:4px; min-width:0">
+                          <div class="text-xs" style="color:var(--text-bright); white-space:nowrap" x-text="formatNum(b.value)"></div>
+                          <div :style="'width:80%; background:' + chart.color + '; height:' + (b.pct*100) + '%; min-height:2px; transition:height 0.3s'"></div>
+                        </div>
+                      </template>
+                    </div>
+                    <div style="display:flex; gap:6px; padding:6px 4px 0">
+                      <template x-for="b in seriesForChart(chart.key)" :key="b.label + chart.key + '-lbl'">
+                        <div class="text-xs text-dim" style="flex:1; text-align:center; white-space:nowrap; overflow:hidden; text-overflow:ellipsis" x-text="b.label"></div>
+                      </template>
+                    </div>
+                  </div>
+                </template>
+              </div>
+            </div>
+
             <div class="grid-3 mb-lg">
               <div class="card stat">
                 <div class="value" x-text="usage.summary?.turns_today ?? '-'"></div>

--- a/src/admin_html_usage.py
+++ b/src/admin_html_usage.py
@@ -1,0 +1,159 @@
+"""Admin usage-log tab HTML."""
+
+
+def get_usage_html() -> str:
+    """Return the admin usage tab html."""
+    return """      <!-- Usage Tab -->
+      <div x-show="tab==='usage'" role="tabpanel">
+        <div x-show="usage.enabled === false" class="card" style="text-align:center; padding:2rem">
+          <div class="text-muted">[ USAGE LOGGING OFF ]</div>
+          <div class="text-xs text-dim" style="margin-top:0.5rem">
+            Set <span class="text-mono" style="color:var(--cyan)">USAGE_LOG_DB_URL</span>
+            and restart the gateway to enable per-turn token / tool logging.
+          </div>
+        </div>
+
+        <template x-if="usage.enabled !== false">
+          <div>
+            <div class="flex-between mb-md" style="flex-wrap:wrap; gap:0.5rem">
+              <h3 style="margin:0">Usage</h3>
+              <div class="flex-gap-sm" style="flex-wrap:wrap">
+                <label class="text-xs text-dim" style="display:flex; gap:4px; align-items:center">
+                  WINDOW
+                  <select x-model.number="usageWindow" @change="loadUsage()"
+                    style="padding:4px 8px; font-size:0.75rem">
+                    <option value="1">1d</option>
+                    <option value="7">7d</option>
+                    <option value="30">30d</option>
+                    <option value="90">90d</option>
+                  </select>
+                </label>
+                <button class="btn btn-sm btn-ghost" @click="loadUsage()">[RELOAD]</button>
+              </div>
+            </div>
+
+            <div class="grid-3 mb-lg">
+              <div class="card stat">
+                <div class="value" x-text="usage.summary?.turns_today ?? '-'"></div>
+                <div class="label">TURNS TODAY</div>
+              </div>
+              <div class="card stat">
+                <div class="value" x-text="formatNum(usage.summary?.tokens_today)"></div>
+                <div class="label">TOKENS TODAY</div>
+              </div>
+              <div class="card stat">
+                <div class="value" x-text="usage.summary?.turns_window ?? '-'"></div>
+                <div class="label" x-text="'TURNS ' + usageWindow + 'D'"></div>
+              </div>
+              <div class="card stat">
+                <div class="value" x-text="formatNum((usage.summary?.input_tokens_window ?? 0) + (usage.summary?.output_tokens_window ?? 0))"></div>
+                <div class="label" x-text="'TOKENS ' + usageWindow + 'D'"></div>
+              </div>
+              <div class="card stat">
+                <div class="value" x-text="usage.summary?.users_window ?? '-'"></div>
+                <div class="label" x-text="'USERS ' + usageWindow + 'D'"></div>
+              </div>
+              <div class="card stat">
+                <div class="value" :style="(usage.summary?.errors_window ?? 0) > 0 ? 'color:var(--red)' : ''" x-text="usage.summary?.errors_window ?? '-'"></div>
+                <div class="label">ERROR TURNS</div>
+              </div>
+            </div>
+
+            <div class="card mb-lg">
+              <div class="flex-between mb-md">
+                <h3 style="margin:0">Top users</h3>
+                <span class="text-xs text-dim" x-text="'last ' + usageWindow + 'd'"></span>
+              </div>
+              <div class="table-wrapper">
+                <table>
+                  <thead><tr><th>USER</th><th>CHATS</th><th>TURNS</th><th>TOKENS</th><th>CACHE READ</th><th>TOOL CALLS</th><th>ERRORS</th></tr></thead>
+                  <tbody>
+                    <template x-for="u in (usage.users ?? [])" :key="u.user">
+                      <tr style="cursor:pointer" @click="usageTurnsFilter = u.user; loadUsageTurns()">
+                        <td class="text-mono" style="color:var(--text-bright)" x-text="u.user"></td>
+                        <td class="text-sm" x-text="u.chats"></td>
+                        <td class="text-sm" x-text="u.turns"></td>
+                        <td class="text-sm" style="color:var(--amber)" x-text="formatNum(u.tokens)"></td>
+                        <td class="text-sm" style="color:var(--cyan)" x-text="formatNum(u.cache_read_tokens)"></td>
+                        <td class="text-sm" x-text="u.tool_calls"></td>
+                        <td class="text-sm" :style="(u.tool_errors + u.turn_errors) > 0 ? 'color:var(--red)' : 'color:var(--text-dim)'"
+                          x-text="(u.tool_errors ?? 0) + '/' + (u.turn_errors ?? 0)"></td>
+                      </tr>
+                    </template>
+                  </tbody>
+                </table>
+              </div>
+              <div x-show="(usage.users ?? []).length === 0" class="text-muted" style="padding:1rem; text-align:center">[ NO USERS ]</div>
+              <div class="text-xs text-dim" style="margin-top:0.5rem">// click a user to filter the turns table below</div>
+            </div>
+
+            <div class="card mb-lg">
+              <div class="flex-between mb-md">
+                <h3 style="margin:0">Top tools</h3>
+                <span class="text-xs text-dim" x-text="'last ' + usageWindow + 'd'"></span>
+              </div>
+              <div class="table-wrapper">
+                <table>
+                  <thead><tr><th>TOOL</th><th>CALLS</th><th>ERRORS</th><th>USERS</th><th>TOTAL MS</th><th>AVG MS</th></tr></thead>
+                  <tbody>
+                    <template x-for="t in (usage.tools ?? [])" :key="t.tool_name">
+                      <tr>
+                        <td class="text-mono" style="color:var(--cyan); max-width:360px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap" x-text="t.tool_name"></td>
+                        <td class="text-sm" x-text="t.calls"></td>
+                        <td class="text-sm" :style="(t.errors ?? 0) > 0 ? 'color:var(--red)' : 'color:var(--text-dim)'" x-text="t.errors"></td>
+                        <td class="text-sm" x-text="t.users"></td>
+                        <td class="text-sm" style="color:var(--amber)" x-text="t.total_ms"></td>
+                        <td class="text-sm" style="color:var(--text-dim)" x-text="t.calls > 0 ? Math.round(t.total_ms / t.calls) : '-'"></td>
+                      </tr>
+                    </template>
+                  </tbody>
+                </table>
+              </div>
+              <div x-show="(usage.tools ?? []).length === 0" class="text-muted" style="padding:1rem; text-align:center">[ NO TOOL CALLS ]</div>
+            </div>
+
+            <div class="card">
+              <div class="flex-between mb-md">
+                <h3 style="margin:0">Recent turns</h3>
+                <div class="flex-gap-sm" style="flex-wrap:wrap">
+                  <input type="text" x-model="usageTurnsFilter" placeholder="filter:user"
+                    style="padding:4px 8px; font-size:0.75rem; width:150px"
+                    @input.debounce.300ms="usageTurnsOffset = 0; loadUsageTurns()">
+                  <button class="btn btn-sm btn-ghost" @click="usageTurnsFilter=''; usageTurnsOffset=0; loadUsageTurns()">[CLEAR]</button>
+                </div>
+              </div>
+              <div class="table-wrapper">
+                <table>
+                  <thead><tr><th>TIME</th><th>USER</th><th>SESSION</th><th>TURN</th><th>IN</th><th>OUT</th><th>CACHE R</th><th>MS</th><th>STATUS</th></tr></thead>
+                  <tbody>
+                    <template x-for="r in (usage.turns ?? [])" :key="r.id">
+                      <tr>
+                        <td class="text-xs" style="white-space:nowrap; color:var(--text-dim)" x-text="formatTime(r.ts)"></td>
+                        <td class="text-mono" style="color:var(--text-bright)" x-text="r.user"></td>
+                        <td class="text-mono text-xs" style="color:var(--cyan)" x-text="(r.session_id || '').substring(0,8)"></td>
+                        <td class="text-sm" x-text="r.turn"></td>
+                        <td class="text-sm" x-text="formatNum(r.input_tokens)"></td>
+                        <td class="text-sm" x-text="formatNum(r.output_tokens)"></td>
+                        <td class="text-sm" style="color:var(--cyan)" x-text="formatNum(r.cache_read_tokens)"></td>
+                        <td class="text-sm" style="color:var(--amber)" x-text="r.duration_ms"></td>
+                        <td><span :class="r.status === 'completed' ? 'badge badge-ok' : 'badge badge-err'" x-text="r.status"></span></td>
+                      </tr>
+                    </template>
+                  </tbody>
+                </table>
+              </div>
+              <div x-show="(usage.turns ?? []).length === 0" class="text-muted" style="padding:1rem; text-align:center">[ NO TURNS ]</div>
+              <div style="display:flex; justify-content:center; gap:0.5rem; margin-top:0.75rem">
+                <button class="btn btn-sm btn-ghost"
+                  @click="usageTurnsOffset = Math.max(0, usageTurnsOffset - 50); loadUsageTurns()"
+                  :disabled="usageTurnsOffset === 0">[PREV]</button>
+                <span class="text-xs text-muted" style="padding:4px 8px"
+                  x-text="'OFFSET ' + usageTurnsOffset"></span>
+                <button class="btn btn-sm btn-ghost"
+                  @click="usageTurnsOffset += 50; loadUsageTurns()"
+                  :disabled="(usage.turns ?? []).length < 50">[NEXT]</button>
+              </div>
+            </div>
+          </div>
+        </template>
+      </div>"""

--- a/src/admin_html_usage.py
+++ b/src/admin_html_usage.py
@@ -17,10 +17,11 @@ def get_usage_html() -> str:
           <div>
             <div class="flex-between mb-md" style="flex-wrap:wrap; gap:0.5rem">
               <h3 style="margin:0">Usage</h3>
-              <div class="flex-gap-sm" style="flex-wrap:wrap">
+              <div class="flex-gap-sm" style="flex-wrap:wrap; align-items:center">
                 <label class="text-xs text-dim" style="display:flex; gap:4px; align-items:center">
                   WINDOW
-                  <select x-model.number="usageWindow" @change="loadUsage()"
+                  <select x-model.number="usageWindow"
+                    @change="usageStart=''; usageEnd=''; loadUsage()"
                     style="padding:4px 8px; font-size:0.75rem">
                     <option value="1">1d</option>
                     <option value="7">7d</option>
@@ -28,47 +29,72 @@ def get_usage_html() -> str:
                     <option value="90">90d</option>
                   </select>
                 </label>
+                <span class="text-xs text-dim">or</span>
+                <label class="text-xs text-dim" style="display:flex; gap:4px; align-items:center">
+                  FROM
+                  <input type="date" x-model="usageStart"
+                    style="padding:4px 8px; font-size:0.75rem; color-scheme:dark">
+                </label>
+                <label class="text-xs text-dim" style="display:flex; gap:4px; align-items:center">
+                  TO
+                  <input type="date" x-model="usageEnd"
+                    style="padding:4px 8px; font-size:0.75rem; color-scheme:dark">
+                </label>
+                <button class="btn btn-sm" :class="(usageStart && usageEnd) ? 'btn-primary' : 'btn-ghost'"
+                  @click="loadUsage()" :disabled="(usageStart || usageEnd) && !(usageStart && usageEnd)">[APPLY]</button>
+                <button class="btn btn-sm btn-ghost" x-show="usageStart || usageEnd"
+                  @click="usageStart=''; usageEnd=''; loadUsage()">[CLEAR]</button>
                 <button class="btn btn-sm btn-ghost" @click="loadUsage()">[RELOAD]</button>
               </div>
+            </div>
+            <div x-show="usageStart && usageEnd" class="text-xs text-dim" style="margin-top:-0.5rem; margin-bottom:0.75rem">
+              showing <span style="color:var(--cyan)" x-text="usageStart"></span> → <span style="color:var(--cyan)" x-text="usageEnd"></span> (inclusive)
             </div>
 
             <div class="card mb-lg">
               <div class="flex-between mb-md">
                 <h3 style="margin:0">Trends</h3>
-                <div class="flex-gap-sm">
-                  <template x-for="g in ['day','week','month']" :key="g">
-                    <button class="btn btn-sm"
-                      :class="usageGran === g ? 'btn-primary' : 'btn-ghost'"
-                      @click="usageGran = g; loadUsageSeries()"
-                      x-text="g.toUpperCase()"></button>
-                  </template>
-                </div>
+                <span class="text-xs text-dim">last 5 · day / week / month</span>
               </div>
-              <div x-show="(usage.series ?? []).length === 0" class="text-muted" style="padding:1rem; text-align:center">[ NO DATA ]</div>
-              <div x-show="(usage.series ?? []).length > 0"
-                style="display:grid; grid-template-columns:repeat(auto-fit, minmax(260px, 1fr)); gap:1rem">
+              <div x-show="usageSeriesEmpty()" class="text-muted" style="padding:1rem; text-align:center">[ NO DATA ]</div>
+              <div x-show="!usageSeriesEmpty()"
+                style="display:grid; grid-template-columns:auto repeat(3, 1fr); gap:0.75rem 1rem; align-items:stretch">
+                <div></div>
+                <template x-for="g in ['day','week','month']" :key="'hdr-' + g">
+                  <div class="text-xs text-dim" style="text-align:center; letter-spacing:0.08em" x-text="g.toUpperCase()"></div>
+                </template>
                 <template x-for="chart in [
                   {key:'turns', label:'QUERIES', color:'var(--green)'},
                   {key:'users', label:'USERS', color:'var(--cyan)'},
                   {key:'tool_calls', label:'TOOL CALLS', color:'var(--amber)'},
-                  {key:'tokens', label:'TOKENS (IN+OUT)', color:'var(--red)'}
+                  {key:'tokens', label:'TOKENS', color:'var(--red)'}
                 ]" :key="chart.key">
-                  <div>
-                    <div class="text-xs text-dim" style="margin-bottom:4px" x-text="chart.label"></div>
-                    <div style="display:flex; gap:6px; align-items:flex-end; height:140px; padding:4px 4px 0; border-bottom:1px solid var(--border-dim)">
-                      <template x-for="b in seriesForChart(chart.key)" :key="b.label + chart.key">
-                        <div style="flex:1; display:flex; flex-direction:column; align-items:center; gap:4px; min-width:0">
-                          <div class="text-xs" style="color:var(--text-bright); white-space:nowrap" x-text="formatNum(b.value)"></div>
-                          <div :style="'width:80%; background:' + chart.color + '; height:' + (b.pct*100) + '%; min-height:2px; transition:height 0.3s'"></div>
+                  <template x-for="cell in [
+                    {row: chart, gran: 'day'},
+                    {row: chart, gran: 'week'},
+                    {row: chart, gran: 'month'}
+                  ]" :key="chart.key + '-' + cell.gran">
+                    <div style="display:contents">
+                      <template x-if="cell.gran === 'day'">
+                        <div class="text-xs text-dim" style="align-self:center; white-space:nowrap" x-text="chart.label"></div>
+                      </template>
+                      <div>
+                        <div style="display:flex; gap:4px; align-items:flex-end; height:100px; padding:4px 4px 0; border-bottom:1px solid var(--border-dim)">
+                          <template x-for="b in seriesForChart(cell.gran, chart.key)" :key="cell.gran + chart.key + b.label">
+                            <div style="flex:1; display:flex; flex-direction:column; align-items:center; gap:2px; min-width:0">
+                              <div class="text-xs" style="color:var(--text-bright); white-space:nowrap; font-size:0.65rem" x-text="formatNum(b.value)"></div>
+                              <div :style="'width:78%; background:' + chart.color + '; height:' + (b.pct*100) + '%; min-height:2px; transition:height 0.3s'"></div>
+                            </div>
+                          </template>
                         </div>
-                      </template>
+                        <div style="display:flex; gap:4px; padding:4px 4px 0">
+                          <template x-for="b in seriesForChart(cell.gran, chart.key)" :key="cell.gran + chart.key + b.label + '-lbl'">
+                            <div class="text-xs text-dim" style="flex:1; text-align:center; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; font-size:0.6rem" x-text="b.label"></div>
+                          </template>
+                        </div>
+                      </div>
                     </div>
-                    <div style="display:flex; gap:6px; padding:6px 4px 0">
-                      <template x-for="b in seriesForChart(chart.key)" :key="b.label + chart.key + '-lbl'">
-                        <div class="text-xs text-dim" style="flex:1; text-align:center; white-space:nowrap; overflow:hidden; text-overflow:ellipsis" x-text="b.label"></div>
-                      </template>
-                    </div>
-                  </div>
+                  </template>
                 </template>
               </div>
             </div>

--- a/src/admin_html_usage.py
+++ b/src/admin_html_usage.py
@@ -57,45 +57,65 @@ def get_usage_html() -> str:
                 <span class="text-xs text-dim">last 5 · day / week / month</span>
               </div>
               <div x-show="usageSeriesEmpty()" class="text-muted" style="padding:1rem; text-align:center">[ NO DATA ]</div>
-              <div x-show="!usageSeriesEmpty()"
-                style="display:grid; grid-template-columns:auto repeat(3, 1fr); gap:0.75rem 1rem; align-items:stretch">
-                <div></div>
-                <template x-for="g in ['day','week','month']" :key="'hdr-' + g">
-                  <div class="text-xs text-dim" style="text-align:center; letter-spacing:0.08em" x-text="g.toUpperCase()"></div>
-                </template>
-                <template x-for="chart in [
-                  {key:'turns', label:'QUERIES', color:'var(--green)'},
-                  {key:'users', label:'USERS', color:'var(--cyan)'},
-                  {key:'tool_calls', label:'TOOL CALLS', color:'var(--amber)'},
-                  {key:'tokens', label:'TOKENS', color:'var(--red)'}
-                ]" :key="chart.key">
-                  <template x-for="cell in [
-                    {row: chart, gran: 'day'},
-                    {row: chart, gran: 'week'},
-                    {row: chart, gran: 'month'}
-                  ]" :key="chart.key + '-' + cell.gran">
-                    <div style="display:contents">
-                      <template x-if="cell.gran === 'day'">
-                        <div class="text-xs text-dim" style="align-self:center; white-space:nowrap" x-text="chart.label"></div>
-                      </template>
-                      <div>
-                        <div style="display:flex; gap:4px; align-items:flex-end; height:100px; padding:4px 4px 0; border-bottom:1px solid var(--border-dim)">
-                          <template x-for="b in seriesForChart(cell.gran, chart.key)" :key="cell.gran + chart.key + b.label">
-                            <div style="flex:1; display:flex; flex-direction:column; align-items:center; gap:2px; min-width:0">
-                              <div class="text-xs" style="color:var(--text-bright); white-space:nowrap; font-size:0.65rem" x-text="formatNum(b.value)"></div>
-                              <div :style="'width:78%; background:' + chart.color + '; height:' + (b.pct*100) + '%; min-height:2px; transition:height 0.3s'"></div>
+              <div x-show="!usageSeriesEmpty()" class="table-wrapper">
+                <table style="table-layout:fixed; width:100%">
+                  <colgroup>
+                    <col style="width:110px">
+                    <col><col><col>
+                  </colgroup>
+                  <thead>
+                    <tr>
+                      <th></th>
+                      <th style="text-align:center">DAY</th>
+                      <th style="text-align:center">WEEK</th>
+                      <th style="text-align:center">MONTH</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <template x-for="chart in [
+                      {key:'turns', label:'QUERIES', color:'var(--green)'},
+                      {key:'users', label:'USERS', color:'var(--cyan)'},
+                      {key:'tokens', label:'TOKENS', color:'var(--red)'}
+                    ]" :key="'row-' + chart.key">
+                      <tr>
+                        <td class="text-xs text-dim" style="vertical-align:middle; letter-spacing:0.08em" x-text="chart.label"></td>
+                        <template x-for="g in ['day','week','month']" :key="'cell-' + chart.key + '-' + g">
+                          <td style="vertical-align:middle; padding:8px">
+                            <div style="display:flex; gap:4px; align-items:flex-end; height:90px; border-bottom:1px solid var(--border-dim)">
+                              <template x-for="b in seriesForChart(g, chart.key)" :key="g + chart.key + b.label">
+                                <div style="flex:1; display:flex; flex-direction:column; align-items:center; gap:2px; min-width:0">
+                                  <div class="text-xs" style="color:var(--text-bright); white-space:nowrap; font-size:0.65rem" x-text="formatNum(b.value)"></div>
+                                  <div :style="'width:78%; background:' + chart.color + '; height:' + (b.pct*100) + '%; min-height:2px; transition:height 0.3s'"></div>
+                                </div>
+                              </template>
                             </div>
-                          </template>
-                        </div>
-                        <div style="display:flex; gap:4px; padding:4px 4px 0">
-                          <template x-for="b in seriesForChart(cell.gran, chart.key)" :key="cell.gran + chart.key + b.label + '-lbl'">
-                            <div class="text-xs text-dim" style="flex:1; text-align:center; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; font-size:0.6rem" x-text="b.label"></div>
-                          </template>
-                        </div>
-                      </div>
-                    </div>
-                  </template>
-                </template>
+                            <div style="display:flex; gap:4px; padding-top:4px">
+                              <template x-for="b in seriesForChart(g, chart.key)" :key="g + chart.key + b.label + '-lbl'">
+                                <div class="text-xs text-dim" style="flex:1; text-align:center; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; font-size:0.6rem" x-text="b.label"></div>
+                              </template>
+                            </div>
+                          </td>
+                        </template>
+                      </tr>
+                    </template>
+                    <tr>
+                      <td class="text-xs text-dim" style="vertical-align:top; letter-spacing:0.08em; padding-top:12px">TOOL CALLS</td>
+                      <template x-for="g in ['day','week','month']" :key="'tools-' + g">
+                        <td style="vertical-align:top; padding:8px">
+                          <div x-show="(usage.toolsByGran?.[g] ?? []).length === 0" class="text-muted text-xs">-</div>
+                          <ul style="margin:0; padding:0; list-style:none">
+                            <template x-for="t in (usage.toolsByGran?.[g] ?? []).slice(0, 6)" :key="g + t.tool_name">
+                              <li class="text-xs" style="padding:2px 0; display:flex; justify-content:space-between; gap:8px">
+                                <span class="text-mono" style="color:var(--cyan); overflow:hidden; text-overflow:ellipsis; white-space:nowrap" x-text="t.tool_name"></span>
+                                <span style="color:var(--amber); white-space:nowrap" x-text="formatNum(t.calls) + '회'"></span>
+                              </li>
+                            </template>
+                          </ul>
+                        </td>
+                      </template>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
 

--- a/src/admin_js.py
+++ b/src/admin_js.py
@@ -56,9 +56,13 @@ def get_admin_js() -> str:
     newPromptNameWarning: '',
     newPromptContent: '',
     loading: { dashboard: false, logs: false, sessions: false, usage: false },
-    usage: { enabled: null, summary: null, users: [], tools: [], turns: [], series: [] },
+    usage: {
+      enabled: null, summary: null, users: [], tools: [], turns: [],
+      series: { day: [], week: [], month: [] },
+    },
     usageWindow: 7,
-    usageGran: 'day',
+    usageStart: '',
+    usageEnd: '',
     usageTurnsFilter: '',
     usageTurnsOffset: 0,
 
@@ -256,14 +260,22 @@ def get_admin_js() -> str:
       if (this.logsAutoRefresh) { this.logsPollTimer = setInterval(() => this.loadLogs(), 5000); }
     },
 
+    _usageWindowQs() {
+      if (this.usageStart && this.usageEnd) {
+        return 'start_date=' + encodeURIComponent(this.usageStart) +
+               '&end_date=' + encodeURIComponent(this.usageEnd);
+      }
+      return 'window_days=' + this.usageWindow;
+    },
+
     async loadUsage() {
       this.loading.usage = true;
       try {
-        const w = 'window_days=' + this.usageWindow;
+        const q = this._usageWindowQs();
         const [sumR, userR, toolR] = await Promise.all([
-          this.api('/admin/api/usage/summary?' + w),
-          this.api('/admin/api/usage/users?' + w + '&limit=20'),
-          this.api('/admin/api/usage/tools?' + w + '&limit=30'),
+          this.api('/admin/api/usage/summary?' + q),
+          this.api('/admin/api/usage/users?' + q + '&limit=20'),
+          this.api('/admin/api/usage/tools?' + q + '&limit=30'),
         ]);
         if (sumR.ok) {
           const s = await sumR.json();
@@ -287,21 +299,33 @@ def get_admin_js() -> str:
     },
 
     async loadUsageSeries() {
+      // Always fetch all three granularities for the fixed 4x3 Trends grid.
       try {
-        const r = await this.api('/admin/api/usage/series?granularity=' + this.usageGran + '&buckets=5');
-        if (r.ok) {
-          const j = await r.json();
-          // backend returns DESC (newest first); reverse for left-to-right chronology
-          this.usage.series = (j.buckets || []).slice().reverse();
-          if (this.usage.enabled === null) this.usage.enabled = j.enabled;
+        const grans = ['day', 'week', 'month'];
+        const results = await Promise.all(grans.map(g =>
+          this.api('/admin/api/usage/series?granularity=' + g + '&buckets=5')
+        ));
+        for (let i = 0; i < grans.length; i++) {
+          const r = results[i];
+          if (r.ok) {
+            const j = await r.json();
+            // backend returns DESC; reverse for left-to-right chronology
+            this.usage.series[grans[i]] = (j.buckets || []).slice().reverse();
+            if (this.usage.enabled === null) this.usage.enabled = j.enabled;
+          }
         }
       } catch(e) {
         console.error('Failed to load usage series', e);
       }
     },
 
-    seriesForChart(field) {
-      const rows = this.usage.series || [];
+    usageSeriesEmpty() {
+      const s = this.usage.series || {};
+      return (s.day || []).length === 0 && (s.week || []).length === 0 && (s.month || []).length === 0;
+    },
+
+    seriesForChart(gran, field) {
+      const rows = (this.usage.series || {})[gran] || [];
       if (rows.length === 0) return [];
       const vals = rows.map(r => {
         if (field === 'tokens') return Number(r.input_tokens || 0) + Number(r.output_tokens || 0);

--- a/src/admin_js.py
+++ b/src/admin_js.py
@@ -55,7 +55,11 @@ def get_admin_js() -> str:
     newPromptNameError: '',
     newPromptNameWarning: '',
     newPromptContent: '',
-    loading: { dashboard: false, logs: false, sessions: false },
+    loading: { dashboard: false, logs: false, sessions: false, usage: false },
+    usage: { enabled: null, summary: null, users: [], tools: [], turns: [] },
+    usageWindow: 7,
+    usageTurnsFilter: '',
+    usageTurnsOffset: 0,
 
     async init() {
       document.addEventListener('keydown', (e) => {
@@ -249,6 +253,50 @@ def get_admin_js() -> str:
     toggleLogsPolling() {
       if (this.logsPollTimer) { clearInterval(this.logsPollTimer); this.logsPollTimer = null; }
       if (this.logsAutoRefresh) { this.logsPollTimer = setInterval(() => this.loadLogs(), 5000); }
+    },
+
+    async loadUsage() {
+      this.loading.usage = true;
+      try {
+        const w = 'window_days=' + this.usageWindow;
+        const [sumR, userR, toolR] = await Promise.all([
+          this.api('/admin/api/usage/summary?' + w),
+          this.api('/admin/api/usage/users?' + w + '&limit=20'),
+          this.api('/admin/api/usage/tools?' + w + '&limit=30'),
+        ]);
+        if (sumR.ok) {
+          const s = await sumR.json();
+          this.usage.enabled = s.enabled;
+          this.usage.summary = s.summary || null;
+        }
+        if (userR.ok) {
+          const u = await userR.json();
+          this.usage.users = u.items || [];
+        }
+        if (toolR.ok) {
+          const t = await toolR.json();
+          this.usage.tools = t.items || [];
+        }
+        await this.loadUsageTurns();
+      } catch(e) {
+        console.error('Failed to load usage', e);
+        this.showToast('Failed to load usage', 'err');
+      } finally { this.loading.usage = false; }
+    },
+
+    async loadUsageTurns() {
+      try {
+        let url = '/admin/api/usage/turns?limit=50&offset=' + this.usageTurnsOffset;
+        if (this.usageTurnsFilter) url += '&user=' + encodeURIComponent(this.usageTurnsFilter);
+        const r = await this.api(url);
+        if (r.ok) {
+          const j = await r.json();
+          this.usage.turns = j.items || [];
+          if (this.usage.enabled === null) this.usage.enabled = j.enabled;
+        }
+      } catch(e) {
+        console.error('Failed to load usage turns', e);
+      }
     },
 
     async loadRateLimits() {
@@ -694,6 +742,15 @@ Skill description here.
       if (!t) return '-';
       try { return new Date(t).toLocaleString('ko-KR', { hour12: false }); }
       catch(e) { return t; }
+    },
+
+    formatNum(n) {
+      if (n === null || n === undefined) return '-';
+      const v = Number(n);
+      if (!isFinite(v)) return String(n);
+      if (v >= 1e6) return (v / 1e6).toFixed(1) + 'M';
+      if (v >= 1e3) return (v / 1e3).toFixed(1) + 'k';
+      return String(v);
     }
   };
 }"""

--- a/src/admin_js.py
+++ b/src/admin_js.py
@@ -59,6 +59,7 @@ def get_admin_js() -> str:
     usage: {
       enabled: null, summary: null, users: [], tools: [], turns: [],
       series: { day: [], week: [], month: [] },
+      toolsByGran: { day: [], week: [], month: [] },
     },
     usageWindow: 7,
     usageStart: '',
@@ -302,16 +303,26 @@ def get_admin_js() -> str:
       // Always fetch all three granularities for the fixed 4x3 Trends grid.
       try {
         const grans = ['day', 'week', 'month'];
-        const results = await Promise.all(grans.map(g =>
-          this.api('/admin/api/usage/series?granularity=' + g + '&buckets=5')
-        ));
+        // Approximate "last 5 of granularity" as a rolling-day window for
+        // the per-cell top-tools list.
+        const toolWindow = { day: 5, week: 35, month: 150 };
+        const seriesPromises = grans.map(g =>
+          this.api('/admin/api/usage/series?granularity=' + g + '&buckets=5'));
+        const toolPromises = grans.map(g =>
+          this.api('/admin/api/usage/tools?window_days=' + toolWindow[g] + '&limit=10'));
+        const [seriesRes, toolRes] = await Promise.all([
+          Promise.all(seriesPromises),
+          Promise.all(toolPromises),
+        ]);
         for (let i = 0; i < grans.length; i++) {
-          const r = results[i];
-          if (r.ok) {
-            const j = await r.json();
-            // backend returns DESC; reverse for left-to-right chronology
+          if (seriesRes[i].ok) {
+            const j = await seriesRes[i].json();
             this.usage.series[grans[i]] = (j.buckets || []).slice().reverse();
             if (this.usage.enabled === null) this.usage.enabled = j.enabled;
+          }
+          if (toolRes[i].ok) {
+            const j = await toolRes[i].json();
+            this.usage.toolsByGran[grans[i]] = j.items || [];
           }
         }
       } catch(e) {

--- a/src/admin_js.py
+++ b/src/admin_js.py
@@ -60,6 +60,11 @@ def get_admin_js() -> str:
       enabled: null, summary: null, users: [], tools: [], turns: [],
       series: { day: [], week: [], month: [] },
       toolsByGran: { day: [], week: [], month: [] },
+      toolsSeries: {
+        day: { tools: [], buckets: [] },
+        week: { tools: [], buckets: [] },
+        month: { tools: [], buckets: [] },
+      },
     },
     usageWindow: 7,
     usageStart: '',
@@ -310,9 +315,12 @@ def get_admin_js() -> str:
           this.api('/admin/api/usage/series?granularity=' + g + '&buckets=5'));
         const toolPromises = grans.map(g =>
           this.api('/admin/api/usage/tools?window_days=' + toolWindow[g] + '&limit=10'));
-        const [seriesRes, toolRes] = await Promise.all([
+        const toolSeriesPromises = grans.map(g =>
+          this.api('/admin/api/usage/tools-series?granularity=' + g + '&buckets=5&top=5'));
+        const [seriesRes, toolRes, toolSeriesRes] = await Promise.all([
           Promise.all(seriesPromises),
           Promise.all(toolPromises),
+          Promise.all(toolSeriesPromises),
         ]);
         for (let i = 0; i < grans.length; i++) {
           if (seriesRes[i].ok) {
@@ -324,6 +332,14 @@ def get_admin_js() -> str:
             const j = await toolRes[i].json();
             this.usage.toolsByGran[grans[i]] = j.items || [];
           }
+          if (toolSeriesRes[i].ok) {
+            const j = await toolSeriesRes[i].json();
+            // backend buckets are DESC; reverse so chart reads left = older
+            this.usage.toolsSeries[grans[i]] = {
+              tools: j.tools || [],
+              buckets: (j.buckets || []).slice().reverse(),
+            };
+          }
         }
       } catch(e) {
         console.error('Failed to load usage series', e);
@@ -333,6 +349,27 @@ def get_admin_js() -> str:
     usageSeriesEmpty() {
       const s = this.usage.series || {};
       return (s.day || []).length === 0 && (s.week || []).length === 0 && (s.month || []).length === 0;
+    },
+
+    toolColor(idx) {
+      const palette = [
+        'var(--green)', 'var(--cyan)', 'var(--amber)',
+        'var(--red)', '#a855f7', '#3b82f6'
+      ];
+      return palette[((idx % palette.length) + palette.length) % palette.length];
+    },
+
+    toolSeriesMax(gran) {
+      const ts = (this.usage.toolsSeries || {})[gran];
+      if (!ts) return 1;
+      let max = 1;
+      for (const b of (ts.buckets || [])) {
+        for (const t of (ts.tools || [])) {
+          const v = Number((b.values || {})[t] || 0);
+          if (v > max) max = v;
+        }
+      }
+      return max;
     },
 
     seriesForChart(gran, field) {

--- a/src/admin_js.py
+++ b/src/admin_js.py
@@ -56,8 +56,9 @@ def get_admin_js() -> str:
     newPromptNameWarning: '',
     newPromptContent: '',
     loading: { dashboard: false, logs: false, sessions: false, usage: false },
-    usage: { enabled: null, summary: null, users: [], tools: [], turns: [] },
+    usage: { enabled: null, summary: null, users: [], tools: [], turns: [], series: [] },
     usageWindow: 7,
+    usageGran: 'day',
     usageTurnsFilter: '',
     usageTurnsOffset: 0,
 
@@ -278,10 +279,40 @@ def get_admin_js() -> str:
           this.usage.tools = t.items || [];
         }
         await this.loadUsageTurns();
+        await this.loadUsageSeries();
       } catch(e) {
         console.error('Failed to load usage', e);
         this.showToast('Failed to load usage', 'err');
       } finally { this.loading.usage = false; }
+    },
+
+    async loadUsageSeries() {
+      try {
+        const r = await this.api('/admin/api/usage/series?granularity=' + this.usageGran + '&buckets=5');
+        if (r.ok) {
+          const j = await r.json();
+          // backend returns DESC (newest first); reverse for left-to-right chronology
+          this.usage.series = (j.buckets || []).slice().reverse();
+          if (this.usage.enabled === null) this.usage.enabled = j.enabled;
+        }
+      } catch(e) {
+        console.error('Failed to load usage series', e);
+      }
+    },
+
+    seriesForChart(field) {
+      const rows = this.usage.series || [];
+      if (rows.length === 0) return [];
+      const vals = rows.map(r => {
+        if (field === 'tokens') return Number(r.input_tokens || 0) + Number(r.output_tokens || 0);
+        return Number(r[field] || 0);
+      });
+      const max = Math.max(1, ...vals);
+      return rows.map((r, i) => ({
+        label: String(r.bucket || ''),
+        value: vals[i],
+        pct: vals[i] / max,
+      }));
     },
 
     async loadUsageTurns() {

--- a/src/admin_page.py
+++ b/src/admin_page.py
@@ -13,6 +13,7 @@ from src.admin_html_logs import get_logs_html
 from src.admin_html_ratelimits import get_ratelimits_html
 from src.admin_html_sessions import get_sessions_html
 from src.admin_html_skills import get_skills_html
+from src.admin_html_usage import get_usage_html
 from src.admin_js import get_admin_js
 from src.admin_styles import get_admin_css
 
@@ -116,6 +117,7 @@ def build_admin_page() -> str:
         <button role="tab" :aria-selected="tab === 'dashboard'" @click="tab='dashboard'">DASH</button>
         <button role="tab" :aria-selected="tab === 'sessions'" @click="tab='sessions'; loadSummary()">SESSIONS</button>
         <button role="tab" :aria-selected="tab === 'logs'" @click="tab='logs'; loadLogs()">LOGS</button>
+        <button role="tab" :aria-selected="tab === 'usage'" @click="tab='usage'; loadUsage()">USAGE</button>
         <button role="tab" :aria-selected="tab === 'ratelimits'" @click="tab='ratelimits'; loadRateLimits()">LIMITS</button>
         <button role="tab" :aria-selected="tab === 'files'" @click="tab='files'; loadFiles()">FILES</button>
         <button role="tab" :aria-selected="tab === 'skills'" @click="tab='skills'; loadSkills()">SKILLS</button>
@@ -127,6 +129,8 @@ def build_admin_page() -> str:
         + get_dashboard_html()
         + "\n\n"
         + get_logs_html()
+        + "\n\n"
+        + get_usage_html()
         + "\n\n"
         + get_ratelimits_html()
         + "\n\n"

--- a/src/routes/admin.py
+++ b/src/routes/admin.py
@@ -815,3 +815,78 @@ async def list_marketplaces_endpoint(_=Depends(require_admin)):
     from src.plugin_service import list_marketplaces
 
     return {"marketplaces": list_marketplaces()}
+
+
+# ---------------------------------------------------------------------------
+# Usage-log dashboard (MySQL-backed analytics)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/usage/summary")
+async def usage_summary_endpoint(
+    window_days: int = 7,
+    _=Depends(require_admin),
+):
+    """Overview counters for the usage tab."""
+    from src.usage_queries import get_summary
+
+    data = await get_summary(window_days=max(1, min(window_days, 90)))
+    if data is None:
+        return {"enabled": False}
+    return {"enabled": True, "window_days": window_days, "summary": data}
+
+
+@router.get("/api/usage/users")
+async def usage_users_endpoint(
+    window_days: int = 7,
+    limit: int = 20,
+    _=Depends(require_admin),
+):
+    """Top users by token usage in the rolling window."""
+    from src.usage_queries import get_top_users
+
+    rows = await get_top_users(
+        window_days=max(1, min(window_days, 90)),
+        limit=max(1, min(limit, 500)),
+    )
+    if rows is None:
+        return {"enabled": False, "items": []}
+    return {"enabled": True, "items": rows}
+
+
+@router.get("/api/usage/tools")
+async def usage_tools_endpoint(
+    window_days: int = 7,
+    limit: int = 30,
+    _=Depends(require_admin),
+):
+    """Top tools by call count in the rolling window."""
+    from src.usage_queries import get_top_tools
+
+    rows = await get_top_tools(
+        window_days=max(1, min(window_days, 90)),
+        limit=max(1, min(limit, 500)),
+    )
+    if rows is None:
+        return {"enabled": False, "items": []}
+    return {"enabled": True, "items": rows}
+
+
+@router.get("/api/usage/turns")
+async def usage_turns_endpoint(
+    user: Optional[str] = None,
+    limit: int = 50,
+    offset: int = 0,
+    _=Depends(require_admin),
+):
+    """Recent turns (newest first), optionally filtered by user."""
+    from src.usage_queries import get_recent_turns
+
+    rows = await get_recent_turns(
+        user=user,
+        limit=max(1, min(limit, 500)),
+        offset=max(0, offset),
+    )
+    if rows is None:
+        return {"enabled": False, "items": []}
+    return {"enabled": True, "items": rows}

--- a/src/routes/admin.py
+++ b/src/routes/admin.py
@@ -825,12 +825,18 @@ async def list_marketplaces_endpoint(_=Depends(require_admin)):
 @router.get("/api/usage/summary")
 async def usage_summary_endpoint(
     window_days: int = 7,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
     _=Depends(require_admin),
 ):
     """Overview counters for the usage tab."""
     from src.usage_queries import get_summary
 
-    data = await get_summary(window_days=max(1, min(window_days, 90)))
+    data = await get_summary(
+        window_days=max(1, min(window_days, 365)),
+        start_date=start_date,
+        end_date=end_date,
+    )
     if data is None:
         return {"enabled": False}
     return {"enabled": True, "window_days": window_days, "summary": data}
@@ -840,14 +846,18 @@ async def usage_summary_endpoint(
 async def usage_users_endpoint(
     window_days: int = 7,
     limit: int = 20,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
     _=Depends(require_admin),
 ):
-    """Top users by token usage in the rolling window."""
+    """Top users by token usage in the selected range."""
     from src.usage_queries import get_top_users
 
     rows = await get_top_users(
-        window_days=max(1, min(window_days, 90)),
+        window_days=max(1, min(window_days, 365)),
         limit=max(1, min(limit, 500)),
+        start_date=start_date,
+        end_date=end_date,
     )
     if rows is None:
         return {"enabled": False, "items": []}
@@ -858,14 +868,18 @@ async def usage_users_endpoint(
 async def usage_tools_endpoint(
     window_days: int = 7,
     limit: int = 30,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
     _=Depends(require_admin),
 ):
-    """Top tools by call count in the rolling window."""
+    """Top tools by call count in the selected range."""
     from src.usage_queries import get_top_tools
 
     rows = await get_top_tools(
-        window_days=max(1, min(window_days, 90)),
+        window_days=max(1, min(window_days, 365)),
         limit=max(1, min(limit, 500)),
+        start_date=start_date,
+        end_date=end_date,
     )
     if rows is None:
         return {"enabled": False, "items": []}

--- a/src/routes/admin.py
+++ b/src/routes/admin.py
@@ -872,6 +872,22 @@ async def usage_tools_endpoint(
     return {"enabled": True, "items": rows}
 
 
+@router.get("/api/usage/series")
+async def usage_series_endpoint(
+    granularity: str = "day",
+    buckets: int = 5,
+    _=Depends(require_admin),
+):
+    """Recent bucket aggregates for USAGE time-series charts."""
+    from src.usage_queries import get_time_series
+
+    gran = granularity if granularity in ("day", "week", "month") else "day"
+    rows = await get_time_series(granularity=gran, buckets=max(1, min(buckets, 60)))
+    if rows is None:
+        return {"enabled": False, "granularity": gran, "buckets": []}
+    return {"enabled": True, "granularity": gran, "buckets": rows}
+
+
 @router.get("/api/usage/turns")
 async def usage_turns_endpoint(
     user: Optional[str] = None,

--- a/src/routes/admin.py
+++ b/src/routes/admin.py
@@ -902,6 +902,27 @@ async def usage_series_endpoint(
     return {"enabled": True, "granularity": gran, "buckets": rows}
 
 
+@router.get("/api/usage/tools-series")
+async def usage_tools_series_endpoint(
+    granularity: str = "day",
+    buckets: int = 5,
+    top: int = 5,
+    _=Depends(require_admin),
+):
+    """Per-bucket tool-call breakdown for the grouped TOOL CALLS chart."""
+    from src.usage_queries import get_tool_breakdown_series
+
+    gran = granularity if granularity in ("day", "week", "month") else "day"
+    data = await get_tool_breakdown_series(
+        granularity=gran,
+        buckets=max(1, min(buckets, 60)),
+        top_n=max(1, min(top, 20)),
+    )
+    if data is None:
+        return {"enabled": False, "granularity": gran, "tools": [], "buckets": []}
+    return {"enabled": True, "granularity": gran, **data}
+
+
 @router.get("/api/usage/turns")
 async def usage_turns_endpoint(
     user: Optional[str] = None,

--- a/src/usage_logger.py
+++ b/src/usage_logger.py
@@ -161,6 +161,29 @@ class UsageLogger:
     def enabled(self) -> bool:
         return self._pool is not None
 
+    async def fetch_rows(self, sql: str, params: tuple = ()) -> Optional[list]:
+        """Execute a read-only SELECT and return ``list[dict]`` (DictCursor).
+
+        Returns ``None`` when the pool is not configured or the query fails -
+        callers should treat that as "usage logging is not available".
+        Intended only for admin-side analytics queries; callers must supply
+        the full parameterised SQL (no automatic quoting).
+        """
+        if self._pool is None:
+            return None
+        try:
+            import aiomysql  # local import - optional dep
+        except ImportError:
+            return None
+        try:
+            async with self._pool.acquire() as conn:
+                async with conn.cursor(aiomysql.DictCursor) as cur:
+                    await cur.execute(sql, params)
+                    return list(await cur.fetchall())
+        except Exception:
+            logger.warning("usage-log read failed: %s", sql[:120], exc_info=True)
+            return None
+
     # ------------------------------------------------------------------
     # Write path
     # ------------------------------------------------------------------

--- a/src/usage_queries.py
+++ b/src/usage_queries.py
@@ -8,17 +8,60 @@ render a "usage logging off" hint without treating it as an error.
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+import datetime as _dt
+from typing import Any, Dict, List, Optional, Tuple
 
 from src.usage_logger import usage_logger
 
 
-async def get_summary(window_days: int = 7) -> Optional[Dict[str, Any]]:
-    """Overview counters for the given rolling window and today (00:00 KST-ish)."""
+def _parse_date(value: Optional[str]) -> Optional[_dt.date]:
+    """Return ``date`` from an ``YYYY-MM-DD`` string, or ``None``."""
+    if not value:
+        return None
+    try:
+        return _dt.date.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _window_clause(
+    start_date: Optional[str],
+    end_date: Optional[str],
+    window_days: int,
+    *,
+    column: str = "ts",
+) -> Tuple[str, tuple]:
+    """Build the WHERE clause fragment for the requested range.
+
+    When both ``start_date`` and ``end_date`` are valid ``YYYY-MM-DD``
+    strings, filters the inclusive calendar range.  Otherwise falls back
+    to the rolling ``window_days`` window ending now.
+    """
+    s, e = _parse_date(start_date), _parse_date(end_date)
+    if s and e:
+        if e < s:
+            s, e = e, s
+        return (
+            f"{column} >= %s AND {column} < DATE_ADD(%s, INTERVAL 1 DAY)",
+            (s.isoformat(), e.isoformat()),
+        )
+    return (
+        f"{column} >= NOW() - INTERVAL %s DAY",
+        (max(1, int(window_days)),),
+    )
+
+
+async def get_summary(
+    window_days: int = 7,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Overview counters for the given range plus today's totals."""
     if not usage_logger.enabled:
         return None
+    where, params = _window_clause(start_date, end_date, window_days)
     rows = await usage_logger.fetch_rows(
-        """
+        f"""
         SELECT
           COUNT(*) AS turns_window,
           COUNT(DISTINCT user) AS users_window,
@@ -29,9 +72,9 @@ async def get_summary(window_days: int = 7) -> Optional[Dict[str, Any]]:
           COALESCE(SUM(cache_creation_tokens), 0) AS cache_creation_tokens_window,
           SUM(status <> 'completed') AS errors_window
         FROM usage_turn
-        WHERE ts >= NOW() - INTERVAL %s DAY
+        WHERE {where}
         """,
-        (int(window_days),),
+        params,
     )
     today_rows = await usage_logger.fetch_rows(
         """
@@ -49,11 +92,17 @@ async def get_summary(window_days: int = 7) -> Optional[Dict[str, Any]]:
     return out
 
 
-async def get_top_users(window_days: int = 7, limit: int = 20) -> Optional[List[Dict[str, Any]]]:
+async def get_top_users(
+    window_days: int = 7,
+    limit: int = 20,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+) -> Optional[List[Dict[str, Any]]]:
     if not usage_logger.enabled:
         return None
+    where, params = _window_clause(start_date, end_date, window_days, column="u.ts")
     rows = await usage_logger.fetch_rows(
-        """
+        f"""
         SELECT
           u.user,
           COUNT(DISTINCT u.session_id) AS chats,
@@ -65,21 +114,27 @@ async def get_top_users(window_days: int = 7, limit: int = 20) -> Optional[List[
           SUM(u.status <> 'completed') AS turn_errors
         FROM usage_turn u
         LEFT JOIN usage_tool t ON t.turn_id = u.id
-        WHERE u.ts >= NOW() - INTERVAL %s DAY
+        WHERE {where}
         GROUP BY u.user
         ORDER BY tokens DESC
         LIMIT %s
         """,
-        (int(window_days), int(limit)),
+        params + (int(limit),),
     )
     return rows
 
 
-async def get_top_tools(window_days: int = 7, limit: int = 30) -> Optional[List[Dict[str, Any]]]:
+async def get_top_tools(
+    window_days: int = 7,
+    limit: int = 30,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+) -> Optional[List[Dict[str, Any]]]:
     if not usage_logger.enabled:
         return None
+    where, params = _window_clause(start_date, end_date, window_days, column="u.ts")
     rows = await usage_logger.fetch_rows(
-        """
+        f"""
         SELECT
           t.tool_name,
           SUM(t.call_count) AS calls,
@@ -88,12 +143,12 @@ async def get_top_tools(window_days: int = 7, limit: int = 30) -> Optional[List[
           COUNT(DISTINCT u.user) AS users
         FROM usage_tool t
         JOIN usage_turn u ON u.id = t.turn_id
-        WHERE u.ts >= NOW() - INTERVAL %s DAY
+        WHERE {where}
         GROUP BY t.tool_name
         ORDER BY calls DESC
         LIMIT %s
         """,
-        (int(window_days), int(limit)),
+        params + (int(limit),),
     )
     return rows
 

--- a/src/usage_queries.py
+++ b/src/usage_queries.py
@@ -102,9 +102,13 @@ _GRANULARITY_SQL: Dict[str, str] = {
     # MySQL expressions that bucket ``ts`` for the requested granularity.
     # ``%v`` (ISO week) paired with ``%x`` (ISO week year) so boundaries
     # line up with the Monday-first ISO week definition.
+    #
+    # ``%`` is doubled because aiomysql.Cursor.execute uses printf-style
+    # parameter interpolation on the SQL string; any bare ``%`` would be
+    # eaten as a format directive and raise a binding error.
     "day": "DATE(ts)",
-    "week": "DATE_FORMAT(ts, '%x-W%v')",
-    "month": "DATE_FORMAT(ts, '%Y-%m')",
+    "week": "DATE_FORMAT(ts, '%%x-W%%v')",
+    "month": "DATE_FORMAT(ts, '%%Y-%%m')",
 }
 
 

--- a/src/usage_queries.py
+++ b/src/usage_queries.py
@@ -223,6 +223,74 @@ async def get_time_series(
     return rows
 
 
+async def get_tool_breakdown_series(
+    granularity: str = "day",
+    buckets: int = 5,
+    top_n: int = 5,
+) -> Optional[Dict[str, Any]]:
+    """Per-bucket tool-call breakdown for the grouped TOOL CALLS bar chart.
+
+    Returns ``{tools: [...], buckets: [{bucket, values: {tool: calls}}]}``
+    with ``tools`` ordered by total calls (descending) so the frontend
+    can map each tool to a stable colour.
+
+    Approximates the time window per granularity as 5d / 35d / 150d for
+    day / week / month so the same backend can serve all three columns.
+    """
+    bucket_expr = _GRANULARITY_SQL.get(granularity)
+    if bucket_expr is None or not usage_logger.enabled:
+        return None
+    bucket_expr_uts = bucket_expr.replace("ts", "u.ts")
+    days_window = {"day": 5, "week": 35, "month": 150}.get(granularity, 30)
+
+    rows = await usage_logger.fetch_rows(
+        f"""
+        SELECT
+          {bucket_expr_uts} AS bucket,
+          t.tool_name AS tool_name,
+          SUM(t.call_count) AS calls
+        FROM usage_tool t
+        JOIN usage_turn u ON u.id = t.turn_id
+        WHERE u.ts >= NOW() - INTERVAL %s DAY
+        GROUP BY {bucket_expr_uts}, t.tool_name
+        ORDER BY {bucket_expr_uts} DESC, calls DESC
+        """,
+        (days_window,),
+    )
+    if not rows:
+        return {"tools": [], "buckets": []}
+
+    # Distinct buckets in DESC order, take the most recent N
+    seen: List[str] = []
+    for r in rows:
+        b = str(r["bucket"])
+        if b not in seen:
+            seen.append(b)
+        if len(seen) >= int(buckets):
+            break
+    keep_buckets = seen[: int(buckets)]
+    keep_set = set(keep_buckets)
+
+    # Sum tool totals over the kept buckets to pick the top N
+    tool_totals: Dict[str, int] = {}
+    for r in rows:
+        if str(r["bucket"]) in keep_set:
+            tool_totals[r["tool_name"]] = tool_totals.get(r["tool_name"], 0) + int(r["calls"])
+    top_tools = [t for t, _ in sorted(tool_totals.items(), key=lambda x: -x[1])[: int(top_n)]]
+    top_set = set(top_tools)
+
+    # Pivot: bucket -> {tool: calls}
+    by_bucket: Dict[str, Dict[str, int]] = {b: {} for b in keep_buckets}
+    for r in rows:
+        b = str(r["bucket"])
+        if b in keep_set and r["tool_name"] in top_set:
+            by_bucket[b][r["tool_name"]] = int(r["calls"])
+    return {
+        "tools": top_tools,
+        "buckets": [{"bucket": b, "values": by_bucket[b]} for b in keep_buckets],
+    }
+
+
 async def get_recent_turns(
     user: Optional[str] = None,
     limit: int = 50,

--- a/src/usage_queries.py
+++ b/src/usage_queries.py
@@ -98,6 +98,72 @@ async def get_top_tools(window_days: int = 7, limit: int = 30) -> Optional[List[
     return rows
 
 
+_GRANULARITY_SQL: Dict[str, str] = {
+    # MySQL expressions that bucket ``ts`` for the requested granularity.
+    # ``%v`` (ISO week) paired with ``%x`` (ISO week year) so boundaries
+    # line up with the Monday-first ISO week definition.
+    "day": "DATE(ts)",
+    "week": "DATE_FORMAT(ts, '%x-W%v')",
+    "month": "DATE_FORMAT(ts, '%Y-%m')",
+}
+
+
+async def get_time_series(
+    granularity: str = "day",
+    buckets: int = 5,
+) -> Optional[List[Dict[str, Any]]]:
+    """Recent bucket totals for the USAGE time-series charts.
+
+    Returns up to ``buckets`` rows ordered newest-first with fields:
+      - ``bucket`` (string label)
+      - ``turns``, ``users``, ``tool_calls``, ``input_tokens``,
+        ``output_tokens``
+
+    Returns ``None`` when usage logging is disabled or the granularity is
+    unknown (caller surfaces that as "logging off").
+    """
+    bucket_expr = _GRANULARITY_SQL.get(granularity)
+    if bucket_expr is None or not usage_logger.enabled:
+        return None
+    n = max(1, min(int(buckets), 60))
+
+    # Turn aggregates - SUM(input_tokens) etc. must be computed BEFORE the
+    # join with usage_tool so tool rows don't duplicate turn tokens.
+    rows = await usage_logger.fetch_rows(
+        f"""
+        SELECT
+          turn_agg.bucket AS bucket,
+          turn_agg.turns AS turns,
+          turn_agg.users AS users,
+          turn_agg.input_tokens AS input_tokens,
+          turn_agg.output_tokens AS output_tokens,
+          COALESCE(tool_agg.tool_calls, 0) AS tool_calls
+        FROM (
+          SELECT
+            {bucket_expr} AS bucket,
+            COUNT(*) AS turns,
+            COUNT(DISTINCT user) AS users,
+            COALESCE(SUM(input_tokens), 0) AS input_tokens,
+            COALESCE(SUM(output_tokens), 0) AS output_tokens
+          FROM usage_turn
+          GROUP BY {bucket_expr}
+        ) turn_agg
+        LEFT JOIN (
+          SELECT
+            {bucket_expr.replace('ts', 'u.ts')} AS bucket,
+            SUM(t.call_count) AS tool_calls
+          FROM usage_tool t
+          JOIN usage_turn u ON u.id = t.turn_id
+          GROUP BY {bucket_expr.replace('ts', 'u.ts')}
+        ) tool_agg ON tool_agg.bucket = turn_agg.bucket
+        ORDER BY turn_agg.bucket DESC
+        LIMIT %s
+        """,
+        (n,),
+    )
+    return rows
+
+
 async def get_recent_turns(
     user: Optional[str] = None,
     limit: int = 50,

--- a/src/usage_queries.py
+++ b/src/usage_queries.py
@@ -1,0 +1,129 @@
+"""Read-side analytics queries for the admin usage dashboard.
+
+All functions return plain Python values (lists of dicts / dicts) or ``None``
+when the usage-log pool is disabled / unavailable.  The calling endpoints in
+``src.routes.admin`` translate ``None`` into an empty response so the UI can
+render a "usage logging off" hint without treating it as an error.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from src.usage_logger import usage_logger
+
+
+async def get_summary(window_days: int = 7) -> Optional[Dict[str, Any]]:
+    """Overview counters for the given rolling window and today (00:00 KST-ish)."""
+    if not usage_logger.enabled:
+        return None
+    rows = await usage_logger.fetch_rows(
+        """
+        SELECT
+          COUNT(*) AS turns_window,
+          COUNT(DISTINCT user) AS users_window,
+          COUNT(DISTINCT session_id) AS chats_window,
+          COALESCE(SUM(input_tokens), 0) AS input_tokens_window,
+          COALESCE(SUM(output_tokens), 0) AS output_tokens_window,
+          COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens_window,
+          COALESCE(SUM(cache_creation_tokens), 0) AS cache_creation_tokens_window,
+          SUM(status <> 'completed') AS errors_window
+        FROM usage_turn
+        WHERE ts >= NOW() - INTERVAL %s DAY
+        """,
+        (int(window_days),),
+    )
+    today_rows = await usage_logger.fetch_rows(
+        """
+        SELECT
+          COUNT(*) AS turns_today,
+          COALESCE(SUM(input_tokens + output_tokens), 0) AS tokens_today
+        FROM usage_turn
+        WHERE ts >= CURDATE()
+        """,
+    )
+    if rows is None or today_rows is None:
+        return None
+    out = dict(rows[0]) if rows else {}
+    out.update(today_rows[0] if today_rows else {})
+    return out
+
+
+async def get_top_users(window_days: int = 7, limit: int = 20) -> Optional[List[Dict[str, Any]]]:
+    if not usage_logger.enabled:
+        return None
+    rows = await usage_logger.fetch_rows(
+        """
+        SELECT
+          u.user,
+          COUNT(DISTINCT u.session_id) AS chats,
+          COUNT(*) AS turns,
+          COALESCE(SUM(u.input_tokens + u.output_tokens), 0) AS tokens,
+          COALESCE(SUM(u.cache_read_tokens), 0) AS cache_read_tokens,
+          COALESCE(SUM(t.call_count), 0) AS tool_calls,
+          COALESCE(SUM(t.error_count), 0) AS tool_errors,
+          SUM(u.status <> 'completed') AS turn_errors
+        FROM usage_turn u
+        LEFT JOIN usage_tool t ON t.turn_id = u.id
+        WHERE u.ts >= NOW() - INTERVAL %s DAY
+        GROUP BY u.user
+        ORDER BY tokens DESC
+        LIMIT %s
+        """,
+        (int(window_days), int(limit)),
+    )
+    return rows
+
+
+async def get_top_tools(window_days: int = 7, limit: int = 30) -> Optional[List[Dict[str, Any]]]:
+    if not usage_logger.enabled:
+        return None
+    rows = await usage_logger.fetch_rows(
+        """
+        SELECT
+          t.tool_name,
+          SUM(t.call_count) AS calls,
+          SUM(t.error_count) AS errors,
+          SUM(t.total_duration_ms) AS total_ms,
+          COUNT(DISTINCT u.user) AS users
+        FROM usage_tool t
+        JOIN usage_turn u ON u.id = t.turn_id
+        WHERE u.ts >= NOW() - INTERVAL %s DAY
+        GROUP BY t.tool_name
+        ORDER BY calls DESC
+        LIMIT %s
+        """,
+        (int(window_days), int(limit)),
+    )
+    return rows
+
+
+async def get_recent_turns(
+    user: Optional[str] = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> Optional[List[Dict[str, Any]]]:
+    if not usage_logger.enabled:
+        return None
+    params: list = []
+    where = ""
+    if user:
+        where = "WHERE user = %s"
+        params.append(user)
+    params.extend([int(limit), int(offset)])
+    rows = await usage_logger.fetch_rows(
+        f"""
+        SELECT
+          id, ts, user, session_id, response_id, previous_response_id,
+          turn, model, backend,
+          input_tokens, output_tokens,
+          cache_read_tokens, cache_creation_tokens,
+          duration_ms, status, error_code
+        FROM usage_turn
+        {where}
+        ORDER BY id DESC
+        LIMIT %s OFFSET %s
+        """,
+        tuple(params),
+    )
+    return rows


### PR DESCRIPTION
## Summary

Adds opt-in per-turn usage logging to the gateway plus a USAGE tab on `/admin` with summary tables and time-series charts. Logging is **off by default** so existing deployments are unaffected.

## What gets logged

### `usage_turn` — one row per `/v1/responses` turn
| column | description |
|---|---|
| `ts`, `user`, `session_id`, `response_id`, `previous_response_id`, `turn`, `model`, `backend` | request metadata |
| `input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_creation_tokens` | from `ResultMessage.usage` |
| `duration_ms`, `status`, `error_code` | outcome |

### `usage_tool` — one row per distinct tool name per turn
| column | description |
|---|---|
| `turn_id` (FK `usage_turn.id` ON DELETE CASCADE) | |
| `tool_name`, `call_count`, `error_count`, `total_duration_ms` | aggregated per turn |

**Intentionally not logged**: prompts / completions / tool args / tool results (PII & auth-token risk).

## How to enable

1. Uncomment `USAGE_LOG_DB_URL=mysql://gateway:gateway@...:3306/gateway_log` in `.env`
2. Bring up the bundled sidecar: `docker compose --profile logging up -d`

The sidecar (`gateway-log`, mysql:8.0) self-initialises the schema from `docker/mysql_init/01_schema.sql` on first start. `claude-wrapper` `depends_on` the sidecar's healthcheck so startup is race-free.

When `USAGE_LOG_DB_URL` is unset or the pool fails to open, the logger stays in no-op mode; DB errors are logged at WARNING and swallowed — usage logging never blocks chat traffic.

## Admin USAGE tab (`/admin`)

**Header controls**
- `WINDOW` preset (1d / 7d / 30d / 90d) **or** `FROM` / `TO` calendar inputs that override the rolling window for the summary cards / users table / tools table

**Summary cards** — turns today, tokens today, turns/tokens/users in window, error turns

**Trends** — fixed 4×3 table (rows: QUERIES / USERS / TOKENS / TOOL CALLS / TOP TOOLS, columns: DAY / WEEK / MONTH, last 5 buckets each)
- QUERIES / USERS / TOKENS rows: per-bucket bar chart
- TOOL CALLS row: **grouped bar chart** — within each bucket, one thin colour-coded bar per top-N tool, with inline legend; hover shows `<tool>: NN회`
- TOP TOOLS row: per-granularity ranked list (`tool_name : NN회`)

**Top users table** — chats, turns, tokens, cache reads, tool calls, errors (`tool_errors / turn_errors`); click a row → filters Recent turns below

**Top tools table** — calls / errors / distinct users / avg ms

**Recent turns table** — paginated, user filter, status badges

### Backing endpoints (all require admin auth)
- `GET /admin/api/usage/summary` — overview counters
- `GET /admin/api/usage/users` — top users
- `GET /admin/api/usage/tools` — top tools
- `GET /admin/api/usage/turns` — recent turns (filter / paginate)
- `GET /admin/api/usage/series` — bucketed totals (turns / users / tokens / tool_calls)
- `GET /admin/api/usage/tools-series` — per-bucket per-tool counts (grouped chart)

All accept `start_date` / `end_date` where applicable and return `{"enabled": false, ...}` when the log pool isn't configured, so the UI can show a "USAGE LOGGING OFF" card.

## File-level overview
| file | change |
|---|---|
| `pyproject.toml`, `.env.example` | + `aiomysql`, opt-in env vars |
| `docker-compose.yml` | `gateway-log` service behind `logging` profile, `depends_on` healthcheck |
| `docker/mysql_init/01_schema.sql` | schema (`usage_turn`, `usage_tool`) |
| `src/tool_stats.py` | per-turn `ToolStatsCollector` |
| `src/usage_logger.py` | async `UsageLogger` (aiomysql pool, fetch_rows, extract_sdk_usage_detail) |
| `src/usage_queries.py` | analytics SELECTs (summary / users / tools / turns / series / tool-breakdown series); supports `start_date` / `end_date` |
| `src/main.py` | pool start/close in FastAPI lifespan |
| `src/streaming_utils.py` | hook `ToolStatsCollector` into all tool-event sources (with `_block_field` for SDK dataclass / dict compatibility), emit usage at every stream exit |
| `src/routes/responses.py` | log completed non-stream turns (main + function_call_output continuation) |
| `src/routes/admin.py` | `/admin/api/usage/*` endpoints |
| `src/admin_html_usage.py`, `src/admin_page.py`, `src/admin_js.py` | USAGE tab markup, tab wiring, JS loaders, grouped bar chart helpers |

## Test plan

- [ ] `docker compose --profile logging up -d` — gateway logs `Usage logging enabled (mysql://...)`
- [ ] Send a streaming request with `body.user` set — one row in `usage_turn`, matching `usage_tool` rows for tool calls
- [ ] Follow-up with `previous_response_id` — `session_id` reused, `turn` increments
- [ ] `/admin` → USAGE tab renders all rows; click user row → filter applies
- [ ] Switch summary header to FROM/TO date inputs → tables refilter on APPLY; CLEAR returns to preset
- [ ] Trends table renders 5 columns × {QUERIES, USERS, TOKENS, TOOL CALLS, TOP TOOLS} with grouped bars + legend in TOOL CALLS row
- [ ] Unset `USAGE_LOG_DB_URL` → gateway boots cleanly; tab shows "USAGE LOGGING OFF" card
- [ ] Failure paths (SDK error, rate limit, empty response) log with appropriate `status` / `error_code`

## Known limitations

- `claude-agent-sdk==0.1.57` does not attach `cache_control` blocks in this flow, so `cache_read_tokens` / `cache_creation_tokens` come back as 0 from `ResultMessage.usage`. Field mapping is correct; SDK just isn't requesting caching. Out of scope.
- Non-streaming turns capture tokens but `tool_stats` stays empty (no per-event timestamps).
- TOOL CALLS grouped chart approximates "last 5 of granularity" with rolling-day windows (5d / 35d / 150d) rather than calendar-aligned weeks/months.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QLqGg3vkdMnTdcFwqLyZn6)_