### PR TITLE
[codex] OpenCode 권한·이미지·세션 정리 지원

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,10 +54,8 @@ DEFAULT_MODEL=sonnet
 # BACKENDS=claude,opencode
 
 # OpenCode Backend Configuration
-# Managed mode starts `opencode serve` automatically. Set OPENCODE_BASE_URL
-# instead if you want to connect to an already-running OpenCode server.
+# The gateway starts `opencode serve` automatically.
 # OPENCODE_BIN=opencode
-# OPENCODE_BASE_URL=http://127.0.0.1:4096
 # OPENCODE_HOST=127.0.0.1
 # OPENCODE_PORT=0
 # OPENCODE_START_TIMEOUT_MS=5000
@@ -72,7 +70,7 @@ DEFAULT_MODEL=sonnet
 # OPENCODE_MODELS=openai/gpt-5.5,openai/gpt-5.5-fast,openai/gpt-5.4,openai/gpt-5.4-mini,opencode/gpt-5-nano
 
 # Optional live OpenCode smoke test settings
-# OPENCODE_SMOKE_BASE_URL=http://127.0.0.1:4096
+# OPENCODE_SMOKE_ENABLED=0
 # OPENCODE_SMOKE_MODEL=openai/gpt-5.5
 # OPENCODE_SMOKE_CWD=/path/to/workspace
 

--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,25 @@ CORS_ORIGINS=["*"]
 # Default Claude model to use when none specified in request
 DEFAULT_MODEL=sonnet
 
+# Backend Configuration
+# Default is Claude only. Enable OpenCode by adding it to BACKENDS.
+# Backend is selected by model ID:
+#   sonnet/opus/haiku               -> Claude
+#   opencode/<provider>/<model>     -> OpenCode
+# BACKENDS=claude
+# BACKENDS=claude,opencode
+
+# OpenCode Backend Configuration
+# Managed mode starts `opencode serve` automatically. Set OPENCODE_BASE_URL
+# instead if you want to connect to an already-running OpenCode server.
+# OPENCODE_BIN=opencode
+# OPENCODE_BASE_URL=http://127.0.0.1:4096
+# OPENCODE_HOST=127.0.0.1
+# OPENCODE_PORT=0
+# OPENCODE_START_TIMEOUT_MS=5000
+# OPENCODE_AGENT=general
+# OPENCODE_MODELS=openai/gpt-5.5,openai/gpt-5.5-fast,openai/gpt-5.4,openai/gpt-5.4-mini,opencode/gpt-5-nano
+
 # SDK Configuration
 # Maximum conversation turns per request
 # DEFAULT_MAX_TURNS=10

--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,9 @@ DEFAULT_MODEL=sonnet
 # OPENCODE_PORT=0
 # OPENCODE_START_TIMEOUT_MS=5000
 # OPENCODE_AGENT=general
+# Managed mode exposes OpenCode's question tool by default.
+# Set to deny to hide it, or allow to enable without permission prompts.
+# OPENCODE_QUESTION_PERMISSION=ask
 # OPENCODE_MODELS=openai/gpt-5.5,openai/gpt-5.5-fast,openai/gpt-5.4,openai/gpt-5.4-mini,opencode/gpt-5-nano
 
 # Optional live OpenCode smoke test settings

--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,11 @@ DEFAULT_MODEL=sonnet
 # OPENCODE_AGENT=general
 # OPENCODE_MODELS=openai/gpt-5.5,openai/gpt-5.5-fast,openai/gpt-5.4,openai/gpt-5.4-mini,opencode/gpt-5-nano
 
+# Optional live OpenCode smoke test settings
+# OPENCODE_SMOKE_BASE_URL=http://127.0.0.1:4096
+# OPENCODE_SMOKE_MODEL=openai/gpt-5.5
+# OPENCODE_SMOKE_CWD=/path/to/workspace
+
 # SDK Configuration
 # Maximum conversation turns per request
 # DEFAULT_MAX_TURNS=10

--- a/.env.example
+++ b/.env.example
@@ -62,9 +62,13 @@ DEFAULT_MODEL=sonnet
 # OPENCODE_PORT=0
 # OPENCODE_START_TIMEOUT_MS=5000
 # OPENCODE_AGENT=general
+# OPENCODE_DEFAULT_MODEL=openai/gpt-5.5
 # Managed mode exposes OpenCode's question tool by default.
 # Set to deny to hide it, or allow to enable without permission prompts.
 # OPENCODE_QUESTION_PERMISSION=ask
+# Include validated wrapper MCP_CONFIG in managed OpenCode config.
+# External OpenCode servers must be configured separately.
+# OPENCODE_USE_WRAPPER_MCP_CONFIG=false
 # OPENCODE_MODELS=openai/gpt-5.5,openai/gpt-5.5-fast,openai/gpt-5.4,openai/gpt-5.4-mini,opencode/gpt-5-nano
 
 # Optional live OpenCode smoke test settings
@@ -153,7 +157,7 @@ DEFAULT_MODEL=sonnet
 
 # MCP Server Configuration
 # Path to MCP config JSON file or inline JSON string
-# Format: {"mcpServers": {"name": {"type": "stdio|sse|http", ...}}}
+# Format: {"mcpServers": {"name": {"type": "stdio|sse|http|streamable-http", ...}}}
 # MCP_CONFIG={"mcpServers": {"filesystem": {"type": "stdio", "command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "/workspace"]}}}
 # MCP_CONFIG=/path/to/mcp-config.json
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,19 @@ FROM python:3.12-slim
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
-    PIP_NO_CACHE_DIR=1
+    PIP_NO_CACHE_DIR=1 \
+    PATH="/root/.opencode/bin:${PATH}"
 
 # Install system dependencies.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends jq \
+    && apt-get install -y --no-install-recommends bash ca-certificates curl git jq ripgrep \
     && rm -rf /var/lib/apt/lists/*
+
+ARG OPENCODE_VERSION=1.14.29
+
+# Install OpenCode for the managed OpenCode backend.
+RUN curl -fsSL https://opencode.ai/install | bash -s -- --version ${OPENCODE_VERSION} --no-modify-path \
+    && opencode --version
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ opencode serve --hostname 127.0.0.1 --port 4096
 export OPENCODE_BASE_URL=http://127.0.0.1:4096
 ```
 
-Managed server mode starts `opencode serve` automatically when `OPENCODE_BASE_URL` is unset. Managed mode requires the `opencode` binary on `PATH`.
+Managed server mode starts `opencode serve` automatically when `OPENCODE_BASE_URL` is unset. Managed mode requires the `opencode` binary on `PATH`. Managed mode exposes OpenCode's `question` tool by default with `OPENCODE_QUESTION_PERMISSION=ask`; set it to `deny` to hide the tool.
 
-Additional OpenCode options such as `OPENCODE_BIN`, `OPENCODE_HOST`, `OPENCODE_PORT`, `OPENCODE_AGENT`, `OPENCODE_DEFAULT_MODEL`, and server authentication variables are documented in `.env.example`.
+Additional OpenCode options such as `OPENCODE_BIN`, `OPENCODE_HOST`, `OPENCODE_PORT`, `OPENCODE_AGENT`, `OPENCODE_DEFAULT_MODEL`, `OPENCODE_QUESTION_PERMISSION`, and server authentication variables are documented in `.env.example`.
 
 ### Bash Sandbox
 

--- a/README.md
+++ b/README.md
@@ -72,11 +72,32 @@ Key environment variables (see `.env.example` for full list):
 | `TOKEN_STREAMING` | `true` | Token-level partial streaming |
 | `MAX_TIMEOUT` | `600000` | Request timeout (ms) |
 | `DEFAULT_MAX_TURNS` | `10` | Max agent turns per request |
+| `BACKENDS` | `claude` | Backend allowlist, for example `claude,opencode` |
+| `OPENCODE_MODELS` | _(unset)_ | Comma-separated OpenCode `provider/model` IDs exposed as `opencode/...` |
+| `OPENCODE_BASE_URL` | _(unset)_ | External OpenCode server URL; unset starts managed mode |
 | `DISALLOWED_SUBAGENT_TYPES` | `statusline-setup` | Comma-separated subagent types to block |
 | `CLAUDE_SANDBOX_ENABLED` | unset | Bash sandbox: unset = project settings, `true` = force on, `false` = force off |
 | `MCP_CONFIG` | — | MCP server config (JSON string or file path) |
 | `API_KEY` | — | Optional Bearer token for access control |
 | `SESSION_MAX_AGE_MINUTES` | `60` | Session TTL |
+
+### OpenCode Backend
+
+OpenCode is opt-in. Claude remains the default backend when `BACKENDS` is unset.
+
+```bash
+export BACKENDS=claude,opencode
+export OPENCODE_MODELS=openai/gpt-5.5
+```
+
+External server mode:
+
+```bash
+opencode serve --hostname 127.0.0.1 --port 4096
+export OPENCODE_BASE_URL=http://127.0.0.1:4096
+```
+
+Managed server mode starts `opencode serve` automatically when `OPENCODE_BASE_URL` is unset. Managed mode requires the `opencode` binary on `PATH`.
 
 ### Bash Sandbox
 
@@ -124,6 +145,16 @@ curl -N http://localhost:8000/v1/responses \
 curl http://localhost:8000/v1/responses \
   -H "Content-Type: application/json" \
   -d '{"model": "sonnet", "input": "What did I just say?", "previous_response_id": "<response_id_from_previous_turn>"}'
+```
+
+### OpenCode Smoke Test
+
+Live OpenCode smoke test:
+
+```bash
+OPENCODE_SMOKE_BASE_URL=http://127.0.0.1:4096 \
+OPENCODE_SMOKE_MODEL=openai/gpt-5.5 \
+uv run pytest tests/integration/test_opencode_smoke.py -q
 ```
 
 ### Per-User Workspace Isolation

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ export OPENCODE_BASE_URL=http://127.0.0.1:4096
 
 Managed server mode starts `opencode serve` automatically when `OPENCODE_BASE_URL` is unset. Managed mode requires the `opencode` binary on `PATH`.
 
+Additional OpenCode options such as `OPENCODE_BIN`, `OPENCODE_HOST`, `OPENCODE_PORT`, `OPENCODE_AGENT`, `OPENCODE_DEFAULT_MODEL`, and server authentication variables are documented in `.env.example`.
+
 ### Bash Sandbox
 
 The gateway can enable OS-level process isolation for Bash tool execution using the Claude Agent SDK's `SandboxSettings`. This uses macOS Seatbelt or Linux bubblewrap to restrict what Bash commands can access.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Key environment variables (see `.env.example` for full list):
 | `BACKENDS` | `claude` | Backend allowlist, for example `claude,opencode` |
 | `OPENCODE_MODELS` | _(unset)_ | Comma-separated OpenCode `provider/model` IDs exposed as `opencode/...` |
 | `OPENCODE_BASE_URL` | _(unset)_ | External OpenCode server URL; unset starts managed mode |
+| `OPENCODE_USE_WRAPPER_MCP_CONFIG` | `false` | Copy validated wrapper `MCP_CONFIG` into managed OpenCode config |
 | `DISALLOWED_SUBAGENT_TYPES` | `statusline-setup` | Comma-separated subagent types to block |
 | `CLAUDE_SANDBOX_ENABLED` | unset | Bash sandbox: unset = project settings, `true` = force on, `false` = force off |
 | `MCP_CONFIG` | — | MCP server config (JSON string or file path) |
@@ -99,7 +100,11 @@ export OPENCODE_BASE_URL=http://127.0.0.1:4096
 
 Managed server mode starts `opencode serve` automatically when `OPENCODE_BASE_URL` is unset. Managed mode requires the `opencode` binary on `PATH`. Managed mode exposes OpenCode's `question` tool by default with `OPENCODE_QUESTION_PERMISSION=ask`; set it to `deny` to hide the tool.
 
-Additional OpenCode options such as `OPENCODE_BIN`, `OPENCODE_HOST`, `OPENCODE_PORT`, `OPENCODE_AGENT`, `OPENCODE_DEFAULT_MODEL`, `OPENCODE_QUESTION_PERMISSION`, and server authentication variables are documented in `.env.example`.
+OpenCode MCP integration is available only in managed mode. Set `OPENCODE_USE_WRAPPER_MCP_CONFIG=true` to copy the validated wrapper `MCP_CONFIG` into the generated OpenCode config. The wrapper converts `stdio` servers to OpenCode `local` MCP entries and `http`, `sse`, or `streamable-http` servers to OpenCode `remote` entries. External OpenCode servers keep their own config and are not modified by the gateway.
+
+When `OPENCODE_CONFIG_CONTENT` is set in managed mode, the wrapper parses it as JSON, preserves explicit values, fills missing safe defaults, and then serializes the generated config passed to `opencode serve`.
+
+Additional OpenCode options such as `OPENCODE_BIN`, `OPENCODE_HOST`, `OPENCODE_PORT`, `OPENCODE_AGENT`, `OPENCODE_DEFAULT_MODEL`, `OPENCODE_QUESTION_PERMISSION`, `OPENCODE_USE_WRAPPER_MCP_CONFIG`, and server authentication variables are documented in `.env.example`.
 
 ### Bash Sandbox
 

--- a/README.md
+++ b/README.md
@@ -74,8 +74,7 @@ Key environment variables (see `.env.example` for full list):
 | `DEFAULT_MAX_TURNS` | `10` | Max agent turns per request |
 | `BACKENDS` | `claude` | Backend allowlist, for example `claude,opencode` |
 | `OPENCODE_MODELS` | _(unset)_ | Comma-separated OpenCode `provider/model` IDs exposed as `opencode/...` |
-| `OPENCODE_BASE_URL` | _(unset)_ | External OpenCode server URL; unset starts managed mode |
-| `OPENCODE_USE_WRAPPER_MCP_CONFIG` | `false` | Copy validated wrapper `MCP_CONFIG` into managed OpenCode config |
+| `OPENCODE_USE_WRAPPER_MCP_CONFIG` | `false` | Copy validated wrapper `MCP_CONFIG` into OpenCode config |
 | `DISALLOWED_SUBAGENT_TYPES` | `statusline-setup` | Comma-separated subagent types to block |
 | `CLAUDE_SANDBOX_ENABLED` | unset | Bash sandbox: unset = project settings, `true` = force on, `false` = force off |
 | `MCP_CONFIG` | — | MCP server config (JSON string or file path) |
@@ -91,18 +90,11 @@ export BACKENDS=claude,opencode
 export OPENCODE_MODELS=openai/gpt-5.5
 ```
 
-External server mode:
+The gateway starts `opencode serve` automatically and requires the `opencode` binary on `PATH`. The Docker image installs OpenCode during build. OpenCode's `question` tool is exposed by default with `OPENCODE_QUESTION_PERMISSION=ask`; set it to `deny` to hide the tool.
 
-```bash
-opencode serve --hostname 127.0.0.1 --port 4096
-export OPENCODE_BASE_URL=http://127.0.0.1:4096
-```
+Set `OPENCODE_USE_WRAPPER_MCP_CONFIG=true` to copy the validated wrapper `MCP_CONFIG` into the generated OpenCode config. The wrapper converts `stdio` servers to OpenCode `local` MCP entries and `http`, `sse`, or `streamable-http` servers to OpenCode `remote` entries.
 
-Managed server mode starts `opencode serve` automatically when `OPENCODE_BASE_URL` is unset. Managed mode requires the `opencode` binary on `PATH`. Managed mode exposes OpenCode's `question` tool by default with `OPENCODE_QUESTION_PERMISSION=ask`; set it to `deny` to hide the tool.
-
-OpenCode MCP integration is available only in managed mode. Set `OPENCODE_USE_WRAPPER_MCP_CONFIG=true` to copy the validated wrapper `MCP_CONFIG` into the generated OpenCode config. The wrapper converts `stdio` servers to OpenCode `local` MCP entries and `http`, `sse`, or `streamable-http` servers to OpenCode `remote` entries. External OpenCode servers keep their own config and are not modified by the gateway.
-
-When `OPENCODE_CONFIG_CONTENT` is set in managed mode, the wrapper parses it as JSON, preserves explicit values, fills missing safe defaults, and then serializes the generated config passed to `opencode serve`.
+When `OPENCODE_CONFIG_CONTENT` is set, the wrapper parses it as JSON, preserves explicit values, fills missing safe defaults, and then serializes the generated config passed to `opencode serve`.
 
 Additional OpenCode options such as `OPENCODE_BIN`, `OPENCODE_HOST`, `OPENCODE_PORT`, `OPENCODE_AGENT`, `OPENCODE_DEFAULT_MODEL`, `OPENCODE_QUESTION_PERMISSION`, `OPENCODE_USE_WRAPPER_MCP_CONFIG`, and server authentication variables are documented in `.env.example`.
 
@@ -159,7 +151,7 @@ curl http://localhost:8000/v1/responses \
 Live OpenCode smoke test:
 
 ```bash
-OPENCODE_SMOKE_BASE_URL=http://127.0.0.1:4096 \
+OPENCODE_SMOKE_ENABLED=1 \
 OPENCODE_SMOKE_MODEL=openai/gpt-5.5 \
 uv run pytest tests/integration/test_opencode_smoke.py -q
 ```
@@ -319,6 +311,11 @@ docker build \
   --build-arg PIP_INDEX_URL=https://pypi.example.com/simple \
   -t claude-code-gateway .
 
+# Pin or override the OpenCode version
+docker build \
+  --build-arg OPENCODE_VERSION=1.14.29 \
+  -t claude-code-gateway .
+
 # With API key auth
 docker run -d -p 8000:8000 \
   -e ANTHROPIC_AUTH_TOKEN=your-key \
@@ -335,9 +332,16 @@ docker run -d -p 8000:8000 \
   -v /path/to/project:/workspace \
   -e CLAUDE_CWD=/workspace \
   claude-code-gateway
+
+# With OpenCode enabled
+docker run -d -p 8000:8000 \
+  -e BACKENDS=claude,opencode \
+  -e OPENCODE_MODELS=openai/gpt-5.5 \
+  -e OPENAI_API_KEY=your-key \
+  claude-code-gateway
 ```
 
-Or with docker-compose: `docker compose up -d`
+Or with docker-compose: set `BACKENDS=claude,opencode`, `OPENCODE_MODELS`, and provider keys in `.env`, then run `docker compose up -d`. The image includes OpenCode and the gateway starts it automatically.
 
 ## Development
 

--- a/docs/superpowers/plans/2026-04-28-opencode-backend-mvp.md
+++ b/docs/superpowers/plans/2026-04-28-opencode-backend-mvp.md
@@ -1,5 +1,9 @@
 # OpenCode Backend MVP Implementation Plan
 
+> **SUPERSEDED:** The current OpenCode backend is managed-only. The earlier
+> dual-mode implementation plan that referenced `OPENCODE_BASE_URL` was
+> replaced; external OpenCode servers are no longer supported.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Build an opt-in OpenCode backend that can be selected through `BACKENDS` and called through `/v1/models` and `/v1/responses`.

--- a/docs/superpowers/plans/2026-04-28-opencode-backend-mvp.md
+++ b/docs/superpowers/plans/2026-04-28-opencode-backend-mvp.md
@@ -1,0 +1,384 @@
+# OpenCode Backend MVP Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build an opt-in OpenCode backend that can be selected through `BACKENDS` and called through `/v1/models` and `/v1/responses`.
+
+**Architecture:** Add a focused `src/backends/opencode` package that satisfies the existing `BackendClient` protocol and talks to OpenCode over HTTP with `httpx`. Update backend discovery to parse `BACKENDS`, update auth fallback for `opencode`, and keep route changes limited to backend-neutral errors and lifecycle cleanup.
+
+**Tech Stack:** Python 3.10+, FastAPI, httpx, pytest, existing `BackendRegistry`/`BackendClient` abstractions.
+
+---
+
+### Task 1: Backend Selection and Descriptor
+
+**Files:**
+- Modify: `src/backends/__init__.py`
+- Create: `src/backends/opencode/__init__.py`
+- Create: `src/backends/opencode/constants.py`
+- Test: `tests/test_opencode_backend.py`
+- Modify: `tests/test_backends_init_unit.py`
+
+- [ ] **Step 1: Write failing descriptor and BACKENDS tests**
+
+Add tests that expect `BACKENDS` to default to Claude, support `claude,opencode`, skip unknown values, and resolve `opencode/<provider>/<model>`:
+
+```python
+def test_opencode_descriptor_resolves_prefixed_model(monkeypatch):
+    monkeypatch.setenv("OPENCODE_MODELS", "anthropic/claude-sonnet-4-5")
+    import importlib
+    import src.backends.opencode as opencode_pkg
+    opencode_pkg = importlib.reload(opencode_pkg)
+
+    resolved = opencode_pkg.OPENCODE_DESCRIPTOR.resolve_fn(
+        "opencode/anthropic/claude-sonnet-4-5"
+    )
+
+    assert resolved is not None
+    assert resolved.backend == "opencode"
+    assert resolved.provider_model == "anthropic/claude-sonnet-4-5"
+    assert opencode_pkg.OPENCODE_DESCRIPTOR.models == [
+        "opencode/anthropic/claude-sonnet-4-5"
+    ]
+```
+
+```python
+def test_discover_backends_respects_backends_env(monkeypatch):
+    calls = []
+
+    def fake_claude_register(registry_cls=None):
+        calls.append("claude")
+
+    def fake_opencode_register(registry_cls=None):
+        calls.append("opencode")
+
+    monkeypatch.setenv("BACKENDS", "claude,opencode")
+    monkeypatch.setattr("src.backends.claude.register", fake_claude_register)
+    monkeypatch.setattr("src.backends.opencode.register", fake_opencode_register)
+
+    from src.backends import discover_backends
+
+    discover_backends()
+
+    assert calls == ["claude", "opencode"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/test_opencode_backend.py tests/test_backends_init_unit.py -q
+```
+
+Expected: FAIL because `src.backends.opencode` does not exist and `discover_backends()` ignores `BACKENDS`.
+
+- [ ] **Step 3: Implement descriptor and BACKENDS discovery**
+
+Implement:
+
+```python
+def _enabled_backend_names() -> list[str]:
+    raw = os.getenv("BACKENDS", "claude")
+    names = []
+    for item in raw.split(","):
+        name = item.strip().lower()
+        if name and name not in names:
+            names.append(name)
+    return names or ["claude"]
+```
+
+Implement OpenCode descriptor:
+
+```python
+def configured_public_models() -> list[str]:
+    return [f"opencode/{m}" for m in configured_provider_models()]
+
+def _opencode_resolve(model: str) -> Optional[ResolvedModel]:
+    prefix = "opencode/"
+    if not model.startswith(prefix):
+        return None
+    provider_model = model[len(prefix):]
+    if "/" not in provider_model:
+        return None
+    return ResolvedModel(model, "opencode", provider_model)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+uv run pytest tests/test_opencode_backend.py tests/test_backends_init_unit.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backends/__init__.py src/backends/opencode/__init__.py src/backends/opencode/constants.py tests/test_opencode_backend.py tests/test_backends_init_unit.py
+git commit -m "feat: add opencode backend discovery"
+```
+
+### Task 2: OpenCode Auth and HTTP Client
+
+**Files:**
+- Create: `src/backends/opencode/auth.py`
+- Create: `src/backends/opencode/client.py`
+- Modify: `src/auth.py`
+- Test: `tests/test_opencode_backend.py`
+
+- [ ] **Step 1: Write failing auth and client tests**
+
+Add tests for `OpenCodeAuthProvider`, `auth_manager.get_provider("opencode")`,
+external server mode, prompt conversion, and text parsing:
+
+```python
+def test_auth_manager_returns_opencode_provider():
+    from src.auth import auth_manager
+
+    provider = auth_manager.get_provider("opencode")
+
+    assert provider.name == "opencode"
+```
+
+```python
+async def test_opencode_client_sends_prompt_to_existing_server(monkeypatch):
+    calls = []
+
+    class FakeResponse:
+        def __init__(self, payload):
+            self._payload = payload
+        def raise_for_status(self):
+            return None
+        def json(self):
+            return self._payload
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, *args):
+            return None
+        async def get(self, path):
+            return FakeResponse({"healthy": True, "version": "test"})
+        async def post(self, path, **kwargs):
+            calls.append((path, kwargs))
+            if path == "/session":
+                return FakeResponse({"id": "oc-session"})
+            return FakeResponse({
+                "info": {
+                    "role": "assistant",
+                    "tokens": {"input": 7, "output": 3, "reasoning": 0, "cache": {"read": 0, "write": 0}},
+                },
+                "parts": [{"type": "text", "text": "hello from opencode"}],
+            })
+
+    monkeypatch.setenv("OPENCODE_BASE_URL", "http://127.0.0.1:4096")
+    monkeypatch.setattr("src.backends.opencode.client.httpx.AsyncClient", FakeAsyncClient)
+
+    from src.backends.opencode.client import OpenCodeClient
+    from src.session_manager import Session
+
+    backend = OpenCodeClient()
+    session = Session(session_id="gw-session")
+    client = await backend.create_client(
+        session=session,
+        model="anthropic/claude-sonnet-4-5",
+        system_prompt="request instructions",
+        _custom_base="base prompt",
+        cwd="/tmp/work",
+    )
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "say hi", session)]
+
+    assert calls[0][0] == "/session"
+    assert calls[1][0] == "/session/oc-session/message"
+    assert calls[1][1]["json"]["system"] == "base prompt\n\nrequest instructions"
+    assert chunks[-1]["result"] == "hello from opencode"
+    assert backend.parse_message(chunks) == "hello from opencode"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/test_opencode_backend.py -q
+```
+
+Expected: FAIL because auth and client modules do not exist.
+
+- [ ] **Step 3: Implement auth provider and HTTP client**
+
+Implement `OpenCodeAuthProvider.validate()` with:
+
+```python
+if os.getenv("OPENCODE_BASE_URL"):
+    return {"valid": True, "errors": [], "config": {"mode": "external", "base_url": base_url}}
+if shutil.which("opencode"):
+    return {"valid": True, "errors": [], "config": {"mode": "managed", "binary": "opencode"}}
+return {"valid": False, "errors": ["opencode binary not found on PATH"], "config": {"mode": "managed"}}
+```
+
+Implement `OpenCodeClient` with an `OpenCodeSessionClient` dataclass, `verify()`,
+`create_client()`, `run_completion_with_client()`, `parse_message()`,
+`estimate_token_usage()`, and managed server startup parsing.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+uv run pytest tests/test_opencode_backend.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backends/opencode/auth.py src/backends/opencode/client.py src/auth.py tests/test_opencode_backend.py
+git commit -m "feat: add opencode backend client"
+```
+
+### Task 3: Responses Route and Model Surface Integration
+
+**Files:**
+- Modify: `src/routes/responses.py`
+- Modify: `src/main.py`
+- Test: `tests/test_main_api_unit.py`
+- Test: `tests/test_main_coverage_unit.py`
+
+- [ ] **Step 1: Write failing route integration tests**
+
+Add tests proving `/v1/models` includes configured OpenCode models and
+`/v1/responses` dispatches to the OpenCode backend without Claude-specific
+failure text:
+
+```python
+def test_models_endpoint_lists_opencode_models_when_registered():
+    from src.backends.base import BackendDescriptor, BackendRegistry, ResolvedModel
+
+    def resolve(model):
+        if model == "opencode/anthropic/claude-sonnet-4-5":
+            return ResolvedModel(model, "opencode", "anthropic/claude-sonnet-4-5")
+        return None
+
+    backend = MagicMock()
+    backend.name = "opencode"
+    BackendRegistry.register_descriptor(
+        BackendDescriptor("opencode", "opencode", ["opencode/anthropic/claude-sonnet-4-5"], resolve)
+    )
+    BackendRegistry.register("opencode", backend)
+
+    with client_context() as (client, _mock_cli):
+        response = client.get("/v1/models")
+
+    ids = [item["id"] for item in response.json()["data"]]
+    assert "opencode/anthropic/claude-sonnet-4-5" in ids
+```
+
+```python
+def test_create_client_failure_uses_backend_neutral_message():
+    async def failing_create_client(**kwargs):
+        raise RuntimeError("simulated opencode failure")
+
+    with client_context() as (client, mock_cli):
+        mock_cli.create_client = failing_create_client
+        response = client.post("/v1/responses", json={"model": DEFAULT_MODEL, "input": "hi"})
+
+    assert response.status_code == 503
+    assert "Claude Code SDK" not in response.json()["error"]["message"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/test_main_api_unit.py tests/test_main_coverage_unit.py -q
+```
+
+Expected: FAIL on the backend-neutral error assertion until route text changes.
+
+- [ ] **Step 3: Implement route and lifecycle integration**
+
+Change `src/routes/responses.py` failure detail to:
+
+```python
+detail=f"{resolved.backend} backend unavailable; retry shortly"
+```
+
+Add shutdown lifecycle cleanup in `src/main.py`:
+
+```python
+for _name, backend in BackendRegistry.all_backends().items():
+    close = getattr(backend, "close", None) or getattr(backend, "shutdown", None)
+    if close is None:
+        continue
+    result = close()
+    if inspect.isawaitable(result):
+        await result
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+uv run pytest tests/test_main_api_unit.py tests/test_main_coverage_unit.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/routes/responses.py src/main.py tests/test_main_api_unit.py tests/test_main_coverage_unit.py
+git commit -m "feat: wire opencode backend into responses"
+```
+
+### Task 4: Final Verification
+
+**Files:**
+- Modify: `README.md` only if documenting env usage is necessary for the implemented surface.
+
+- [ ] **Step 1: Run targeted backend tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_opencode_backend.py tests/test_backends_init_unit.py tests/test_backend_contract.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run route tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_main_api_unit.py tests/test_main_coverage_unit.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run full non-e2e suite**
+
+Run:
+
+```bash
+uv run pytest -q
+```
+
+Expected: PASS or a clear unrelated pre-existing failure documented in the final summary.
+
+- [ ] **Step 4: Push branch**
+
+```bash
+git push
+```
+
+Expected: `codex/opencode-backend-mvp-design` updates on origin.

--- a/docs/superpowers/plans/2026-04-28-opencode-post-mvp-1-4.md
+++ b/docs/superpowers/plans/2026-04-28-opencode-post-mvp-1-4.md
@@ -1,0 +1,1010 @@
+# OpenCode Post-MVP 1-4 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete the first four OpenCode post-MVP tracks: operational hardening, streaming quality, OpenCode question continuation, and MCP/config integration.
+
+**Architecture:** Keep the existing backend-neutral Responses route as the orchestration layer. Add focused OpenCode helpers inside `src/backends/opencode/` for health metadata, event conversion, question state, and config generation, then expose those capabilities through existing admin, response, and MCP boundaries. Each track must be independently testable and should preserve Claude behavior by gating OpenCode-specific logic on `resolved.backend == "opencode"` or OpenCode client capabilities.
+
+**Tech Stack:** Python 3.10+, FastAPI, httpx, pytest, existing `BackendRegistry`, `BackendClient`, `SessionManager`, and Responses API models.
+
+---
+
+## File Map
+
+- `README.md`: Add OpenCode setup, external/managed mode examples, streaming notes, and MCP notes.
+- `.env.example`: Add any new OpenCode environment variables introduced by this plan.
+- `src/backends/opencode/client.py`: Add health metadata, stronger streaming lifecycle handling, question event conversion, and generated config support.
+- `src/backends/opencode/constants.py`: Add parsing helpers for new OpenCode toggles.
+- `src/backends/opencode/config.py`: New focused module for merging OpenCode base config with wrapper MCP config.
+- `src/backends/opencode/events.py`: New focused module for converting OpenCode event payloads into gateway chunks and question state.
+- `src/mcp_config.py`: Add an exported helper that returns the validated raw MCP server config for reuse by OpenCode config conversion.
+- `src/admin_service.py`: Include OpenCode mode, base URL, configured models, config source, and health data in backend diagnostics.
+- `src/routes/responses.py`: Route OpenCode question continuations through backend-specific continuation support instead of Claude-only hook state.
+- `src/session_manager.py`: Continue using `Session.pending_tool_call`, adding a `"backend": "opencode"` marker for OpenCode question state.
+- `tests/test_opencode_backend.py`: Unit tests for OpenCode health, streaming event conversion, question state, and generated config.
+- `tests/test_main_api_unit.py`: Route-level tests for OpenCode streaming and question continuation.
+- `tests/test_admin_service_unit.py`: Admin diagnostics tests for OpenCode status fields.
+- `tests/test_mcp_config.py`: MCP-to-OpenCode config conversion tests.
+- `tests/integration/test_opencode_smoke.py`: Optional live smoke test gated by environment variables.
+
+---
+
+### Task 1: Operational Hardening and Documentation
+
+**Files:**
+- Modify: `README.md`
+- Modify: `.env.example`
+- Modify: `src/backends/opencode/client.py`
+- Modify: `src/admin_service.py`
+- Test: `tests/test_opencode_backend.py`
+- Test: `tests/test_admin_service_unit.py`
+- Create: `tests/integration/test_opencode_smoke.py`
+
+- [ ] **Step 1: Write failing tests for OpenCode runtime metadata**
+
+Add tests that define the metadata surface expected from the OpenCode client and admin diagnostics:
+
+```python
+def test_opencode_client_exposes_runtime_metadata(monkeypatch):
+    monkeypatch.setenv("OPENCODE_BASE_URL", "http://127.0.0.1:4096")
+    monkeypatch.setenv("OPENCODE_MODELS", "openai/gpt-5.5")
+
+    from src.backends.opencode.client import OpenCodeClient
+
+    client = OpenCodeClient()
+
+    assert client.runtime_metadata() == {
+        "mode": "external",
+        "base_url": "http://127.0.0.1:4096",
+        "agent": "general",
+        "models": ["opencode/openai/gpt-5.5"],
+        "managed_process": False,
+    }
+```
+
+```python
+async def test_admin_backend_health_includes_opencode_metadata(monkeypatch):
+    from src.backends.base import BackendRegistry
+    from src.admin_service import get_backends_health
+
+    class FakeOpenCodeBackend:
+        name = "opencode"
+
+        def supported_models(self):
+            return ["opencode/openai/gpt-5.5"]
+
+        def get_auth_provider(self):
+            class Provider:
+                name = "opencode"
+
+                def validate(self):
+                    return {"valid": True, "errors": [], "config": {"mode": "external"}}
+
+            return Provider()
+
+        async def verify(self):
+            return True
+
+        def runtime_metadata(self):
+            return {
+                "mode": "external",
+                "base_url": "http://127.0.0.1:4096",
+                "agent": "general",
+                "models": ["opencode/openai/gpt-5.5"],
+                "managed_process": False,
+            }
+
+    BackendRegistry.clear()
+    BackendRegistry.register("opencode", FakeOpenCodeBackend())
+
+    health = await get_backends_health()
+
+    opencode = next(item for item in health if item["name"] == "opencode")
+    assert opencode["metadata"]["mode"] == "external"
+    assert opencode["metadata"]["base_url"] == "http://127.0.0.1:4096"
+    assert opencode["metadata"]["models"] == ["opencode/openai/gpt-5.5"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/test_opencode_backend.py::test_opencode_client_exposes_runtime_metadata tests/test_admin_service_unit.py::test_admin_backend_health_includes_opencode_metadata -q
+```
+
+Expected: FAIL because `runtime_metadata()` and admin `metadata` fields do not exist yet.
+
+- [ ] **Step 3: Implement runtime metadata**
+
+Add `runtime_metadata()` to `OpenCodeClient`:
+
+```python
+def runtime_metadata(self) -> Dict[str, Any]:
+    mode = "external" if os.getenv("OPENCODE_BASE_URL") else "managed"
+    return {
+        "mode": mode,
+        "base_url": self.base_url,
+        "agent": self._agent,
+        "models": self.supported_models(),
+        "managed_process": self._process is not None,
+    }
+```
+
+Update `src/admin_service.py::get_backends_health()` so each backend item includes metadata when the live backend exposes it:
+
+```python
+metadata: Dict[str, Any] = {}
+runtime_metadata = getattr(backend, "runtime_metadata", None) if backend else None
+if callable(runtime_metadata):
+    try:
+        metadata = runtime_metadata()
+    except Exception:
+        logger.warning("Failed to collect backend runtime metadata for %s", name, exc_info=True)
+        metadata = {}
+item["metadata"] = metadata
+```
+
+- [ ] **Step 4: Add live smoke test gated by explicit env**
+
+Create `tests/integration/test_opencode_smoke.py`:
+
+```python
+import os
+
+import pytest
+
+
+pytestmark = pytest.mark.skipif(
+    not os.getenv("OPENCODE_SMOKE_BASE_URL"),
+    reason="OPENCODE_SMOKE_BASE_URL is required for live OpenCode smoke tests",
+)
+
+
+async def test_live_opencode_health_and_prompt(monkeypatch):
+    monkeypatch.setenv("OPENCODE_BASE_URL", os.environ["OPENCODE_SMOKE_BASE_URL"])
+
+    from src.backends.opencode.client import OpenCodeClient
+    from src.session_manager import Session
+
+    backend = OpenCodeClient()
+    assert await backend.verify() is True
+
+    session = Session(session_id="opencode-smoke")
+    client = await backend.create_client(
+        session=session,
+        model=os.getenv("OPENCODE_SMOKE_MODEL", "openai/gpt-5.5"),
+        cwd=os.getenv("OPENCODE_SMOKE_CWD") or None,
+    )
+    chunks = [
+        chunk
+        async for chunk in backend.run_completion_with_client(
+            client,
+            "Reply with exactly: smoke-ok",
+            session,
+        )
+    ]
+
+    assert "smoke-ok" in (backend.parse_message(chunks) or "")
+```
+
+- [ ] **Step 5: Document OpenCode operations**
+
+Add README sections under Configuration and Usage:
+
+````markdown
+### OpenCode Backend
+
+OpenCode is opt-in. Claude remains the default backend when `BACKENDS` is unset.
+
+```bash
+export BACKENDS=claude,opencode
+export OPENCODE_MODELS=openai/gpt-5.5
+```
+
+External server mode:
+
+```bash
+opencode serve --hostname 127.0.0.1 --port 4096
+export OPENCODE_BASE_URL=http://127.0.0.1:4096
+```
+
+Managed server mode starts `opencode serve` automatically when `OPENCODE_BASE_URL` is unset. Managed mode requires the `opencode` binary on `PATH`.
+````
+
+Add smoke test instructions:
+
+````markdown
+Live OpenCode smoke test:
+
+```bash
+OPENCODE_SMOKE_BASE_URL=http://127.0.0.1:4096 \
+OPENCODE_SMOKE_MODEL=openai/gpt-5.5 \
+uv run pytest tests/integration/test_opencode_smoke.py -q
+```
+````
+
+- [ ] **Step 6: Run verification**
+
+Run:
+
+```bash
+uv run pytest tests/test_opencode_backend.py tests/test_admin_service_unit.py tests/integration/test_opencode_smoke.py -q
+```
+
+Expected: PASS, with the live smoke test skipped unless `OPENCODE_SMOKE_BASE_URL` is set.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add README.md .env.example src/backends/opencode/client.py src/admin_service.py tests/test_opencode_backend.py tests/test_admin_service_unit.py tests/integration/test_opencode_smoke.py
+git commit -m "docs: document and expose opencode runtime status"
+```
+
+---
+
+### Task 2: Streaming Quality and Event Conversion
+
+**Files:**
+- Create: `src/backends/opencode/events.py`
+- Modify: `src/backends/opencode/client.py`
+- Modify: `src/routes/responses.py`
+- Test: `tests/test_opencode_backend.py`
+- Test: `tests/test_main_api_unit.py`
+
+- [ ] **Step 1: Write failing tests for isolated event conversion**
+
+Add tests that define a pure converter API before moving conversion logic out of `client.py`:
+
+```python
+def test_opencode_event_converter_emits_text_delta_and_final_text():
+    from src.backends.opencode.events import OpenCodeEventConverter
+
+    converter = OpenCodeEventConverter(session_id="oc-session")
+
+    chunks = converter.convert(
+        {
+            "type": "message.part.delta",
+            "properties": {
+                "sessionID": "oc-session",
+                "partID": "p1",
+                "field": "text",
+                "delta": "hello",
+            },
+        }
+    )
+
+    assert chunks == [
+        {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "hello"},
+            },
+        }
+    ]
+    assert converter.final_text() == "hello"
+```
+
+```python
+def test_opencode_event_converter_ignores_other_sessions():
+    from src.backends.opencode.events import OpenCodeEventConverter
+
+    converter = OpenCodeEventConverter(session_id="oc-session")
+
+    chunks = converter.convert(
+        {
+            "type": "message.part.delta",
+            "properties": {
+                "sessionID": "other-session",
+                "partID": "p1",
+                "field": "text",
+                "delta": "wrong",
+            },
+        }
+    )
+
+    assert chunks == []
+    assert converter.final_text() == ""
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/test_opencode_backend.py::test_opencode_event_converter_emits_text_delta_and_final_text tests/test_opencode_backend.py::test_opencode_event_converter_ignores_other_sessions -q
+```
+
+Expected: FAIL because `src.backends.opencode.events` does not exist.
+
+- [ ] **Step 3: Create event converter module**
+
+Create `src/backends/opencode/events.py` with a small public API:
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class OpenCodeEventConverter:
+    session_id: str
+    text_by_part: Dict[str, str] = field(default_factory=dict)
+    text_parts: List[str] = field(default_factory=list)
+    emitted_tool_uses: set[str] = field(default_factory=set)
+    emitted_tool_results: set[str] = field(default_factory=set)
+    usage: Optional[Dict[str, int]] = None
+    saw_activity: bool = False
+
+    def convert(self, event: Dict[str, Any]) -> List[Dict[str, Any]]:
+        if self._event_session_id(event) != self.session_id:
+            return []
+        chunks: List[Dict[str, Any]] = []
+        self._convert_usage_event(event)
+        text_chunk = self._convert_text_event(event)
+        if text_chunk:
+            chunks.append(text_chunk)
+        chunks.extend(self._convert_tool_event(event))
+        return chunks
+
+    def final_text(self) -> str:
+        return "".join(self.text_parts)
+
+    def finished(self, event: Dict[str, Any]) -> bool:
+        return (
+            event.get("type") == "session.idle"
+            and self._event_session_id(event) == self.session_id
+            and self.saw_activity
+        )
+
+    def error_message(self, event: Dict[str, Any]) -> Optional[str]:
+        if event.get("type") != "session.error":
+            return None
+        event_session = self._event_session_id(event)
+        if event_session not in (None, self.session_id):
+            return None
+        props = event.get("properties") if isinstance(event.get("properties"), dict) else {}
+        error = props.get("error") or props.get("message") or props
+        return str(error)
+
+    def _event_session_id(self, event: Dict[str, Any]) -> Optional[str]:
+        props = event.get("properties")
+        if not isinstance(props, dict):
+            return None
+        if isinstance(props.get("sessionID"), str):
+            return props["sessionID"]
+        part = props.get("part")
+        if isinstance(part, dict) and isinstance(part.get("sessionID"), str):
+            return part["sessionID"]
+        return None
+
+    def _text_delta_chunk(self, delta: str) -> Dict[str, Any]:
+        return {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": delta},
+            },
+        }
+
+    def _convert_text_event(self, event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        event_type = event.get("type")
+        props = event.get("properties") if isinstance(event.get("properties"), dict) else {}
+        if event_type == "message.part.delta":
+            if props.get("field") not in (None, "text"):
+                return None
+            delta = props.get("delta")
+            if not isinstance(delta, str) or not delta:
+                return None
+            part_id = str(props.get("partID") or props.get("partId") or "")
+            if part_id:
+                self.text_by_part[part_id] = self.text_by_part.get(part_id, "") + delta
+            self.text_parts.append(delta)
+            self.saw_activity = True
+            return self._text_delta_chunk(delta)
+        return None
+
+    def _convert_usage_event(self, event: Dict[str, Any]) -> None:
+        return None
+
+    def _convert_tool_event(self, event: Dict[str, Any]) -> List[Dict[str, Any]]:
+        return []
+```
+
+Move the existing usage, tool, `message.part.updated`, idle, and error conversion branches from `client.py` into this module after the minimal module passes the first tests.
+
+- [ ] **Step 4: Refactor OpenCodeClient to use the converter**
+
+In `OpenCodeClient._run_completion_streaming()`, replace direct `OpenCodeStreamState` usage with:
+
+```python
+from src.backends.opencode.events import OpenCodeEventConverter
+
+converter = OpenCodeEventConverter(session_id=client.session_id)
+
+async for event in self._iter_sse_events(event_response):
+    error_message = converter.error_message(event)
+    if error_message:
+        yield {"type": "error", "is_error": True, "error_message": error_message}
+        return
+    if converter.finished(event):
+        break
+    for chunk in converter.convert(event):
+        yield chunk
+
+text = converter.final_text()
+usage = converter.usage
+```
+
+Keep the output chunk shape unchanged:
+
+```python
+assistant: Dict[str, Any] = {
+    "type": "assistant",
+    "content": [{"type": "text", "text": text}],
+}
+result: Dict[str, Any] = {"type": "result", "subtype": "success", "result": text}
+```
+
+- [ ] **Step 5: Add streaming cancellation cleanup test**
+
+Add a route-level test that proves cancellation disconnects an OpenCode session client:
+
+```python
+def test_opencode_streaming_disconnects_client_on_error(isolated_session_manager):
+    from src.backends.base import BackendDescriptor, BackendRegistry, ResolvedModel
+    import src.main as main
+
+    class FakeOpenCodeSessionClient:
+        stream_events = False
+
+        def __init__(self):
+            self.disconnected = False
+
+        async def disconnect(self):
+            self.disconnected = True
+
+    created_client = FakeOpenCodeSessionClient()
+
+    def resolve(model):
+        if model == "opencode/openai/gpt-5.5":
+            return ResolvedModel(model, "opencode", "openai/gpt-5.5")
+        return None
+
+    async def create_client(**kwargs):
+        return created_client
+
+    async def run_completion_with_client(client, prompt, session):
+        yield {"type": "error", "is_error": True, "error_message": "stream failed"}
+
+    backend = MagicMock()
+    backend.name = "opencode"
+    backend.create_client = create_client
+    backend.run_completion_with_client = run_completion_with_client
+    backend.parse_message.return_value = None
+    backend.estimate_token_usage.return_value = {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+
+    BackendRegistry.clear()
+    BackendRegistry.register_descriptor(
+        BackendDescriptor("opencode", "opencode", ["opencode/openai/gpt-5.5"], resolve)
+    )
+    BackendRegistry.register("opencode", backend)
+
+    with client_context() as (client, _):
+        response = client.post(
+            "/v1/responses",
+            json={"model": "opencode/openai/gpt-5.5", "input": "hi", "stream": True},
+        )
+
+    assert response.status_code == 200
+    assert "response.failed" in response.text
+    assert created_client.disconnected is True
+```
+
+- [ ] **Step 6: Run streaming tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_opencode_backend.py tests/test_main_api_unit.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/backends/opencode/events.py src/backends/opencode/client.py src/routes/responses.py tests/test_opencode_backend.py tests/test_main_api_unit.py
+git commit -m "refactor: isolate opencode event conversion"
+```
+
+---
+
+### Task 3: OpenCode Question Continuation
+
+**Files:**
+- Modify: `src/backends/opencode/events.py`
+- Modify: `src/backends/opencode/client.py`
+- Modify: `src/routes/responses.py`
+- Modify: `src/session_manager.py`
+- Test: `tests/test_opencode_backend.py`
+- Test: `tests/test_main_api_unit.py`
+- Test: `tests/test_ask_user_question.py`
+
+- [ ] **Step 1: Define OpenCode question event behavior with failing tests**
+
+Add converter tests for OpenCode question events. The route should ultimately emit the existing Responses `requires_action` shape, so the backend chunk should use the same `tool_use` content type the current route already understands:
+
+```python
+def test_opencode_event_converter_emits_question_tool_use():
+    from src.backends.opencode.events import OpenCodeEventConverter
+
+    converter = OpenCodeEventConverter(session_id="oc-session")
+    chunks = converter.convert(
+        {
+            "type": "message.part.updated",
+            "properties": {
+                "part": {
+                    "sessionID": "oc-session",
+                    "type": "tool",
+                    "tool": "question",
+                    "callID": "q1",
+                    "state": {
+                        "status": "running",
+                        "input": {
+                            "question": "Continue?",
+                            "options": [{"label": "Yes"}, {"label": "No"}],
+                        },
+                    },
+                }
+            },
+        }
+    )
+
+    assert chunks == [
+        {
+            "type": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "q1",
+                    "name": "question",
+                    "input": {
+                        "question": "Continue?",
+                        "options": [{"label": "Yes"}, {"label": "No"}],
+                    },
+                }
+            ],
+        }
+    ]
+    assert converter.pending_question == {
+        "call_id": "q1",
+        "name": "question",
+        "arguments": {
+            "question": "Continue?",
+            "options": [{"label": "Yes"}, {"label": "No"}],
+        },
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+uv run pytest tests/test_opencode_backend.py::test_opencode_event_converter_emits_question_tool_use -q
+```
+
+Expected: FAIL because `pending_question` does not exist.
+
+- [ ] **Step 3: Extend converter state**
+
+Add `pending_question` to `OpenCodeEventConverter`:
+
+```python
+pending_question: Optional[Dict[str, Any]] = None
+```
+
+When converting a tool event where `part["tool"] == "question"` and the input contains a non-empty `question`, set:
+
+```python
+self.pending_question = {
+    "call_id": call_id,
+    "name": "question",
+    "arguments": input_value,
+}
+```
+
+Keep emitting the existing `tool_use` chunk so current Responses helpers can build `requires_action`.
+
+- [ ] **Step 4: Add backend continuation API**
+
+Add an OpenCode-specific continuation method to `OpenCodeClient`:
+
+```python
+async def resume_question_with_client(
+    self,
+    client: OpenCodeSessionClient,
+    call_id: str,
+    output: str,
+    session: Any,
+) -> AsyncGenerator[Dict[str, Any], None]:
+    body = {
+        "agent": self._agent,
+        "parts": [
+            {
+                "type": "tool",
+                "callID": call_id,
+                "tool": "question",
+                "state": {"status": "completed", "output": output},
+            }
+        ],
+    }
+    model = self._split_provider_model(client.model)
+    if model:
+        body["model"] = model
+    async with httpx.AsyncClient(**self._client_kwargs()) as http_client:
+        response = await http_client.post(
+            f"/session/{client.session_id}/message",
+            json=body,
+            params=self._directory_params(client.cwd),
+        )
+        response.raise_for_status()
+        payload = response.json()
+    text = self._extract_text(payload)
+    yield {"type": "assistant", "content": [{"type": "text", "text": text}]}
+    yield {"type": "result", "subtype": "success", "result": text}
+```
+
+Use this method as the only route-facing continuation API. If the live smoke test shows OpenCode requires a different HTTP endpoint or body shape, update `resume_question_with_client()` and keep `_handle_function_call_output()` unchanged.
+
+- [ ] **Step 5: Store OpenCode pending question on session**
+
+When streaming or non-streaming chunks include a `question` tool use from OpenCode, set session state:
+
+```python
+session.pending_tool_call = {
+    "call_id": tool_use["id"],
+    "name": tool_use["name"],
+    "arguments": tool_use.get("input", {}),
+    "backend": "opencode",
+}
+```
+
+Keep the existing Claude fields intact for Claude sessions.
+
+- [ ] **Step 6: Route function_call_output to OpenCode continuation**
+
+In `_handle_function_call_output()`, branch on `resolved.backend`:
+
+```python
+if resolved.backend == "opencode":
+    resume = getattr(backend, "resume_question_with_client", None)
+    if resume is None:
+        raise HTTPException(
+            status_code=400,
+            detail="OpenCode question continuation is not supported by this backend",
+        )
+    chunks = [
+        chunk
+        async for chunk in resume(
+            session.client,
+            fc_output["call_id"],
+            fc_output["output"],
+            session,
+        )
+    ]
+    assistant_text = backend.parse_message(chunks) or ""
+    if not assistant_text:
+        raise HTTPException(status_code=502, detail="No response from backend")
+```
+
+Use the same response ID, turn counter, usage logging, and streaming/non-streaming output rules already used by the Claude continuation path.
+
+- [ ] **Step 7: Add route-level continuation test**
+
+Add a test that starts with an OpenCode session containing a pending question and then sends `function_call_output`:
+
+```python
+def test_opencode_function_call_output_resumes_question(isolated_session_manager):
+    from src.backends.base import BackendDescriptor, BackendRegistry, ResolvedModel
+    from src.session_manager import session_manager
+
+    session_id = str(uuid.uuid4())
+    session = session_manager.get_or_create_session(session_id)
+    session.backend = "opencode"
+    session.turn_counter = 1
+    session.last_response_id = f"resp_{session_id}_1"
+    session.client = object()
+    session.pending_tool_call = {
+        "call_id": "q1",
+        "name": "question",
+        "arguments": {"question": "Continue?"},
+        "backend": "opencode",
+    }
+
+    def resolve(model):
+        if model == "opencode/openai/gpt-5.5":
+            return ResolvedModel(model, "opencode", "openai/gpt-5.5")
+        return None
+
+    async def resume_question_with_client(client, call_id, output, session):
+        assert call_id == "q1"
+        assert output == "yes"
+        yield {"type": "assistant", "content": [{"type": "text", "text": "continued"}]}
+        yield {"type": "result", "subtype": "success", "result": "continued"}
+
+    backend = MagicMock()
+    backend.name = "opencode"
+    backend.resume_question_with_client = resume_question_with_client
+    backend.parse_message.return_value = "continued"
+    backend.estimate_token_usage.return_value = {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+
+    BackendRegistry.clear()
+    BackendRegistry.register_descriptor(
+        BackendDescriptor("opencode", "opencode", ["opencode/openai/gpt-5.5"], resolve)
+    )
+    BackendRegistry.register("opencode", backend)
+
+    with client_context() as (client, _):
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": "opencode/openai/gpt-5.5",
+                "previous_response_id": session.last_response_id,
+                "input": [{"type": "function_call_output", "call_id": "q1", "output": "yes"}],
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "completed"
+    assert response.json()["output"][0]["content"][0]["text"] == "continued"
+```
+
+- [ ] **Step 8: Run continuation tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_opencode_backend.py tests/test_main_api_unit.py tests/test_ask_user_question.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/backends/opencode/events.py src/backends/opencode/client.py src/routes/responses.py src/session_manager.py tests/test_opencode_backend.py tests/test_main_api_unit.py tests/test_ask_user_question.py
+git commit -m "feat: support opencode question continuation"
+```
+
+---
+
+### Task 4: MCP and OpenCode Config Integration
+
+**Files:**
+- Create: `src/backends/opencode/config.py`
+- Modify: `src/backends/opencode/client.py`
+- Modify: `src/backends/opencode/constants.py`
+- Modify: `src/mcp_config.py`
+- Modify: `.env.example`
+- Modify: `README.md`
+- Test: `tests/test_mcp_config.py`
+- Test: `tests/test_opencode_backend.py`
+
+- [ ] **Step 1: Write failing tests for config generation**
+
+Add tests for converting wrapper MCP config into OpenCode config:
+
+```python
+def test_build_opencode_config_includes_safe_defaults_and_mcp_servers():
+    from src.backends.opencode.config import build_opencode_config
+
+    config = build_opencode_config(
+        base_config={},
+        mcp_servers={
+            "filesystem": {
+                "type": "stdio",
+                "command": "npx",
+                "args": ["-y", "@modelcontextprotocol/server-filesystem", "/workspace"],
+            }
+        },
+        default_model="openai/gpt-5.5",
+        question_permission="deny",
+    )
+
+    assert config["permission"]["question"] == "deny"
+    assert config["share"] == "disabled"
+    assert config["model"] == "openai/gpt-5.5"
+    assert config["mcp"]["filesystem"]["type"] == "stdio"
+    assert config["mcp"]["filesystem"]["command"] == "npx"
+```
+
+```python
+def test_build_opencode_config_preserves_explicit_base_config_over_defaults():
+    from src.backends.opencode.config import build_opencode_config
+
+    config = build_opencode_config(
+        base_config={"share": "enabled", "permission": {"question": "ask"}},
+        mcp_servers={},
+        default_model=None,
+        question_permission="deny",
+    )
+
+    assert config["share"] == "enabled"
+    assert config["permission"]["question"] == "ask"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/test_mcp_config.py::test_build_opencode_config_includes_safe_defaults_and_mcp_servers tests/test_mcp_config.py::test_build_opencode_config_preserves_explicit_base_config_over_defaults -q
+```
+
+Expected: FAIL because `src.backends.opencode.config` does not exist.
+
+- [ ] **Step 3: Create config builder**
+
+Create `src/backends/opencode/config.py`:
+
+```python
+from __future__ import annotations
+
+import copy
+import json
+from typing import Any, Dict, Optional
+
+
+def _deep_merge_missing(target: Dict[str, Any], defaults: Dict[str, Any]) -> Dict[str, Any]:
+    for key, value in defaults.items():
+        if key not in target:
+            target[key] = copy.deepcopy(value)
+            continue
+        if isinstance(target[key], dict) and isinstance(value, dict):
+            _deep_merge_missing(target[key], value)
+    return target
+
+
+def build_opencode_config(
+    *,
+    base_config: Dict[str, Any],
+    mcp_servers: Dict[str, Dict[str, Any]],
+    default_model: Optional[str],
+    question_permission: str,
+) -> Dict[str, Any]:
+    config = copy.deepcopy(base_config)
+    defaults: Dict[str, Any] = {
+        "permission": {"question": question_permission},
+        "share": "disabled",
+    }
+    if default_model:
+        defaults["model"] = default_model
+    _deep_merge_missing(config, defaults)
+    if mcp_servers:
+        config.setdefault("mcp", {})
+        for name, server in mcp_servers.items():
+            config["mcp"].setdefault(name, copy.deepcopy(server))
+    return config
+
+
+def parse_opencode_config_content(content: Optional[str]) -> Dict[str, Any]:
+    if not content:
+        return {}
+    parsed = json.loads(content)
+    if not isinstance(parsed, dict):
+        raise ValueError("OPENCODE_CONFIG_CONTENT must be a JSON object")
+    return parsed
+```
+
+- [ ] **Step 4: Export reusable MCP config**
+
+In `src/mcp_config.py`, keep `get_mcp_servers()` as-is and add:
+
+```python
+def get_validated_mcp_config() -> McpServersDict:
+    """Return the validated wrapper MCP config for backend-specific conversion."""
+    return dict(_server_mcp_config)
+```
+
+Use this helper from OpenCode code rather than re-reading `MCP_CONFIG`.
+
+- [ ] **Step 5: Wire generated config into managed OpenCode startup**
+
+Update `OpenCodeClient._managed_config_content()`:
+
+```python
+def _managed_config_content(self) -> str:
+    from src.backends.opencode.config import (
+        build_opencode_config,
+        parse_opencode_config_content,
+    )
+    from src.mcp_config import get_validated_mcp_config
+
+    base_config = parse_opencode_config_content(os.getenv("OPENCODE_CONFIG_CONTENT"))
+    config = build_opencode_config(
+        base_config=base_config,
+        mcp_servers=get_validated_mcp_config()
+        if os.getenv("OPENCODE_USE_WRAPPER_MCP_CONFIG", "false").lower() == "true"
+        else {},
+        default_model=os.getenv("OPENCODE_DEFAULT_MODEL") or None,
+        question_permission=os.getenv("OPENCODE_QUESTION_PERMISSION", "deny"),
+    )
+    return json.dumps(config)
+```
+
+External server mode should not generate or send config because the gateway does not own that process.
+
+- [ ] **Step 6: Add client-level config test**
+
+Add:
+
+```python
+def test_managed_config_can_include_wrapper_mcp(monkeypatch):
+    monkeypatch.delenv("OPENCODE_CONFIG_CONTENT", raising=False)
+    monkeypatch.setenv("OPENCODE_USE_WRAPPER_MCP_CONFIG", "true")
+    monkeypatch.setenv("OPENCODE_DEFAULT_MODEL", "openai/gpt-5.5")
+    monkeypatch.setattr(
+        "src.mcp_config.get_validated_mcp_config",
+        lambda: {"demo": {"type": "stdio", "command": "uvx", "args": ["demo"]}},
+    )
+
+    from src.backends.opencode.client import OpenCodeClient
+
+    backend = OpenCodeClient(base_url="http://127.0.0.1:4096")
+    config = json.loads(backend._managed_config_content())
+
+    assert config["model"] == "openai/gpt-5.5"
+    assert config["permission"]["question"] == "deny"
+    assert config["mcp"]["demo"]["command"] == "uvx"
+```
+
+- [ ] **Step 7: Document MCP integration controls**
+
+Add to `.env.example`:
+
+```bash
+# Include validated wrapper MCP_CONFIG in managed OpenCode config.
+# External OpenCode servers must be configured separately.
+# OPENCODE_USE_WRAPPER_MCP_CONFIG=false
+# OPENCODE_QUESTION_PERMISSION=deny
+```
+
+Add README notes:
+
+```markdown
+OpenCode MCP integration is available only in managed mode. Set `OPENCODE_USE_WRAPPER_MCP_CONFIG=true` to copy the validated wrapper `MCP_CONFIG` into the generated OpenCode config. External OpenCode servers keep their own config and are not modified by the gateway.
+```
+
+- [ ] **Step 8: Run MCP/config tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_mcp_config.py tests/test_opencode_backend.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Run final verification**
+
+Run:
+
+```bash
+uv run pytest tests/test_opencode_backend.py tests/test_main_api_unit.py tests/test_ask_user_question.py tests/test_mcp_config.py tests/test_admin_service_unit.py -q
+uv run pytest -q
+```
+
+Expected: PASS, with live OpenCode smoke tests skipped unless their env vars are set.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/backends/opencode/config.py src/backends/opencode/client.py src/backends/opencode/constants.py src/mcp_config.py .env.example README.md tests/test_mcp_config.py tests/test_opencode_backend.py
+git commit -m "feat: generate opencode config from wrapper mcp"
+```

--- a/docs/superpowers/plans/2026-04-28-opencode-post-mvp-1-4.md
+++ b/docs/superpowers/plans/2026-04-28-opencode-post-mvp-1-4.md
@@ -1,5 +1,9 @@
 # OpenCode Post-MVP 1-4 Implementation Plan
 
+> **SUPERSEDED:** The current OpenCode backend is managed-only. The earlier
+> dual-mode implementation plan that referenced `OPENCODE_BASE_URL` was
+> replaced; external OpenCode servers are no longer supported.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Complete the first four OpenCode post-MVP tracks: operational hardening, streaming quality, OpenCode question continuation, and MCP/config integration.

--- a/docs/superpowers/specs/2026-04-28-opencode-backend-mvp-design.md
+++ b/docs/superpowers/specs/2026-04-28-opencode-backend-mvp-design.md
@@ -130,10 +130,9 @@ session idle completion.
 The MVP does not map Claude tool names to OpenCode tool names. OpenCode tools
 are controlled through OpenCode config and permissions.
 
-The OpenCode `question` tool is disabled by default in managed config for the
-MVP. The current wrapper `function_call_output` path is Claude hook-specific;
-supporting OpenCode question continuation requires a separate design around
-OpenCode events or TUI control APIs.
+The OpenCode `question` tool is enabled by default in managed config so the
+Responses `function_call_output` continuation path can surface OpenCode
+questions. External OpenCode servers keep their own agent/config settings.
 
 Wrapper `MCP_CONFIG` is not converted in the MVP. Operators can configure
 OpenCode MCP servers through `opencode.json` or `OPENCODE_CONFIG_CONTENT`.
@@ -147,7 +146,7 @@ keys remain OpenCode's responsibility through its normal auth/config system.
 The backend passes selected config to managed OpenCode through
 `OPENCODE_CONFIG_CONTENT`. MVP managed config sets safe defaults:
 
-- `permission.question = "deny"`
+- `permission.question = "ask"`
 - `share = "disabled"`
 - optional `model` if `OPENCODE_DEFAULT_MODEL` is set
 

--- a/docs/superpowers/specs/2026-04-28-opencode-backend-mvp-design.md
+++ b/docs/superpowers/specs/2026-04-28-opencode-backend-mvp-design.md
@@ -1,5 +1,9 @@
 # OpenCode Backend MVP Design
 
+> **SUPERSEDED:** The current OpenCode backend is managed-only. The earlier
+> dual-mode design that referenced `OPENCODE_BASE_URL` was replaced; external
+> OpenCode servers are no longer supported.
+
 Date: 2026-04-28
 
 ## Goal

--- a/docs/superpowers/specs/2026-04-28-opencode-backend-mvp-design.md
+++ b/docs/superpowers/specs/2026-04-28-opencode-backend-mvp-design.md
@@ -1,0 +1,213 @@
+# OpenCode Backend MVP Design
+
+Date: 2026-04-28
+
+## Goal
+
+Add an `opencode` backend to the existing FastAPI gateway so clients can call
+OpenCode through the same `/v1/responses` and `/v1/models` surfaces currently
+used for Claude.
+
+The MVP prioritizes a stable backend integration over full Claude feature
+parity. It must support basic and multi-turn Responses API calls, expose
+configured OpenCode models, and manage or connect to an OpenCode server.
+
+## Non-Goals
+
+The MVP does not implement token-level OpenCode event streaming, OpenCode
+`question` tool continuation, automatic conversion of the existing wrapper
+`MCP_CONFIG` into OpenCode config, or full Docker production hardening. Those
+are follow-up phases after the backend contract is proven.
+
+## Architecture
+
+Add a new backend package:
+
+- `src/backends/opencode/__init__.py` defines the descriptor, model resolver,
+  lazy exports, and `register()`.
+- `src/backends/opencode/client.py` implements the `BackendClient` protocol.
+- `src/backends/opencode/auth.py` implements `BackendAuthProvider`.
+- `src/backends/opencode/constants.py` owns OpenCode env parsing, defaults, and
+  model aliases.
+
+`src/backends/__init__.py::discover_backends()` reads `BACKENDS`, a
+comma-separated backend allowlist. The default is `BACKENDS=claude`, preserving
+the current behavior. Supported values for the MVP are `claude` and `opencode`.
+
+Examples:
+
+```bash
+BACKENDS=claude
+BACKENDS=claude,opencode
+BACKENDS=opencode
+```
+
+The OpenCode backend talks to OpenCode over HTTP with `httpx`. The official
+JS/TS SDK is useful as API reference, but the Python gateway should not add a
+Node helper process just to call the SDK.
+
+## Server Lifecycle
+
+The backend supports two modes:
+
+1. External server mode: when `OPENCODE_BASE_URL` is set, the backend connects
+   to that URL and never starts or stops an OpenCode process.
+2. Managed server mode: when `OPENCODE_BASE_URL` is unset, the backend starts
+   `opencode serve --hostname 127.0.0.1 --port <port>` as a child process.
+
+Defaults:
+
+- `BACKENDS=claude`
+- `OPENCODE_BASE_URL` unset
+- `OPENCODE_HOST=127.0.0.1`
+- `OPENCODE_PORT=0` for managed mode, allowing OpenCode to choose a free port
+- `OPENCODE_START_TIMEOUT_MS=5000`
+
+In managed mode the backend parses the `opencode server listening on ...` line
+from stdout, stores the discovered base URL, verifies `/global/health`, and
+terminates the process during gateway shutdown.
+
+Managed mode requires the `opencode` binary on `PATH`. External server mode does
+not require the binary in the wrapper process environment.
+
+## Model Routing
+
+OpenCode models use `provider/model`. Public wrapper model IDs use an
+`opencode/` prefix:
+
+- `opencode/anthropic/claude-sonnet-4-5`
+- `opencode/openai/gpt-5.1-codex`
+- `opencode/opencode/gpt-5.1-codex`
+
+The resolver maps `opencode/<provider>/<model>` to:
+
+- `backend="opencode"`
+- `provider_model="<provider>/<model>"`
+
+The OpenCode client splits `provider_model` into the body expected by
+`POST /session/{id}/message`:
+
+```json
+{"providerID": "<provider>", "modelID": "<model>"}
+```
+
+`/v1/models` exposes a conservative configured list from
+`OPENCODE_MODELS`, a comma-separated list of full `provider/model` IDs. This
+avoids needing a startup network call to enumerate every provider model.
+
+## Request Flow
+
+For a new `/v1/responses` request using an OpenCode model:
+
+1. The existing route resolves the model to the OpenCode backend.
+2. `create_client()` creates an OpenCode session with the gateway session ID
+   as the stable mapping key and stores the OpenCode session ID on a lightweight
+   client object.
+3. On the first turn, the backend sends the resolved wrapper base system prompt
+   plus request instructions as `system` in the OpenCode prompt body.
+4. `run_completion_with_client()` sends `POST /session/{id}/message`.
+5. The backend converts the returned `{ info, parts }` into gateway-compatible
+   chunk dictionaries.
+6. Existing route code commits `turn_counter`, user message, assistant text,
+   and response ID as it does for Claude.
+
+For a continuation request, the existing `previous_response_id` guard keeps the
+same gateway session and reuses the stored OpenCode session ID.
+
+## Streaming MVP
+
+The MVP supports the wrapper's streaming API shape without OpenCode token-level
+streaming. For `stream=true`, the backend waits for OpenCode's completed
+`session.prompt` response, then yields an assistant chunk. Existing
+`streaming_utils` emits the standard Responses SSE sequence from that chunk.
+
+OpenCode event streaming via `session.prompt_async` and `/event` is a follow-up.
+It needs separate handling for `message.part.updated`, tool events, errors, and
+session idle completion.
+
+## Tools, Questions, and MCP
+
+The MVP does not map Claude tool names to OpenCode tool names. OpenCode tools
+are controlled through OpenCode config and permissions.
+
+The OpenCode `question` tool is disabled by default in managed config for the
+MVP. The current wrapper `function_call_output` path is Claude hook-specific;
+supporting OpenCode question continuation requires a separate design around
+OpenCode events or TUI control APIs.
+
+Wrapper `MCP_CONFIG` is not converted in the MVP. Operators can configure
+OpenCode MCP servers through `opencode.json` or `OPENCODE_CONFIG_CONTENT`.
+
+## Auth and Config
+
+`OpenCodeAuthProvider` validates that the `opencode` binary exists for managed
+mode and that the external server is reachable for external mode. Provider API
+keys remain OpenCode's responsibility through its normal auth/config system.
+
+The backend passes selected config to managed OpenCode through
+`OPENCODE_CONFIG_CONTENT`. MVP managed config sets safe defaults:
+
+- `permission.question = "deny"`
+- `share = "disabled"`
+- optional `model` if `OPENCODE_DEFAULT_MODEL` is set
+
+Existing gateway API key auth remains unchanged.
+
+## Error Handling
+
+Startup:
+
+- If `BACKENDS` does not include `opencode`, no OpenCode descriptor or client
+  is registered.
+- If `BACKENDS` includes `opencode` but startup fails, register the descriptor
+  and log the failure; the live backend is unavailable and requests receive
+  the existing "backend not available" response.
+- If `BACKENDS` contains an unknown backend name, startup logs a clear warning
+  and skips that name. Known backends continue registering.
+
+Requests:
+
+- HTTP errors from OpenCode become backend error chunks with sanitized messages.
+- Empty OpenCode text becomes the existing `No response from backend` path.
+- If the managed child process exits, verification fails and active requests
+  return a backend error.
+- The existing `create_client` failure response is made backend-neutral so
+  OpenCode failures are not reported as Claude SDK failures.
+
+## Testing
+
+Add focused tests for:
+
+- OpenCode descriptor fields and `opencode/<provider>/<model>` resolution.
+- `discover_backends()` registration gated by `BACKENDS`.
+- `src.auth.auth_manager.get_provider("opencode")` returns `OpenCodeAuthProvider`
+  before and after backend registration.
+- Managed server startup parsing with subprocess mocked.
+- External server mode using `OPENCODE_BASE_URL`.
+- `create_client()` and `run_completion_with_client()` using mocked `httpx`.
+- `/v1/models` includes OpenCode models when the backend is registered.
+- `/v1/responses` dispatches to OpenCode and preserves `previous_response_id`
+  turn validation.
+
+## Rollout
+
+The feature is opt-in through `BACKENDS=claude,opencode` or `BACKENDS=opencode`.
+Claude remains the default backend and existing model IDs keep their current
+behavior when `BACKENDS` is unset.
+
+Local development flow:
+
+```bash
+export BACKENDS=claude,opencode
+export OPENCODE_MODELS=anthropic/claude-sonnet-4-5,openai/gpt-5.1-codex
+uv run uvicorn src.main:app --reload --port 8000
+```
+
+External server flow:
+
+```bash
+opencode serve --hostname 127.0.0.1 --port 4096
+export BACKENDS=claude,opencode
+export OPENCODE_BASE_URL=http://127.0.0.1:4096
+uv run uvicorn src.main:app --reload --port 8000
+```

--- a/src/admin_service.py
+++ b/src/admin_service.py
@@ -485,6 +485,7 @@ async def get_backends_health() -> List[Dict[str, Any]]:
     results: List[Dict[str, Any]] = []
     for name in backend_names:
         info: Dict[str, Any] = {"name": name, "registered": False}
+        client = None
 
         # Registration status
         if BackendRegistry.is_registered(name):
@@ -517,6 +518,19 @@ async def get_backends_health() -> List[Dict[str, Any]]:
             }
         except Exception as e:
             info["auth"] = {"valid": False, "method": "unknown", "errors": [str(e)]}
+
+        metadata: Dict[str, Any] = {}
+        runtime_metadata = getattr(client, "runtime_metadata", None) if client else None
+        if callable(runtime_metadata):
+            try:
+                metadata = runtime_metadata()
+            except Exception:
+                logger.warning(
+                    "Failed to collect backend runtime metadata for %s",
+                    name,
+                    exc_info=True,
+                )
+        info["metadata"] = metadata
 
         results.append(info)
 

--- a/src/auth.py
+++ b/src/auth.py
@@ -59,6 +59,12 @@ def _get_claude_auth_provider_class():
     return ClaudeAuthProvider
 
 
+def _get_opencode_auth_provider_class():
+    from src.backends.opencode.auth import OpenCodeAuthProvider
+
+    return OpenCodeAuthProvider
+
+
 # ============================================================================
 # ClaudeCodeAuthManager — backward-compatible gateway auth manager
 # ============================================================================
@@ -107,6 +113,8 @@ class ClaudeCodeAuthManager:
         # Pre-startup / fallback: direct instantiation for known backends
         if backend == "claude":
             return self._claude_provider
+        if backend == "opencode":
+            return _get_opencode_auth_provider_class()()
         raise ValueError(f"Unknown backend: {backend!r}")
 
     # ------------------------------------------------------------------
@@ -265,4 +273,6 @@ def get_all_backends_auth_info() -> Dict[str, Any]:
 def __getattr__(name):
     if name == "ClaudeAuthProvider":
         return _get_claude_auth_provider_class()
+    if name == "OpenCodeAuthProvider":
+        return _get_opencode_auth_provider_class()
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/backends/__init__.py
+++ b/src/backends/__init__.py
@@ -7,6 +7,7 @@ as the primary entry points for ``main.py``.
 from __future__ import annotations
 
 import logging
+import os
 from typing import Optional
 
 from src.backends.base import (  # noqa: F401
@@ -19,14 +20,31 @@ from src.backends.base import (  # noqa: F401
 logger = logging.getLogger(__name__)
 
 
+def _enabled_backend_names() -> list[str]:
+    """Return backend names enabled by BACKENDS, preserving order."""
+    raw = os.getenv("BACKENDS", "claude")
+    names: list[str] = []
+    for item in raw.split(","):
+        name = item.strip().lower()
+        if name and name not in names:
+            names.append(name)
+    return names or ["claude"]
+
+
 def discover_backends(registry_cls=None) -> None:
     """Discover and register all known backends."""
     if registry_cls is None:
         registry_cls = BackendRegistry
 
-    from src.backends.claude import register as register_claude
-
-    register_claude(registry_cls=registry_cls)
+    for name in _enabled_backend_names():
+        if name == "claude":
+            from src.backends import claude as backend_pkg
+        elif name == "opencode":
+            from src.backends import opencode as backend_pkg
+        else:
+            logger.warning("Unknown backend in BACKENDS=%r; skipping", name)
+            continue
+        backend_pkg.register(registry_cls=registry_cls)
 
 
 def resolve_model(model: str) -> Optional[ResolvedModel]:

--- a/src/backends/opencode/__init__.py
+++ b/src/backends/opencode/__init__.py
@@ -1,0 +1,63 @@
+"""OpenCode backend subpackage."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from src.backends.base import BackendDescriptor, BackendRegistry, ResolvedModel
+from src.backends.opencode.constants import OPENCODE_MODELS
+
+logger = logging.getLogger(__name__)
+
+
+def _opencode_resolve(model: str) -> Optional[ResolvedModel]:
+    """Resolve opencode/<provider>/<model> into the OpenCode backend."""
+    prefix = "opencode/"
+    if not model.startswith(prefix):
+        return None
+    provider_model = model[len(prefix) :]
+    if "/" not in provider_model:
+        return None
+    return ResolvedModel(
+        public_model=model,
+        backend="opencode",
+        provider_model=provider_model,
+    )
+
+
+OPENCODE_DESCRIPTOR = BackendDescriptor(
+    name="opencode",
+    owned_by="opencode",
+    models=list(OPENCODE_MODELS),
+    resolve_fn=_opencode_resolve,
+)
+
+
+def __getattr__(name):
+    if name == "OpenCodeClient":
+        from src.backends.opencode.client import OpenCodeClient
+
+        return OpenCodeClient
+    if name == "OpenCodeAuthProvider":
+        from src.backends.opencode.auth import OpenCodeAuthProvider
+
+        return OpenCodeAuthProvider
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def register(registry_cls=None) -> None:
+    """Register OpenCode descriptor and live client when available."""
+    if registry_cls is None:
+        registry_cls = BackendRegistry
+
+    registry_cls.register_descriptor(OPENCODE_DESCRIPTOR)
+
+    try:
+        from src.backends.opencode.client import OpenCodeClient
+
+        client = OpenCodeClient()
+        registry_cls.register("opencode", client)
+        logger.info("Registered backend: opencode")
+    except Exception as exc:
+        logger.error("OpenCode backend client creation failed: %s", exc)

--- a/src/backends/opencode/__init__.py
+++ b/src/backends/opencode/__init__.py
@@ -6,7 +6,7 @@ import logging
 from typing import Optional
 
 from src.backends.base import BackendDescriptor, BackendRegistry, ResolvedModel
-from src.backends.opencode.constants import OPENCODE_MODELS
+from src.backends.opencode.constants import configured_public_models
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +29,7 @@ def _opencode_resolve(model: str) -> Optional[ResolvedModel]:
 OPENCODE_DESCRIPTOR = BackendDescriptor(
     name="opencode",
     owned_by="opencode",
-    models=list(OPENCODE_MODELS),
+    models=configured_public_models(),
     resolve_fn=_opencode_resolve,
 )
 

--- a/src/backends/opencode/auth.py
+++ b/src/backends/opencode/auth.py
@@ -46,6 +46,7 @@ class OpenCodeAuthProvider(BackendAuthProvider):
             "OPENCODE_SERVER_USERNAME",
             "OPENCODE_SERVER_PASSWORD",
             "OPENCODE_CONFIG_CONTENT",
+            "OPENCODE_QUESTION_PERMISSION",
         ):
             value = os.getenv(key)
             if value:

--- a/src/backends/opencode/auth.py
+++ b/src/backends/opencode/auth.py
@@ -1,0 +1,56 @@
+"""OpenCode backend authentication provider."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from typing import Any, Dict, List
+
+from src.auth import BackendAuthProvider
+
+
+class OpenCodeAuthProvider(BackendAuthProvider):
+    """OpenCode backend auth and availability checks."""
+
+    @property
+    def name(self) -> str:
+        return "opencode"
+
+    def validate(self) -> Dict[str, Any]:
+        base_url = os.getenv("OPENCODE_BASE_URL")
+        if base_url:
+            return {
+                "valid": True,
+                "errors": [],
+                "config": {"mode": "external", "base_url": base_url},
+            }
+
+        binary = shutil.which(os.getenv("OPENCODE_BIN", "opencode"))
+        if binary:
+            return {
+                "valid": True,
+                "errors": [],
+                "config": {"mode": "managed", "binary": binary},
+            }
+
+        return {
+            "valid": False,
+            "errors": ["opencode binary not found on PATH"],
+            "config": {"mode": "managed"},
+        }
+
+    def build_env(self) -> Dict[str, str]:
+        env: Dict[str, str] = {}
+        for key in (
+            "OPENCODE_BASE_URL",
+            "OPENCODE_SERVER_USERNAME",
+            "OPENCODE_SERVER_PASSWORD",
+            "OPENCODE_CONFIG_CONTENT",
+        ):
+            value = os.getenv(key)
+            if value:
+                env[key] = value
+        return env
+
+    def get_isolation_vars(self) -> List[str]:
+        return []

--- a/src/backends/opencode/auth.py
+++ b/src/backends/opencode/auth.py
@@ -46,7 +46,9 @@ class OpenCodeAuthProvider(BackendAuthProvider):
             "OPENCODE_SERVER_USERNAME",
             "OPENCODE_SERVER_PASSWORD",
             "OPENCODE_CONFIG_CONTENT",
+            "OPENCODE_DEFAULT_MODEL",
             "OPENCODE_QUESTION_PERMISSION",
+            "OPENCODE_USE_WRAPPER_MCP_CONFIG",
         ):
             value = os.getenv(key)
             if value:

--- a/src/backends/opencode/auth.py
+++ b/src/backends/opencode/auth.py
@@ -17,12 +17,13 @@ class OpenCodeAuthProvider(BackendAuthProvider):
         return "opencode"
 
     def validate(self) -> Dict[str, Any]:
-        base_url = os.getenv("OPENCODE_BASE_URL")
-        if base_url:
+        if os.getenv("OPENCODE_BASE_URL"):
             return {
-                "valid": True,
-                "errors": [],
-                "config": {"mode": "external", "base_url": base_url},
+                "valid": False,
+                "errors": [
+                    "OPENCODE_BASE_URL is no longer supported; unset it to use managed OpenCode"
+                ],
+                "config": {"mode": "managed"},
             }
 
         binary = shutil.which(os.getenv("OPENCODE_BIN", "opencode"))
@@ -42,7 +43,11 @@ class OpenCodeAuthProvider(BackendAuthProvider):
     def build_env(self) -> Dict[str, str]:
         env: Dict[str, str] = {}
         for key in (
-            "OPENCODE_BASE_URL",
+            "OPENCODE_BIN",
+            "OPENCODE_HOST",
+            "OPENCODE_PORT",
+            "OPENCODE_START_TIMEOUT_MS",
+            "OPENCODE_AGENT",
             "OPENCODE_SERVER_USERNAME",
             "OPENCODE_SERVER_PASSWORD",
             "OPENCODE_CONFIG_CONTENT",

--- a/src/backends/opencode/client.py
+++ b/src/backends/opencode/client.py
@@ -466,6 +466,48 @@ class OpenCodeClient:
         yield assistant
         yield result
 
+    async def resume_question_with_client(
+        self,
+        client: OpenCodeSessionClient,
+        call_id: str,
+        output: str,
+        session: Any,
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        """Resume an OpenCode question tool call with the user's answer."""
+        _ = session
+        body: Dict[str, Any] = {
+            "agent": self._agent,
+            "parts": [
+                {
+                    "type": "tool",
+                    "callID": call_id,
+                    "tool": "question",
+                    "state": {"status": "completed", "output": output},
+                }
+            ],
+        }
+        model = self._split_provider_model(client.model)
+        if model:
+            body["model"] = model
+
+        try:
+            async with httpx.AsyncClient(**self._client_kwargs()) as http_client:
+                response = await http_client.post(
+                    f"/session/{client.session_id}/message",
+                    json=body,
+                    params=self._directory_params(client.cwd),
+                )
+                response.raise_for_status()
+                payload = response.json()
+        except Exception as exc:
+            logger.error("OpenCode question continuation failed: %s", exc, exc_info=True)
+            yield {"type": "error", "is_error": True, "error_message": str(exc)}
+            return
+
+        text = self._extract_text(payload)
+        yield {"type": "assistant", "content": [{"type": "text", "text": text}]}
+        yield {"type": "result", "subtype": "success", "result": text}
+
     def parse_message(self, messages: List[Dict[str, Any]]) -> Optional[str]:
         for message in reversed(messages):
             if message.get("type") == "result" and message.get("result"):

--- a/src/backends/opencode/client.py
+++ b/src/backends/opencode/client.py
@@ -20,8 +20,10 @@ from typing import Any, AsyncGenerator, Dict, List, Optional
 
 import httpx
 
+import src.mcp_config as mcp_config
 from src.backends.opencode.auth import OpenCodeAuthProvider
-from src.backends.opencode.constants import OPENCODE_MODELS
+from src.backends.opencode.config import build_opencode_config, parse_opencode_config_content
+from src.backends.opencode.constants import OPENCODE_MODELS, use_wrapper_mcp_config
 from src.backends.opencode.events import OpenCodeEventConverter
 from src.constants import DEFAULT_TIMEOUT_MS
 
@@ -88,17 +90,14 @@ class OpenCodeClient:
         return httpx.BasicAuth(self._server_username, self._server_password)
 
     def _managed_config_content(self) -> str:
-        existing = os.getenv("OPENCODE_CONFIG_CONTENT")
-        if existing:
-            return existing
-
-        config: Dict[str, Any] = {
-            "permission": {"question": os.getenv("OPENCODE_QUESTION_PERMISSION", "ask")},
-            "share": "disabled",
-        }
-        default_model = os.getenv("OPENCODE_DEFAULT_MODEL")
-        if default_model:
-            config["model"] = default_model
+        base_config = parse_opencode_config_content(os.getenv("OPENCODE_CONFIG_CONTENT"))
+        mcp_servers = mcp_config.get_validated_mcp_config() if use_wrapper_mcp_config() else {}
+        config = build_opencode_config(
+            base_config=base_config,
+            mcp_servers=mcp_servers,
+            default_model=os.getenv("OPENCODE_DEFAULT_MODEL") or None,
+            question_permission=os.getenv("OPENCODE_QUESTION_PERMISSION", "ask"),
+        )
         return json.dumps(config)
 
     def _start_managed_server(self) -> str:

--- a/src/backends/opencode/client.py
+++ b/src/backends/opencode/client.py
@@ -1,0 +1,343 @@
+"""OpenCode backend client.
+
+Wraps the OpenCode headless HTTP server into the gateway ``BackendClient``
+protocol.  The official OpenCode SDK is TypeScript; this Python backend talks
+to the same server API directly with httpx.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+import select
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, AsyncGenerator, Dict, List, Optional
+
+import httpx
+
+from src.backends.opencode.auth import OpenCodeAuthProvider
+from src.backends.opencode.constants import OPENCODE_MODELS
+from src.constants import DEFAULT_TIMEOUT_MS
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class OpenCodeSessionClient:
+    """Lightweight handle for one OpenCode session."""
+
+    session_id: str
+    cwd: Optional[str]
+    model: Optional[str]
+    system_prompt: Optional[str]
+
+    async def disconnect(self) -> None:
+        """Compatibility hook for SessionManager cleanup."""
+        return None
+
+
+class OpenCodeClient:
+    """BackendClient implementation for OpenCode."""
+
+    def __init__(
+        self,
+        timeout: Optional[int] = None,
+        base_url: Optional[str] = None,
+    ) -> None:
+        self.timeout = (timeout if timeout is not None else DEFAULT_TIMEOUT_MS) / 1000
+        self.base_url = (base_url or os.getenv("OPENCODE_BASE_URL") or "").rstrip("/")
+        self._process: Optional[subprocess.Popen[str]] = None
+        self._server_username = os.getenv("OPENCODE_SERVER_USERNAME", "opencode")
+        self._server_password = os.getenv("OPENCODE_SERVER_PASSWORD")
+
+        if not self.base_url:
+            self.base_url = self._start_managed_server()
+
+    @property
+    def name(self) -> str:
+        return "opencode"
+
+    def supported_models(self) -> List[str]:
+        return list(OPENCODE_MODELS)
+
+    def get_auth_provider(self):
+        return OpenCodeAuthProvider()
+
+    def _auth(self) -> Optional[httpx.BasicAuth]:
+        if not self._server_password:
+            return None
+        return httpx.BasicAuth(self._server_username, self._server_password)
+
+    def _managed_config_content(self) -> str:
+        existing = os.getenv("OPENCODE_CONFIG_CONTENT")
+        if existing:
+            return existing
+
+        config: Dict[str, Any] = {
+            "permission": {"question": "deny"},
+            "share": "disabled",
+        }
+        default_model = os.getenv("OPENCODE_DEFAULT_MODEL")
+        if default_model:
+            config["model"] = default_model
+        return json.dumps(config)
+
+    def _start_managed_server(self) -> str:
+        binary = os.getenv("OPENCODE_BIN", "opencode")
+        host = os.getenv("OPENCODE_HOST", "127.0.0.1")
+        port = os.getenv("OPENCODE_PORT", "0")
+        timeout_ms = int(os.getenv("OPENCODE_START_TIMEOUT_MS", "5000"))
+        command = [binary, "serve", "--hostname", host, "--port", str(port)]
+        env = {
+            **os.environ,
+            "OPENCODE_CONFIG_CONTENT": self._managed_config_content(),
+        }
+
+        proc = subprocess.Popen(  # noqa: S603 - binary is operator-configured
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+            env=env,
+        )
+        self._process = proc
+
+        if proc.stdout is None:
+            self.close()
+            raise RuntimeError("OpenCode server stdout is unavailable")
+
+        deadline = time.monotonic() + timeout_ms / 1000
+        output: list[str] = []
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                raise RuntimeError(
+                    f"OpenCode server exited with code {proc.returncode}: {''.join(output).strip()}"
+                )
+            remaining = max(0.0, deadline - time.monotonic())
+            readable, _, _ = select.select([proc.stdout], [], [], remaining)
+            if not readable:
+                continue
+            line = proc.stdout.readline()
+            if not line:
+                continue
+            output.append(line)
+            match = re.search(r"opencode server listening on\s+(https?://\S+)", line)
+            if match:
+                return match.group(1).rstrip("/")
+
+        self.close()
+        raise TimeoutError(
+            f"Timeout waiting for OpenCode server after {timeout_ms}ms: "
+            f"{''.join(output).strip()}"
+        )
+
+    def close(self) -> None:
+        """Stop a managed OpenCode server if this backend owns one."""
+        proc = self._process
+        if proc is None:
+            return
+        self._process = None
+        if proc.poll() is not None:
+            return
+        proc.terminate()
+        try:
+            proc.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=3)
+
+    shutdown = close
+
+    def _client_kwargs(self) -> Dict[str, Any]:
+        kwargs: Dict[str, Any] = {"base_url": self.base_url, "timeout": self.timeout}
+        auth = self._auth()
+        if auth is not None:
+            kwargs["auth"] = auth
+        return kwargs
+
+    def _directory_params(self, cwd: Optional[str]) -> Optional[Dict[str, str]]:
+        if not cwd:
+            return None
+        return {"directory": cwd}
+
+    def _combine_system_prompt(
+        self,
+        custom_base: Optional[str],
+        system_prompt: Optional[str],
+    ) -> Optional[str]:
+        if custom_base and system_prompt:
+            return f"{custom_base}\n\n{system_prompt}"
+        return custom_base or system_prompt
+
+    def _split_provider_model(self, model: Optional[str]) -> Optional[Dict[str, str]]:
+        if not model or "/" not in model:
+            return None
+        provider_id, model_id = model.split("/", 1)
+        return {"providerID": provider_id, "modelID": model_id}
+
+    async def verify(self) -> bool:
+        try:
+            async with httpx.AsyncClient(**self._client_kwargs()) as client:
+                response = await client.get("/global/health")
+                response.raise_for_status()
+                payload = response.json()
+                return bool(payload.get("healthy", True))
+        except Exception as exc:
+            logger.error("OpenCode backend verification failed: %s", exc)
+            return False
+
+    async def create_client(
+        self,
+        *,
+        session: Any,
+        model: Optional[str] = None,
+        system_prompt: Optional[str] = None,
+        allowed_tools: Optional[List[str]] = None,
+        disallowed_tools: Optional[List[str]] = None,
+        permission_mode: Optional[str] = None,
+        mcp_servers: Optional[Dict[str, Any]] = None,
+        task_budget: Optional[int] = None,
+        cwd: Optional[str] = None,
+        extra_env: Optional[Dict[str, str]] = None,
+        _custom_base: Any = None,
+    ) -> OpenCodeSessionClient:
+        _ = (allowed_tools, disallowed_tools, permission_mode, mcp_servers, task_budget, extra_env)
+        opencode_session_id = getattr(session, "opencode_session_id", None)
+        if opencode_session_id is None:
+            async with httpx.AsyncClient(**self._client_kwargs()) as client:
+                response = await client.post(
+                    "/session",
+                    json={"title": session.session_id},
+                    params=self._directory_params(cwd),
+                )
+                response.raise_for_status()
+                payload = response.json()
+            opencode_session_id = payload["id"]
+            setattr(session, "opencode_session_id", opencode_session_id)
+
+        return OpenCodeSessionClient(
+            session_id=opencode_session_id,
+            cwd=str(Path(cwd)) if cwd else None,
+            model=model,
+            system_prompt=self._combine_system_prompt(_custom_base, system_prompt),
+        )
+
+    def _extract_text(self, payload: Dict[str, Any]) -> str:
+        parts = payload.get("parts")
+        if not isinstance(parts, list):
+            return ""
+        text_parts = [
+            part.get("text", "")
+            for part in parts
+            if isinstance(part, dict) and part.get("type") == "text" and part.get("text")
+        ]
+        return "".join(text_parts)
+
+    def _extract_usage(self, payload: Dict[str, Any]) -> Optional[Dict[str, int]]:
+        info = payload.get("info")
+        if not isinstance(info, dict):
+            return None
+        tokens = info.get("tokens")
+        if not isinstance(tokens, dict):
+            return None
+        input_tokens = int(tokens.get("input") or 0)
+        output_tokens = int(tokens.get("output") or 0)
+        reasoning_tokens = int(tokens.get("reasoning") or 0)
+        return {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "total_tokens": input_tokens + output_tokens + reasoning_tokens,
+        }
+
+    async def run_completion_with_client(
+        self,
+        client: OpenCodeSessionClient,
+        prompt: str,
+        session: Any,
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        _ = session
+        body: Dict[str, Any] = {"parts": [{"type": "text", "text": prompt}]}
+        model = self._split_provider_model(client.model)
+        if model:
+            body["model"] = model
+        if client.system_prompt:
+            body["system"] = client.system_prompt
+
+        try:
+            async with httpx.AsyncClient(**self._client_kwargs()) as http_client:
+                response = await http_client.post(
+                    f"/session/{client.session_id}/message",
+                    json=body,
+                    params=self._directory_params(client.cwd),
+                )
+                response.raise_for_status()
+                payload = response.json()
+        except Exception as exc:
+            logger.error("OpenCode session prompt failed: %s", exc, exc_info=True)
+            yield {"type": "error", "is_error": True, "error_message": str(exc)}
+            return
+
+        info = payload.get("info")
+        if isinstance(info, dict) and info.get("error"):
+            yield {
+                "type": "error",
+                "is_error": True,
+                "error_message": str(info["error"]),
+            }
+            return
+
+        text = self._extract_text(payload)
+        usage = self._extract_usage(payload)
+        assistant: Dict[str, Any] = {
+            "type": "assistant",
+            "content": [{"type": "text", "text": text}],
+        }
+        result: Dict[str, Any] = {"type": "result", "subtype": "success", "result": text}
+        if usage:
+            assistant["usage"] = {
+                "input_tokens": usage["input_tokens"],
+                "output_tokens": usage["output_tokens"],
+            }
+            result["usage"] = {
+                "input_tokens": usage["input_tokens"],
+                "output_tokens": usage["output_tokens"],
+            }
+
+        yield assistant
+        yield result
+
+    def parse_message(self, messages: List[Dict[str, Any]]) -> Optional[str]:
+        for message in reversed(messages):
+            if message.get("type") == "result" and message.get("result"):
+                return message["result"]
+        parts: list[str] = []
+        for message in messages:
+            content = message.get("content")
+            if not isinstance(content, list):
+                continue
+            for part in content:
+                if isinstance(part, dict) and part.get("type") == "text" and part.get("text"):
+                    parts.append(part["text"])
+        return "".join(parts) if parts else None
+
+    def estimate_token_usage(
+        self,
+        prompt: str,
+        completion: str,
+        model: Optional[str] = None,
+    ) -> Dict[str, int]:
+        _ = model
+        prompt_tokens = max(1, len(prompt) // 4)
+        completion_tokens = max(1, len(completion) // 4)
+        return {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        }

--- a/src/backends/opencode/client.py
+++ b/src/backends/opencode/client.py
@@ -85,7 +85,7 @@ class OpenCodeClient:
 
     def runtime_metadata(self) -> Dict[str, Any]:
         """Return operational details for admin diagnostics."""
-        mode = "external" if os.getenv("OPENCODE_BASE_URL") else "managed"
+        mode = "managed" if self._process is not None else "external"
         return {
             "mode": mode,
             "base_url": self.base_url,

--- a/src/backends/opencode/client.py
+++ b/src/backends/opencode/client.py
@@ -7,6 +7,8 @@ to the same server API directly with httpx.
 
 from __future__ import annotations
 
+import asyncio
+import base64
 import json
 import logging
 import os
@@ -29,6 +31,17 @@ from src.constants import DEFAULT_TIMEOUT_MS
 
 logger = logging.getLogger(__name__)
 
+_ATTACHED_IMAGE_RE = re.compile(r'<attached_image\s+path="([^"]+)"\s*/>')
+_IMAGE_FILE_RE = re.compile(r"^img_[0-9a-f]{16}\.(?:png|jpg|jpeg|gif|webp)$")
+_IMAGE_MIME_BY_SUFFIX = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+}
+_PERMISSION_REPLIES = {"once", "always", "reject"}
+
 
 @dataclass
 class OpenCodeSessionClient:
@@ -39,10 +52,31 @@ class OpenCodeSessionClient:
     model: Optional[str]
     system_prompt: Optional[str]
     stream_events: bool = False
+    base_url: Optional[str] = None
+    timeout: Optional[float] = None
+    auth: Optional[httpx.Auth] = None
 
     async def disconnect(self) -> None:
-        """Compatibility hook for SessionManager cleanup."""
-        return None
+        """Delete the OpenCode session when the gateway session is cleaned up."""
+        if not self.base_url:
+            return
+        kwargs: Dict[str, Any] = {"base_url": self.base_url}
+        if self.timeout is not None:
+            kwargs["timeout"] = self.timeout
+        if self.auth is not None:
+            kwargs["auth"] = self.auth
+
+        try:
+            async with httpx.AsyncClient(**kwargs) as client:
+                response = await client.delete(
+                    f"/session/{self.session_id}",
+                    params={"directory": self.cwd} if self.cwd else None,
+                )
+                if getattr(response, "status_code", None) == 404:
+                    return
+                response.raise_for_status()
+        except Exception:
+            logger.warning("OpenCode session delete failed for %s", self.session_id, exc_info=True)
 
 
 class OpenCodeClient:
@@ -146,8 +180,7 @@ class OpenCodeClient:
 
         self.close()
         raise TimeoutError(
-            f"Timeout waiting for OpenCode server after {timeout_ms}ms: "
-            f"{''.join(output).strip()}"
+            f"Timeout waiting for OpenCode server after {timeout_ms}ms: {''.join(output).strip()}"
         )
 
     def close(self) -> None:
@@ -249,6 +282,9 @@ class OpenCodeClient:
             cwd=str(Path(cwd)) if cwd else None,
             model=model,
             system_prompt=self._combine_system_prompt(_custom_base, system_prompt),
+            base_url=self.base_url,
+            timeout=self.timeout,
+            auth=self._auth(),
         )
 
     def _extract_text(self, payload: Dict[str, Any]) -> str:
@@ -291,7 +327,7 @@ class OpenCodeClient:
     def _prompt_body(self, client: OpenCodeSessionClient, prompt: str) -> Dict[str, Any]:
         body: Dict[str, Any] = {
             "agent": self._agent,
-            "parts": [{"type": "text", "text": prompt}],
+            "parts": self._prompt_parts(prompt, client.cwd),
         }
         model = self._split_provider_model(client.model)
         if model:
@@ -299,6 +335,60 @@ class OpenCodeClient:
         if client.system_prompt:
             body["system"] = client.system_prompt
         return body
+
+    async def _prompt_body_async(
+        self,
+        client: OpenCodeSessionClient,
+        prompt: str,
+    ) -> Dict[str, Any]:
+        return await asyncio.to_thread(self._prompt_body, client, prompt)
+
+    def _prompt_parts(self, prompt: str, cwd: Optional[str]) -> List[Dict[str, Any]]:
+        parts: List[Dict[str, Any]] = []
+        cursor = 0
+        for match in _ATTACHED_IMAGE_RE.finditer(prompt):
+            raw_path = match.group(1)
+            file_part = self._file_part_from_path(raw_path, cwd)
+            if file_part is None:
+                logger.warning("OpenCode dropped untrusted attached_image marker: %s", raw_path)
+                continue
+            if match.start() > cursor:
+                parts.append({"type": "text", "text": prompt[cursor : match.start()]})
+            parts.append(file_part)
+            cursor = match.end()
+
+        if cursor < len(prompt) or not parts:
+            parts.append({"type": "text", "text": prompt[cursor:]})
+        return parts
+
+    def _trusted_attached_image_path(self, raw_path: str, cwd: Optional[str]) -> Optional[Path]:
+        if not cwd:
+            return None
+        try:
+            path = Path(raw_path).resolve(strict=True)
+            image_dir = (Path(cwd).resolve() / ".claude_images").resolve()
+        except (OSError, RuntimeError):
+            return None
+        if not path.is_file() or path.parent != image_dir:
+            return None
+        if path.suffix.lower() not in _IMAGE_MIME_BY_SUFFIX:
+            return None
+        if not _IMAGE_FILE_RE.fullmatch(path.name):
+            return None
+        return path
+
+    def _file_part_from_path(self, raw_path: str, cwd: Optional[str]) -> Optional[Dict[str, Any]]:
+        path = self._trusted_attached_image_path(raw_path, cwd)
+        if path is None:
+            return None
+        mime = _IMAGE_MIME_BY_SUFFIX.get(path.suffix.lower(), "application/octet-stream")
+        encoded = base64.b64encode(path.read_bytes()).decode("ascii")
+        return {
+            "type": "file",
+            "mime": mime,
+            "filename": path.name,
+            "url": f"data:{mime};base64,{encoded}",
+        }
 
     def _question_reply_body(self, output: str) -> Dict[str, Any]:
         answers: list[list[str]]
@@ -318,6 +408,45 @@ class OpenCodeClient:
         else:
             answers = [[str(output)]]
         return {"answers": answers}
+
+    def _permission_reply_body(self, output: str) -> Dict[str, Any]:
+        try:
+            parsed = json.loads(output)
+        except json.JSONDecodeError:
+            parsed = output
+
+        message: Optional[str] = None
+        candidates: list[str] = []
+        if isinstance(parsed, dict):
+            for key in ("reply", "answer", "output"):
+                value = parsed.get(key)
+                if isinstance(value, str):
+                    candidates.append(value)
+            value = parsed.get("message")
+            if isinstance(value, str) and value:
+                message = value
+        elif isinstance(parsed, list):
+            candidates.extend(item for item in parsed if isinstance(item, str))
+        elif isinstance(parsed, str):
+            candidates.append(parsed)
+
+        reply: Optional[str] = None
+        for candidate in candidates:
+            normalized = candidate.strip().lower()
+            if normalized in _PERMISSION_REPLIES:
+                reply = normalized
+                break
+            if normalized in {"yes", "y", "allow", "approve", "approved", "ok", "okay"}:
+                reply = "once"
+                break
+            if normalized in {"no", "n", "deny", "denied", "reject", "rejected"}:
+                reply = "reject"
+                break
+
+        body = {"reply": reply or "reject"}
+        if message:
+            body["message"] = message
+        return body
 
     def _describe_http_error(self, response: Any) -> str:
         status = getattr(response, "status_code", "unknown")
@@ -369,7 +498,7 @@ class OpenCodeClient:
         client: OpenCodeSessionClient,
         prompt: str,
     ) -> AsyncGenerator[Dict[str, Any], None]:
-        body = self._prompt_body(client, prompt)
+        body = await self._prompt_body_async(client, prompt)
         converter = OpenCodeEventConverter(session_id=client.session_id)
 
         try:
@@ -437,7 +566,7 @@ class OpenCodeClient:
                 yield chunk
             return
 
-        body = self._prompt_body(client, prompt)
+        body = await self._prompt_body_async(client, prompt)
 
         try:
             async with httpx.AsyncClient(**self._client_kwargs()) as http_client:
@@ -488,16 +617,15 @@ class OpenCodeClient:
         yield assistant
         yield result
 
-    async def resume_question_with_client(
+    async def _resume_with_client(
         self,
         client: OpenCodeSessionClient,
-        call_id: str,
-        output: str,
+        reply_path: str,
+        reply_body: Dict[str, Any],
         session: Any,
+        label: str,
     ) -> AsyncGenerator[Dict[str, Any], None]:
-        """Resume an OpenCode question tool call with the user's answer."""
         _ = session
-        request_id = call_id
         converter = OpenCodeEventConverter(session_id=client.session_id)
         try:
             async with httpx.AsyncClient(**self._event_client_kwargs()) as event_client:
@@ -509,8 +637,8 @@ class OpenCodeClient:
                     event_response.raise_for_status()
                     async with httpx.AsyncClient(**self._client_kwargs()) as reply_client:
                         response = await reply_client.post(
-                            f"/question/{request_id}/reply",
-                            json=self._question_reply_body(output),
+                            reply_path,
+                            json=reply_body,
                             params=self._directory_params(client.cwd),
                         )
                         try:
@@ -532,13 +660,47 @@ class OpenCodeClient:
                         for chunk in converter.convert(event):
                             yield chunk
         except Exception as exc:
-            logger.error("OpenCode question continuation failed: %s", exc, exc_info=True)
+            logger.error("OpenCode %s continuation failed: %s", label, exc, exc_info=True)
             yield {"type": "error", "is_error": True, "error_message": str(exc)}
             return
 
         text = converter.final_text()
         yield {"type": "assistant", "content": [{"type": "text", "text": text}]}
         yield {"type": "result", "subtype": "success", "result": text}
+
+    async def resume_question_with_client(
+        self,
+        client: OpenCodeSessionClient,
+        call_id: str,
+        output: str,
+        session: Any,
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        """Resume an OpenCode question tool call with the user's answer."""
+        async for chunk in self._resume_with_client(
+            client,
+            f"/question/{call_id}/reply",
+            self._question_reply_body(output),
+            session,
+            "question",
+        ):
+            yield chunk
+
+    async def resume_permission_with_client(
+        self,
+        client: OpenCodeSessionClient,
+        call_id: str,
+        output: str,
+        session: Any,
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        """Resume an OpenCode permission prompt with the user's decision."""
+        async for chunk in self._resume_with_client(
+            client,
+            f"/permission/{call_id}/reply",
+            self._permission_reply_body(output),
+            session,
+            "permission",
+        ):
+            yield chunk
 
     def parse_message(self, messages: List[Dict[str, Any]]) -> Optional[str]:
         for message in reversed(messages):

--- a/src/backends/opencode/client.py
+++ b/src/backends/opencode/client.py
@@ -36,10 +36,23 @@ class OpenCodeSessionClient:
     cwd: Optional[str]
     model: Optional[str]
     system_prompt: Optional[str]
+    stream_events: bool = False
 
     async def disconnect(self) -> None:
         """Compatibility hook for SessionManager cleanup."""
         return None
+
+
+@dataclass
+class OpenCodeStreamState:
+    """Mutable state used while converting OpenCode events to gateway chunks."""
+
+    text_by_part: Dict[str, str]
+    text_parts: List[str]
+    emitted_tool_uses: set[str]
+    emitted_tool_results: set[str]
+    usage: Optional[Dict[str, int]]
+    saw_activity: bool
 
 
 class OpenCodeClient:
@@ -163,6 +176,16 @@ class OpenCodeClient:
             kwargs["auth"] = auth
         return kwargs
 
+    def _event_client_kwargs(self) -> Dict[str, Any]:
+        kwargs = self._client_kwargs()
+        kwargs["timeout"] = httpx.Timeout(
+            connect=self.timeout,
+            read=None,
+            write=self.timeout,
+            pool=self.timeout,
+        )
+        return kwargs
+
     def _directory_params(self, cwd: Optional[str]) -> Optional[Dict[str, str]]:
         if not cwd:
             return None
@@ -267,13 +290,7 @@ class OpenCodeClient:
             f"(status={status}, content-type={content_type}, body={body!r})"
         )
 
-    async def run_completion_with_client(
-        self,
-        client: OpenCodeSessionClient,
-        prompt: str,
-        session: Any,
-    ) -> AsyncGenerator[Dict[str, Any], None]:
-        _ = session
+    def _prompt_body(self, client: OpenCodeSessionClient, prompt: str) -> Dict[str, Any]:
         body: Dict[str, Any] = {
             "agent": self._agent,
             "parts": [{"type": "text", "text": prompt}],
@@ -283,6 +300,339 @@ class OpenCodeClient:
             body["model"] = model
         if client.system_prompt:
             body["system"] = client.system_prompt
+        return body
+
+    async def _iter_sse_events(self, response: Any) -> AsyncGenerator[Dict[str, Any], None]:
+        event_type: Optional[str] = None
+        data_lines: list[str] = []
+
+        def flush() -> Optional[Dict[str, Any]]:
+            if not data_lines:
+                return None
+            raw = "\n".join(data_lines)
+            try:
+                event = json.loads(raw)
+            except json.JSONDecodeError:
+                logger.debug("Ignoring non-JSON OpenCode SSE data: %r", raw[:200])
+                return None
+            if event_type and isinstance(event, dict) and not event.get("type"):
+                event["type"] = event_type
+            return event if isinstance(event, dict) else None
+
+        async for line in response.aiter_lines():
+            if line == "":
+                event = flush()
+                if event:
+                    yield event
+                event_type = None
+                data_lines = []
+                continue
+            if line.startswith(":"):
+                continue
+            if line.startswith("event:"):
+                event_type = line[len("event:") :].strip()
+                continue
+            if line.startswith("data:"):
+                data_lines.append(line[len("data:") :].lstrip())
+                continue
+            if line.startswith("{"):
+                data_lines.append(line)
+
+        event = flush()
+        if event:
+            yield event
+
+    def _text_delta_chunk(self, delta: str) -> Dict[str, Any]:
+        return {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": delta},
+            },
+        }
+
+    def _event_session_id(self, event: Dict[str, Any]) -> Optional[str]:
+        props = event.get("properties")
+        if not isinstance(props, dict):
+            return None
+        if isinstance(props.get("sessionID"), str):
+            return props["sessionID"]
+        part = props.get("part")
+        if isinstance(part, dict) and isinstance(part.get("sessionID"), str):
+            return part["sessionID"]
+        return None
+
+    def _event_finished(
+        self,
+        event: Dict[str, Any],
+        session_id: str,
+        state: OpenCodeStreamState,
+    ) -> bool:
+        if event.get("type") != "session.idle":
+            return False
+        event_session = self._event_session_id(event)
+        return event_session == session_id and state.saw_activity
+
+    def _event_error_message(self, event: Dict[str, Any], session_id: str) -> Optional[str]:
+        if event.get("type") != "session.error":
+            return None
+        event_session = self._event_session_id(event)
+        if event_session not in (None, session_id):
+            return None
+        props = event.get("properties") if isinstance(event.get("properties"), dict) else {}
+        error = props.get("error") or props.get("message") or props
+        return str(error)
+
+    def _convert_text_event(
+        self,
+        event: Dict[str, Any],
+        state: OpenCodeStreamState,
+    ) -> Optional[Dict[str, Any]]:
+        event_type = event.get("type")
+        props = event.get("properties") if isinstance(event.get("properties"), dict) else {}
+
+        if event_type == "message.part.delta":
+            if props.get("field") not in (None, "text"):
+                return None
+            delta = props.get("delta")
+            if not isinstance(delta, str) or not delta:
+                return None
+            part_id = str(props.get("partID") or props.get("partId") or "")
+            if part_id:
+                state.text_by_part[part_id] = state.text_by_part.get(part_id, "") + delta
+            state.text_parts.append(delta)
+            state.saw_activity = True
+            return self._text_delta_chunk(delta)
+
+        if event_type != "message.part.updated":
+            return None
+
+        delta = props.get("delta")
+        part = props.get("part")
+        if not isinstance(part, dict) or part.get("type") != "text":
+            return None
+
+        part_id = str(part.get("id") or "")
+        if isinstance(delta, str) and delta:
+            if part_id:
+                state.text_by_part[part_id] = state.text_by_part.get(part_id, "") + delta
+            state.text_parts.append(delta)
+            state.saw_activity = True
+            return self._text_delta_chunk(delta)
+
+        text = part.get("text")
+        if not isinstance(text, str) or not text:
+            return None
+        previous = state.text_by_part.get(part_id, "") if part_id else ""
+        if previous and text.startswith(previous):
+            computed_delta = text[len(previous) :]
+        elif text != previous:
+            computed_delta = text
+        else:
+            computed_delta = ""
+        if part_id:
+            state.text_by_part[part_id] = text
+        if not computed_delta:
+            return None
+        state.text_parts.append(computed_delta)
+        state.saw_activity = True
+        return self._text_delta_chunk(computed_delta)
+
+    def _convert_usage_event(
+        self,
+        event: Dict[str, Any],
+        state: OpenCodeStreamState,
+    ) -> None:
+        if event.get("type") != "message.part.updated":
+            return
+        props = event.get("properties") if isinstance(event.get("properties"), dict) else {}
+        part = props.get("part")
+        if not isinstance(part, dict) or part.get("type") != "step-finish":
+            return
+        tokens = part.get("tokens")
+        if not isinstance(tokens, dict):
+            return
+        cache = tokens.get("cache") if isinstance(tokens.get("cache"), dict) else {}
+        input_tokens = int(tokens.get("input") or 0)
+        input_tokens += int(cache.get("read") or 0)
+        input_tokens += int(cache.get("write") or 0)
+        output_tokens = int(tokens.get("output") or 0)
+        reasoning_tokens = int(tokens.get("reasoning") or 0)
+        state.usage = {
+            "input_tokens": (state.usage or {}).get("input_tokens", 0) + input_tokens,
+            "output_tokens": (state.usage or {}).get("output_tokens", 0) + output_tokens,
+            "total_tokens": (
+                (state.usage or {}).get("total_tokens", 0)
+                + input_tokens
+                + output_tokens
+                + reasoning_tokens
+            ),
+        }
+        state.saw_activity = True
+
+    def _convert_tool_event(
+        self,
+        event: Dict[str, Any],
+        state: OpenCodeStreamState,
+    ) -> list[Dict[str, Any]]:
+        if event.get("type") != "message.part.updated":
+            return []
+        props = event.get("properties") if isinstance(event.get("properties"), dict) else {}
+        part = props.get("part")
+        if not isinstance(part, dict) or part.get("type") != "tool":
+            return []
+
+        tool_state = part.get("state")
+        if not isinstance(tool_state, dict):
+            return []
+        call_id = str(part.get("callID") or part.get("callId") or part.get("id") or "")
+        if not call_id:
+            return []
+        status = tool_state.get("status")
+        chunks: list[Dict[str, Any]] = []
+
+        input_value = tool_state.get("input")
+        has_input = bool(input_value)
+        should_emit_use = (
+            status in ("running", "completed", "error")
+            or (status == "pending" and has_input)
+        )
+        if should_emit_use and call_id not in state.emitted_tool_uses:
+            chunks.append(
+                {
+                    "type": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": call_id,
+                            "name": str(part.get("tool") or "unknown"),
+                            "input": input_value or {},
+                        }
+                    ],
+                }
+            )
+            state.emitted_tool_uses.add(call_id)
+            state.saw_activity = True
+
+        if status in ("completed", "error") and call_id not in state.emitted_tool_results:
+            is_error = status == "error"
+            content = tool_state.get("error") if is_error else tool_state.get("output")
+            chunks.append(
+                {
+                    "type": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": call_id,
+                            "content": "" if content is None else str(content),
+                            "is_error": is_error,
+                        }
+                    ],
+                }
+            )
+            state.emitted_tool_results.add(call_id)
+            state.saw_activity = True
+
+        return chunks
+
+    def _convert_opencode_event(
+        self,
+        event: Dict[str, Any],
+        client: OpenCodeSessionClient,
+        state: OpenCodeStreamState,
+    ) -> list[Dict[str, Any]]:
+        event_session = self._event_session_id(event)
+        if event_session != client.session_id:
+            return []
+
+        chunks: list[Dict[str, Any]] = []
+        self._convert_usage_event(event, state)
+        text_chunk = self._convert_text_event(event, state)
+        if text_chunk:
+            chunks.append(text_chunk)
+        chunks.extend(self._convert_tool_event(event, state))
+        return chunks
+
+    async def _run_completion_streaming(
+        self,
+        client: OpenCodeSessionClient,
+        prompt: str,
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        body = self._prompt_body(client, prompt)
+        state = OpenCodeStreamState(
+            text_by_part={},
+            text_parts=[],
+            emitted_tool_uses=set(),
+            emitted_tool_results=set(),
+            usage=None,
+            saw_activity=False,
+        )
+
+        try:
+            async with httpx.AsyncClient(**self._event_client_kwargs()) as event_client:
+                async with event_client.stream(
+                    "GET",
+                    "/event",
+                    params=self._directory_params(client.cwd),
+                ) as event_response:
+                    event_response.raise_for_status()
+                    async with httpx.AsyncClient(**self._client_kwargs()) as prompt_client:
+                        response = await prompt_client.post(
+                            f"/session/{client.session_id}/prompt_async",
+                            json=body,
+                            params=self._directory_params(client.cwd),
+                        )
+                        response.raise_for_status()
+
+                    async for event in self._iter_sse_events(event_response):
+                        error_message = self._event_error_message(event, client.session_id)
+                        if error_message:
+                            yield {
+                                "type": "error",
+                                "is_error": True,
+                                "error_message": error_message,
+                            }
+                            return
+                        if self._event_finished(event, client.session_id, state):
+                            break
+                        for chunk in self._convert_opencode_event(event, client, state):
+                            yield chunk
+        except Exception as exc:
+            logger.error("OpenCode streaming prompt failed: %s", exc, exc_info=True)
+            yield {"type": "error", "is_error": True, "error_message": str(exc)}
+            return
+
+        text = "".join(state.text_parts)
+        assistant: Dict[str, Any] = {
+            "type": "assistant",
+            "content": [{"type": "text", "text": text}],
+        }
+        result: Dict[str, Any] = {"type": "result", "subtype": "success", "result": text}
+        if state.usage:
+            assistant["usage"] = {
+                "input_tokens": state.usage["input_tokens"],
+                "output_tokens": state.usage["output_tokens"],
+            }
+            result["usage"] = {
+                "input_tokens": state.usage["input_tokens"],
+                "output_tokens": state.usage["output_tokens"],
+            }
+        yield assistant
+        yield result
+
+    async def run_completion_with_client(
+        self,
+        client: OpenCodeSessionClient,
+        prompt: str,
+        session: Any,
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        _ = session
+        if client.stream_events:
+            async for chunk in self._run_completion_streaming(client, prompt):
+                yield chunk
+            return
+
+        body = self._prompt_body(client, prompt)
 
         try:
             async with httpx.AsyncClient(**self._client_kwargs()) as http_client:

--- a/src/backends/opencode/client.py
+++ b/src/backends/opencode/client.py
@@ -83,6 +83,17 @@ class OpenCodeClient:
     def get_auth_provider(self):
         return OpenCodeAuthProvider()
 
+    def runtime_metadata(self) -> Dict[str, Any]:
+        """Return operational details for admin diagnostics."""
+        mode = "external" if os.getenv("OPENCODE_BASE_URL") else "managed"
+        return {
+            "mode": mode,
+            "base_url": self.base_url,
+            "agent": self._agent,
+            "models": self.supported_models(),
+            "managed_process": self._process is not None,
+        }
+
     def _auth(self) -> Optional[httpx.BasicAuth]:
         if not self._server_password:
             return None

--- a/src/backends/opencode/client.py
+++ b/src/backends/opencode/client.py
@@ -51,17 +51,18 @@ class OpenCodeClient:
     def __init__(
         self,
         timeout: Optional[int] = None,
-        base_url: Optional[str] = None,
     ) -> None:
         self.timeout = (timeout if timeout is not None else DEFAULT_TIMEOUT_MS) / 1000
-        self.base_url = (base_url or os.getenv("OPENCODE_BASE_URL") or "").rstrip("/")
         self._process: Optional[subprocess.Popen[str]] = None
         self._server_username = os.getenv("OPENCODE_SERVER_USERNAME", "opencode")
         self._server_password = os.getenv("OPENCODE_SERVER_PASSWORD")
         self._agent = os.getenv("OPENCODE_AGENT", "general").strip() or "general"
 
-        if not self.base_url:
-            self.base_url = self._start_managed_server()
+        if os.getenv("OPENCODE_BASE_URL"):
+            raise RuntimeError(
+                "OPENCODE_BASE_URL is no longer supported; unset it to use managed OpenCode"
+            )
+        self.base_url = self._start_managed_server()
 
     @property
     def name(self) -> str:
@@ -75,9 +76,8 @@ class OpenCodeClient:
 
     def runtime_metadata(self) -> Dict[str, Any]:
         """Return operational details for admin diagnostics."""
-        mode = "managed" if self._process is not None else "external"
         return {
-            "mode": mode,
+            "mode": "managed",
             "base_url": self.base_url,
             "agent": self._agent,
             "models": self.supported_models(),

--- a/src/backends/opencode/client.py
+++ b/src/backends/opencode/client.py
@@ -301,6 +301,30 @@ class OpenCodeClient:
             body["system"] = client.system_prompt
         return body
 
+    def _question_reply_body(self, output: str) -> Dict[str, Any]:
+        answers: list[list[str]]
+        try:
+            parsed = json.loads(output)
+        except json.JSONDecodeError:
+            parsed = output
+
+        if (
+            isinstance(parsed, list)
+            and all(isinstance(item, list) for item in parsed)
+            and all(isinstance(answer, str) for item in parsed for answer in item)
+        ):
+            answers = [[answer for answer in item] for item in parsed]
+        elif isinstance(parsed, list) and all(isinstance(item, str) for item in parsed):
+            answers = [[item for item in parsed]]
+        else:
+            answers = [[str(output)]]
+        return {"answers": answers}
+
+    def _describe_http_error(self, response: Any) -> str:
+        status = getattr(response, "status_code", "unknown")
+        body = (getattr(response, "text", "") or "")[:500].replace("\n", "\\n")
+        return f"OpenCode HTTP {status}: {body}"
+
     async def _iter_sse_events(self, response: Any) -> AsyncGenerator[Dict[str, Any], None]:
         event_type: Optional[str] = None
         data_lines: list[str] = []
@@ -474,36 +498,46 @@ class OpenCodeClient:
     ) -> AsyncGenerator[Dict[str, Any], None]:
         """Resume an OpenCode question tool call with the user's answer."""
         _ = session
-        body: Dict[str, Any] = {
-            "agent": self._agent,
-            "parts": [
-                {
-                    "type": "tool",
-                    "callID": call_id,
-                    "tool": "question",
-                    "state": {"status": "completed", "output": output},
-                }
-            ],
-        }
-        model = self._split_provider_model(client.model)
-        if model:
-            body["model"] = model
-
+        request_id = call_id
+        converter = OpenCodeEventConverter(session_id=client.session_id)
         try:
-            async with httpx.AsyncClient(**self._client_kwargs()) as http_client:
-                response = await http_client.post(
-                    f"/session/{client.session_id}/message",
-                    json=body,
+            async with httpx.AsyncClient(**self._event_client_kwargs()) as event_client:
+                async with event_client.stream(
+                    "GET",
+                    "/event",
                     params=self._directory_params(client.cwd),
-                )
-                response.raise_for_status()
-                payload = response.json()
+                ) as event_response:
+                    event_response.raise_for_status()
+                    async with httpx.AsyncClient(**self._client_kwargs()) as reply_client:
+                        response = await reply_client.post(
+                            f"/question/{request_id}/reply",
+                            json=self._question_reply_body(output),
+                            params=self._directory_params(client.cwd),
+                        )
+                        try:
+                            response.raise_for_status()
+                        except httpx.HTTPStatusError:
+                            raise RuntimeError(self._describe_http_error(response)) from None
+
+                    async for event in self._iter_sse_events(event_response):
+                        error_message = converter.error_message(event)
+                        if error_message:
+                            yield {
+                                "type": "error",
+                                "is_error": True,
+                                "error_message": error_message,
+                            }
+                            return
+                        if converter.finished(event):
+                            break
+                        for chunk in converter.convert(event):
+                            yield chunk
         except Exception as exc:
             logger.error("OpenCode question continuation failed: %s", exc, exc_info=True)
             yield {"type": "error", "is_error": True, "error_message": str(exc)}
             return
 
-        text = self._extract_text(payload)
+        text = converter.final_text()
         yield {"type": "assistant", "content": [{"type": "text", "text": text}]}
         yield {"type": "result", "subtype": "success", "result": text}
 

--- a/src/backends/opencode/client.py
+++ b/src/backends/opencode/client.py
@@ -23,6 +23,7 @@ import httpx
 
 from src.backends.opencode.auth import OpenCodeAuthProvider
 from src.backends.opencode.constants import OPENCODE_MODELS
+from src.backends.opencode.events import OpenCodeEventConverter
 from src.constants import DEFAULT_TIMEOUT_MS
 
 logger = logging.getLogger(__name__)
@@ -41,18 +42,6 @@ class OpenCodeSessionClient:
     async def disconnect(self) -> None:
         """Compatibility hook for SessionManager cleanup."""
         return None
-
-
-@dataclass
-class OpenCodeStreamState:
-    """Mutable state used while converting OpenCode events to gateway chunks."""
-
-    text_by_part: Dict[str, str]
-    text_parts: List[str]
-    emitted_tool_uses: set[str]
-    emitted_tool_results: set[str]
-    usage: Optional[Dict[str, int]]
-    saw_activity: bool
 
 
 class OpenCodeClient:
@@ -353,231 +342,13 @@ class OpenCodeClient:
         if event:
             yield event
 
-    def _text_delta_chunk(self, delta: str) -> Dict[str, Any]:
-        return {
-            "type": "stream_event",
-            "event": {
-                "type": "content_block_delta",
-                "delta": {"type": "text_delta", "text": delta},
-            },
-        }
-
-    def _event_session_id(self, event: Dict[str, Any]) -> Optional[str]:
-        props = event.get("properties")
-        if not isinstance(props, dict):
-            return None
-        if isinstance(props.get("sessionID"), str):
-            return props["sessionID"]
-        part = props.get("part")
-        if isinstance(part, dict) and isinstance(part.get("sessionID"), str):
-            return part["sessionID"]
-        return None
-
-    def _event_finished(
-        self,
-        event: Dict[str, Any],
-        session_id: str,
-        state: OpenCodeStreamState,
-    ) -> bool:
-        if event.get("type") != "session.idle":
-            return False
-        event_session = self._event_session_id(event)
-        return event_session == session_id and state.saw_activity
-
-    def _event_error_message(self, event: Dict[str, Any], session_id: str) -> Optional[str]:
-        if event.get("type") != "session.error":
-            return None
-        event_session = self._event_session_id(event)
-        if event_session not in (None, session_id):
-            return None
-        props = event.get("properties") if isinstance(event.get("properties"), dict) else {}
-        error = props.get("error") or props.get("message") or props
-        return str(error)
-
-    def _convert_text_event(
-        self,
-        event: Dict[str, Any],
-        state: OpenCodeStreamState,
-    ) -> Optional[Dict[str, Any]]:
-        event_type = event.get("type")
-        props = event.get("properties") if isinstance(event.get("properties"), dict) else {}
-
-        if event_type == "message.part.delta":
-            if props.get("field") not in (None, "text"):
-                return None
-            delta = props.get("delta")
-            if not isinstance(delta, str) or not delta:
-                return None
-            part_id = str(props.get("partID") or props.get("partId") or "")
-            if part_id:
-                state.text_by_part[part_id] = state.text_by_part.get(part_id, "") + delta
-            state.text_parts.append(delta)
-            state.saw_activity = True
-            return self._text_delta_chunk(delta)
-
-        if event_type != "message.part.updated":
-            return None
-
-        delta = props.get("delta")
-        part = props.get("part")
-        if not isinstance(part, dict) or part.get("type") != "text":
-            return None
-
-        part_id = str(part.get("id") or "")
-        if isinstance(delta, str) and delta:
-            if part_id:
-                state.text_by_part[part_id] = state.text_by_part.get(part_id, "") + delta
-            state.text_parts.append(delta)
-            state.saw_activity = True
-            return self._text_delta_chunk(delta)
-
-        text = part.get("text")
-        if not isinstance(text, str) or not text:
-            return None
-        previous = state.text_by_part.get(part_id, "") if part_id else ""
-        if previous and text.startswith(previous):
-            computed_delta = text[len(previous) :]
-        elif text != previous:
-            computed_delta = text
-        else:
-            computed_delta = ""
-        if part_id:
-            state.text_by_part[part_id] = text
-        if not computed_delta:
-            return None
-        state.text_parts.append(computed_delta)
-        state.saw_activity = True
-        return self._text_delta_chunk(computed_delta)
-
-    def _convert_usage_event(
-        self,
-        event: Dict[str, Any],
-        state: OpenCodeStreamState,
-    ) -> None:
-        if event.get("type") != "message.part.updated":
-            return
-        props = event.get("properties") if isinstance(event.get("properties"), dict) else {}
-        part = props.get("part")
-        if not isinstance(part, dict) or part.get("type") != "step-finish":
-            return
-        tokens = part.get("tokens")
-        if not isinstance(tokens, dict):
-            return
-        cache = tokens.get("cache") if isinstance(tokens.get("cache"), dict) else {}
-        input_tokens = int(tokens.get("input") or 0)
-        input_tokens += int(cache.get("read") or 0)
-        input_tokens += int(cache.get("write") or 0)
-        output_tokens = int(tokens.get("output") or 0)
-        reasoning_tokens = int(tokens.get("reasoning") or 0)
-        state.usage = {
-            "input_tokens": (state.usage or {}).get("input_tokens", 0) + input_tokens,
-            "output_tokens": (state.usage or {}).get("output_tokens", 0) + output_tokens,
-            "total_tokens": (
-                (state.usage or {}).get("total_tokens", 0)
-                + input_tokens
-                + output_tokens
-                + reasoning_tokens
-            ),
-        }
-        state.saw_activity = True
-
-    def _convert_tool_event(
-        self,
-        event: Dict[str, Any],
-        state: OpenCodeStreamState,
-    ) -> list[Dict[str, Any]]:
-        if event.get("type") != "message.part.updated":
-            return []
-        props = event.get("properties") if isinstance(event.get("properties"), dict) else {}
-        part = props.get("part")
-        if not isinstance(part, dict) or part.get("type") != "tool":
-            return []
-
-        tool_state = part.get("state")
-        if not isinstance(tool_state, dict):
-            return []
-        call_id = str(part.get("callID") or part.get("callId") or part.get("id") or "")
-        if not call_id:
-            return []
-        status = tool_state.get("status")
-        chunks: list[Dict[str, Any]] = []
-
-        input_value = tool_state.get("input")
-        has_input = bool(input_value)
-        should_emit_use = (
-            status in ("running", "completed", "error")
-            or (status == "pending" and has_input)
-        )
-        if should_emit_use and call_id not in state.emitted_tool_uses:
-            chunks.append(
-                {
-                    "type": "assistant",
-                    "content": [
-                        {
-                            "type": "tool_use",
-                            "id": call_id,
-                            "name": str(part.get("tool") or "unknown"),
-                            "input": input_value or {},
-                        }
-                    ],
-                }
-            )
-            state.emitted_tool_uses.add(call_id)
-            state.saw_activity = True
-
-        if status in ("completed", "error") and call_id not in state.emitted_tool_results:
-            is_error = status == "error"
-            content = tool_state.get("error") if is_error else tool_state.get("output")
-            chunks.append(
-                {
-                    "type": "user",
-                    "content": [
-                        {
-                            "type": "tool_result",
-                            "tool_use_id": call_id,
-                            "content": "" if content is None else str(content),
-                            "is_error": is_error,
-                        }
-                    ],
-                }
-            )
-            state.emitted_tool_results.add(call_id)
-            state.saw_activity = True
-
-        return chunks
-
-    def _convert_opencode_event(
-        self,
-        event: Dict[str, Any],
-        client: OpenCodeSessionClient,
-        state: OpenCodeStreamState,
-    ) -> list[Dict[str, Any]]:
-        event_session = self._event_session_id(event)
-        if event_session != client.session_id:
-            return []
-
-        chunks: list[Dict[str, Any]] = []
-        self._convert_usage_event(event, state)
-        text_chunk = self._convert_text_event(event, state)
-        if text_chunk:
-            chunks.append(text_chunk)
-        chunks.extend(self._convert_tool_event(event, state))
-        return chunks
-
     async def _run_completion_streaming(
         self,
         client: OpenCodeSessionClient,
         prompt: str,
     ) -> AsyncGenerator[Dict[str, Any], None]:
         body = self._prompt_body(client, prompt)
-        state = OpenCodeStreamState(
-            text_by_part={},
-            text_parts=[],
-            emitted_tool_uses=set(),
-            emitted_tool_results=set(),
-            usage=None,
-            saw_activity=False,
-        )
+        converter = OpenCodeEventConverter(session_id=client.session_id)
 
         try:
             async with httpx.AsyncClient(**self._event_client_kwargs()) as event_client:
@@ -596,7 +367,7 @@ class OpenCodeClient:
                         response.raise_for_status()
 
                     async for event in self._iter_sse_events(event_response):
-                        error_message = self._event_error_message(event, client.session_id)
+                        error_message = converter.error_message(event)
                         if error_message:
                             yield {
                                 "type": "error",
@@ -604,29 +375,30 @@ class OpenCodeClient:
                                 "error_message": error_message,
                             }
                             return
-                        if self._event_finished(event, client.session_id, state):
+                        if converter.finished(event):
                             break
-                        for chunk in self._convert_opencode_event(event, client, state):
+                        for chunk in converter.convert(event):
                             yield chunk
         except Exception as exc:
             logger.error("OpenCode streaming prompt failed: %s", exc, exc_info=True)
             yield {"type": "error", "is_error": True, "error_message": str(exc)}
             return
 
-        text = "".join(state.text_parts)
+        text = converter.final_text()
+        usage = converter.usage
         assistant: Dict[str, Any] = {
             "type": "assistant",
             "content": [{"type": "text", "text": text}],
         }
         result: Dict[str, Any] = {"type": "result", "subtype": "success", "result": text}
-        if state.usage:
+        if usage:
             assistant["usage"] = {
-                "input_tokens": state.usage["input_tokens"],
-                "output_tokens": state.usage["output_tokens"],
+                "input_tokens": usage["input_tokens"],
+                "output_tokens": usage["output_tokens"],
             }
             result["usage"] = {
-                "input_tokens": state.usage["input_tokens"],
-                "output_tokens": state.usage["output_tokens"],
+                "input_tokens": usage["input_tokens"],
+                "output_tokens": usage["output_tokens"],
             }
         yield assistant
         yield result

--- a/src/backends/opencode/client.py
+++ b/src/backends/opencode/client.py
@@ -7,7 +7,6 @@ to the same server API directly with httpx.
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 import os
@@ -94,7 +93,7 @@ class OpenCodeClient:
             return existing
 
         config: Dict[str, Any] = {
-            "permission": {"question": "deny"},
+            "permission": {"question": os.getenv("OPENCODE_QUESTION_PERMISSION", "ask")},
             "share": "disabled",
         }
         default_model = os.getenv("OPENCODE_DEFAULT_MODEL")

--- a/src/backends/opencode/client.py
+++ b/src/backends/opencode/client.py
@@ -55,6 +55,7 @@ class OpenCodeClient:
         self._process: Optional[subprocess.Popen[str]] = None
         self._server_username = os.getenv("OPENCODE_SERVER_USERNAME", "opencode")
         self._server_password = os.getenv("OPENCODE_SERVER_PASSWORD")
+        self._agent = os.getenv("OPENCODE_AGENT", "general").strip() or "general"
 
         if not self.base_url:
             self.base_url = self._start_managed_server()
@@ -256,6 +257,16 @@ class OpenCodeClient:
             "total_tokens": input_tokens + output_tokens + reasoning_tokens,
         }
 
+    def _describe_non_json_response(self, response: Any) -> str:
+        status = getattr(response, "status_code", "unknown")
+        headers = getattr(response, "headers", {}) or {}
+        content_type = headers.get("content-type", "unknown")
+        body = (getattr(response, "text", "") or "")[:200].replace("\n", "\\n")
+        return (
+            "OpenCode returned an empty or non-JSON response "
+            f"(status={status}, content-type={content_type}, body={body!r})"
+        )
+
     async def run_completion_with_client(
         self,
         client: OpenCodeSessionClient,
@@ -263,7 +274,10 @@ class OpenCodeClient:
         session: Any,
     ) -> AsyncGenerator[Dict[str, Any], None]:
         _ = session
-        body: Dict[str, Any] = {"parts": [{"type": "text", "text": prompt}]}
+        body: Dict[str, Any] = {
+            "agent": self._agent,
+            "parts": [{"type": "text", "text": prompt}],
+        }
         model = self._split_provider_model(client.model)
         if model:
             body["model"] = model
@@ -278,7 +292,13 @@ class OpenCodeClient:
                     params=self._directory_params(client.cwd),
                 )
                 response.raise_for_status()
-                payload = response.json()
+                try:
+                    payload = response.json()
+                except json.JSONDecodeError:
+                    error_message = self._describe_non_json_response(response)
+                    logger.error("OpenCode session prompt returned invalid JSON: %s", error_message)
+                    yield {"type": "error", "is_error": True, "error_message": error_message}
+                    return
         except Exception as exc:
             logger.error("OpenCode session prompt failed: %s", exc, exc_info=True)
             yield {"type": "error", "is_error": True, "error_message": str(exc)}

--- a/src/backends/opencode/config.py
+++ b/src/backends/opencode/config.py
@@ -1,0 +1,105 @@
+"""OpenCode config generation helpers."""
+
+from __future__ import annotations
+
+import copy
+import json
+from typing import Any, Dict, Optional
+
+OpenCodeConfig = Dict[str, Any]
+WrapperMcpServers = Dict[str, Dict[str, Any]]
+
+_REMOTE_MCP_TYPES = {"sse", "http", "streamable-http"}
+# Keep this transport set aligned with src.mcp_config.ALLOWED_TYPES.
+
+
+def _deep_merge_missing(target: Dict[str, Any], defaults: Dict[str, Any]) -> Dict[str, Any]:
+    """Merge defaults into target without overriding explicit target values."""
+    for key, value in defaults.items():
+        if key not in target:
+            target[key] = copy.deepcopy(value)
+            continue
+        if isinstance(target[key], dict) and isinstance(value, dict):
+            _deep_merge_missing(target[key], value)
+    return target
+
+
+def _copy_optional_fields(
+    source: Dict[str, Any],
+    target: Dict[str, Any],
+    fields: tuple[str, ...],
+) -> None:
+    for field in fields:
+        if field in source:
+            target[field] = copy.deepcopy(source[field])
+
+
+def _command_list(server: Dict[str, Any]) -> list[str]:
+    command = server["command"]
+    args = server.get("args") or []
+    if isinstance(command, list):
+        return [str(item) for item in [*command, *args]]
+    return [str(command), *[str(item) for item in args]]
+
+
+def _convert_mcp_server(server: Dict[str, Any]) -> Dict[str, Any]:
+    server_type = server.get("type", "stdio")
+    if server_type == "stdio":
+        converted: Dict[str, Any] = {
+            "type": "local",
+            "command": _command_list(server),
+        }
+        environment = server.get("environment", server.get("env"))
+        if environment is not None:
+            converted["environment"] = copy.deepcopy(environment)
+        _copy_optional_fields(server, converted, ("enabled", "timeout"))
+        return converted
+
+    if server_type in _REMOTE_MCP_TYPES:
+        converted = {
+            "type": "remote",
+            "url": server["url"],
+        }
+        _copy_optional_fields(server, converted, ("headers", "enabled", "oauth", "timeout"))
+        return converted
+
+    raise ValueError(f"Unsupported MCP server type for OpenCode config: {server_type}")
+
+
+def build_opencode_config(
+    *,
+    base_config: OpenCodeConfig,
+    mcp_servers: WrapperMcpServers,
+    default_model: Optional[str],
+    question_permission: str,
+) -> OpenCodeConfig:
+    """Build managed OpenCode config from base content and wrapper MCP servers."""
+    config = copy.deepcopy(base_config)
+    defaults: Dict[str, Any] = {
+        "permission": {"question": question_permission},
+        "share": "disabled",
+    }
+    if default_model:
+        defaults["model"] = default_model
+    _deep_merge_missing(config, defaults)
+
+    if mcp_servers:
+        mcp_config = config.setdefault("mcp", {})
+        if isinstance(mcp_config, dict):
+            for name, server in mcp_servers.items():
+                mcp_config.setdefault(name, _convert_mcp_server(server))
+
+    return config
+
+
+def parse_opencode_config_content(content: Optional[str]) -> OpenCodeConfig:
+    """Parse OPENCODE_CONFIG_CONTENT as a JSON object."""
+    if not content:
+        return {}
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"OPENCODE_CONFIG_CONTENT is not valid JSON: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError("OPENCODE_CONFIG_CONTENT must be a JSON object")
+    return parsed

--- a/src/backends/opencode/constants.py
+++ b/src/backends/opencode/constants.py
@@ -1,0 +1,29 @@
+"""OpenCode backend constants and environment parsing."""
+
+from __future__ import annotations
+
+import os
+
+
+def _parse_csv(value: str) -> list[str]:
+    """Parse comma-separated environment values, preserving order."""
+    items: list[str] = []
+    for raw_item in value.split(","):
+        item = raw_item.strip()
+        if item and item not in items:
+            items.append(item)
+    return items
+
+
+def configured_provider_models() -> list[str]:
+    """Return provider/model IDs configured for OpenCode model listing."""
+    return _parse_csv(os.getenv("OPENCODE_MODELS", ""))
+
+
+def configured_public_models() -> list[str]:
+    """Return public wrapper model IDs for configured OpenCode models."""
+    return [f"opencode/{model}" for model in configured_provider_models()]
+
+
+OPENCODE_PROVIDER_MODELS = configured_provider_models()
+OPENCODE_MODELS = configured_public_models()

--- a/src/backends/opencode/constants.py
+++ b/src/backends/opencode/constants.py
@@ -15,6 +15,14 @@ def _parse_csv(value: str) -> list[str]:
     return items
 
 
+def _parse_bool(value: str, *, default: bool = False) -> bool:
+    """Parse common truthy and falsy environment values."""
+    normalized = value.strip().lower()
+    if not normalized:
+        return default
+    return normalized in {"1", "true", "yes", "on"}
+
+
 def configured_provider_models() -> list[str]:
     """Return provider/model IDs configured for OpenCode model listing."""
     return _parse_csv(os.getenv("OPENCODE_MODELS", ""))
@@ -23,6 +31,11 @@ def configured_provider_models() -> list[str]:
 def configured_public_models() -> list[str]:
     """Return public wrapper model IDs for configured OpenCode models."""
     return [f"opencode/{model}" for model in configured_provider_models()]
+
+
+def use_wrapper_mcp_config() -> bool:
+    """Return whether managed OpenCode should include wrapper MCP config."""
+    return _parse_bool(os.getenv("OPENCODE_USE_WRAPPER_MCP_CONFIG", "false"))
 
 
 OPENCODE_PROVIDER_MODELS = configured_provider_models()

--- a/src/backends/opencode/events.py
+++ b/src/backends/opencode/events.py
@@ -16,7 +16,6 @@ class OpenCodeEventConverter:
     emitted_tool_uses: set[str] = field(default_factory=set)
     emitted_tool_results: set[str] = field(default_factory=set)
     usage: Optional[Dict[str, int]] = None
-    pending_question: Optional[Dict[str, Any]] = None
     saw_activity: bool = False
 
     def convert(self, event: Dict[str, Any]) -> List[Dict[str, Any]]:
@@ -179,17 +178,6 @@ class OpenCodeEventConverter:
         )
         if should_emit_use and call_id not in self.emitted_tool_uses:
             tool_name = str(part.get("tool") or "unknown")
-            if (
-                tool_name == "question"
-                and isinstance(input_value, dict)
-                and isinstance(input_value.get("question"), str)
-                and input_value["question"]
-            ):
-                self.pending_question = {
-                    "call_id": call_id,
-                    "name": "question",
-                    "arguments": input_value,
-                }
             chunks.append(
                 {
                     "type": "assistant",

--- a/src/backends/opencode/events.py
+++ b/src/backends/opencode/events.py
@@ -16,6 +16,7 @@ class OpenCodeEventConverter:
     emitted_tool_uses: set[str] = field(default_factory=set)
     emitted_tool_results: set[str] = field(default_factory=set)
     usage: Optional[Dict[str, int]] = None
+    pending_question: Optional[Dict[str, Any]] = None
     saw_activity: bool = False
 
     def convert(self, event: Dict[str, Any]) -> List[Dict[str, Any]]:
@@ -177,6 +178,18 @@ class OpenCodeEventConverter:
             or (status == "pending" and has_input)
         )
         if should_emit_use and call_id not in self.emitted_tool_uses:
+            tool_name = str(part.get("tool") or "unknown")
+            if (
+                tool_name == "question"
+                and isinstance(input_value, dict)
+                and isinstance(input_value.get("question"), str)
+                and input_value["question"]
+            ):
+                self.pending_question = {
+                    "call_id": call_id,
+                    "name": "question",
+                    "arguments": input_value,
+                }
             chunks.append(
                 {
                     "type": "assistant",
@@ -184,7 +197,7 @@ class OpenCodeEventConverter:
                         {
                             "type": "tool_use",
                             "id": call_id,
-                            "name": str(part.get("tool") or "unknown"),
+                            "name": tool_name,
                             "input": input_value or {},
                         }
                     ],

--- a/src/backends/opencode/events.py
+++ b/src/backends/opencode/events.py
@@ -1,0 +1,215 @@
+"""OpenCode event conversion helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class OpenCodeEventConverter:
+    """Convert OpenCode session events into gateway backend chunks."""
+
+    session_id: str
+    text_by_part: Dict[str, str] = field(default_factory=dict)
+    text_parts: List[str] = field(default_factory=list)
+    emitted_tool_uses: set[str] = field(default_factory=set)
+    emitted_tool_results: set[str] = field(default_factory=set)
+    usage: Optional[Dict[str, int]] = None
+    saw_activity: bool = False
+
+    def convert(self, event: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Convert one OpenCode event into zero or more backend chunks."""
+        if self._event_session_id(event) != self.session_id:
+            return []
+
+        chunks: List[Dict[str, Any]] = []
+        self._convert_usage_event(event)
+        text_chunk = self._convert_text_event(event)
+        if text_chunk:
+            chunks.append(text_chunk)
+        chunks.extend(self._convert_tool_event(event))
+        return chunks
+
+    def final_text(self) -> str:
+        """Return accumulated assistant text for the streamed turn."""
+        return "".join(self.text_parts)
+
+    def finished(self, event: Dict[str, Any]) -> bool:
+        """Return whether this event marks the active OpenCode session idle."""
+        return (
+            event.get("type") == "session.idle"
+            and self._event_session_id(event) == self.session_id
+            and self.saw_activity
+        )
+
+    def error_message(self, event: Dict[str, Any]) -> Optional[str]:
+        """Extract an OpenCode session error message when it applies here."""
+        if event.get("type") != "session.error":
+            return None
+        event_session = self._event_session_id(event)
+        if event_session not in (None, self.session_id):
+            return None
+        props = event.get("properties") if isinstance(event.get("properties"), dict) else {}
+        error = props.get("error") or props.get("message") or props
+        return str(error)
+
+    def _event_session_id(self, event: Dict[str, Any]) -> Optional[str]:
+        props = event.get("properties")
+        if not isinstance(props, dict):
+            return None
+        if isinstance(props.get("sessionID"), str):
+            return props["sessionID"]
+        part = props.get("part")
+        if isinstance(part, dict) and isinstance(part.get("sessionID"), str):
+            return part["sessionID"]
+        return None
+
+    def _text_delta_chunk(self, delta: str) -> Dict[str, Any]:
+        return {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": delta},
+            },
+        }
+
+    def _convert_text_event(self, event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        event_type = event.get("type")
+        props = event.get("properties") if isinstance(event.get("properties"), dict) else {}
+
+        if event_type == "message.part.delta":
+            if props.get("field") not in (None, "text"):
+                return None
+            delta = props.get("delta")
+            if not isinstance(delta, str) or not delta:
+                return None
+            part_id = str(props.get("partID") or props.get("partId") or "")
+            if part_id:
+                self.text_by_part[part_id] = self.text_by_part.get(part_id, "") + delta
+            self.text_parts.append(delta)
+            self.saw_activity = True
+            return self._text_delta_chunk(delta)
+
+        if event_type != "message.part.updated":
+            return None
+
+        delta = props.get("delta")
+        part = props.get("part")
+        if not isinstance(part, dict) or part.get("type") != "text":
+            return None
+
+        part_id = str(part.get("id") or "")
+        if isinstance(delta, str) and delta:
+            if part_id:
+                self.text_by_part[part_id] = self.text_by_part.get(part_id, "") + delta
+            self.text_parts.append(delta)
+            self.saw_activity = True
+            return self._text_delta_chunk(delta)
+
+        text = part.get("text")
+        if not isinstance(text, str) or not text:
+            return None
+        previous = self.text_by_part.get(part_id, "") if part_id else ""
+        if previous and text.startswith(previous):
+            computed_delta = text[len(previous) :]
+        elif text != previous:
+            computed_delta = text
+        else:
+            computed_delta = ""
+        if part_id:
+            self.text_by_part[part_id] = text
+        if not computed_delta:
+            return None
+        self.text_parts.append(computed_delta)
+        self.saw_activity = True
+        return self._text_delta_chunk(computed_delta)
+
+    def _convert_usage_event(self, event: Dict[str, Any]) -> None:
+        if event.get("type") != "message.part.updated":
+            return
+        props = event.get("properties") if isinstance(event.get("properties"), dict) else {}
+        part = props.get("part")
+        if not isinstance(part, dict) or part.get("type") != "step-finish":
+            return
+        tokens = part.get("tokens")
+        if not isinstance(tokens, dict):
+            return
+        cache = tokens.get("cache") if isinstance(tokens.get("cache"), dict) else {}
+        input_tokens = int(tokens.get("input") or 0)
+        input_tokens += int(cache.get("read") or 0)
+        input_tokens += int(cache.get("write") or 0)
+        output_tokens = int(tokens.get("output") or 0)
+        reasoning_tokens = int(tokens.get("reasoning") or 0)
+        self.usage = {
+            "input_tokens": (self.usage or {}).get("input_tokens", 0) + input_tokens,
+            "output_tokens": (self.usage or {}).get("output_tokens", 0) + output_tokens,
+            "total_tokens": (
+                (self.usage or {}).get("total_tokens", 0)
+                + input_tokens
+                + output_tokens
+                + reasoning_tokens
+            ),
+        }
+        self.saw_activity = True
+
+    def _convert_tool_event(self, event: Dict[str, Any]) -> List[Dict[str, Any]]:
+        if event.get("type") != "message.part.updated":
+            return []
+        props = event.get("properties") if isinstance(event.get("properties"), dict) else {}
+        part = props.get("part")
+        if not isinstance(part, dict) or part.get("type") != "tool":
+            return []
+
+        tool_state = part.get("state")
+        if not isinstance(tool_state, dict):
+            return []
+        call_id = str(part.get("callID") or part.get("callId") or part.get("id") or "")
+        if not call_id:
+            return []
+        status = tool_state.get("status")
+        chunks: List[Dict[str, Any]] = []
+
+        input_value = tool_state.get("input")
+        has_input = bool(input_value)
+        should_emit_use = (
+            status in ("running", "completed", "error")
+            or (status == "pending" and has_input)
+        )
+        if should_emit_use and call_id not in self.emitted_tool_uses:
+            chunks.append(
+                {
+                    "type": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": call_id,
+                            "name": str(part.get("tool") or "unknown"),
+                            "input": input_value or {},
+                        }
+                    ],
+                }
+            )
+            self.emitted_tool_uses.add(call_id)
+            self.saw_activity = True
+
+        if status in ("completed", "error") and call_id not in self.emitted_tool_results:
+            is_error = status == "error"
+            content = tool_state.get("error") if is_error else tool_state.get("output")
+            chunks.append(
+                {
+                    "type": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": call_id,
+                            "content": "" if content is None else str(content),
+                            "is_error": is_error,
+                        }
+                    ],
+                }
+            )
+            self.emitted_tool_results.add(call_id)
+            self.saw_activity = True
+
+        return chunks

--- a/src/backends/opencode/events.py
+++ b/src/backends/opencode/events.py
@@ -23,6 +23,9 @@ class OpenCodeEventConverter:
         """Convert one OpenCode event and update accumulated stream state."""
         if self._event_session_id(event) != self.session_id:
             return []
+        question_chunk = self._convert_question_event(event)
+        if question_chunk:
+            return [question_chunk]
         self._record_message_role(event)
         if event.get("type") == "message.updated":
             return []
@@ -109,6 +112,33 @@ class OpenCodeEventConverter:
                 "type": "content_block_delta",
                 "delta": {"type": "text_delta", "text": delta},
             },
+        }
+
+    def _convert_question_event(self, event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        if event.get("type") != "question.asked":
+            return None
+        props = event.get("properties") if isinstance(event.get("properties"), dict) else {}
+        request_id = props.get("id")
+        questions = props.get("questions")
+        if not isinstance(request_id, str) or not request_id or not isinstance(questions, list):
+            return None
+        tool = props.get("tool") if isinstance(props.get("tool"), dict) else {}
+        metadata = {"opencode_question_request_id": request_id}
+        tool_call_id = tool.get("callID")
+        if isinstance(tool_call_id, str) and tool_call_id:
+            metadata["opencode_tool_call_id"] = tool_call_id
+        self.saw_activity = True
+        return {
+            "type": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": request_id,
+                    "name": "question",
+                    "input": {"questions": questions},
+                    "metadata": metadata,
+                }
+            ],
         }
 
     def _convert_text_event(self, event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
@@ -211,6 +241,7 @@ class OpenCodeEventConverter:
         if not call_id:
             return []
         status = tool_state.get("status")
+        tool_name = str(part.get("tool") or "unknown")
         chunks: List[Dict[str, Any]] = []
 
         input_value = tool_state.get("input")
@@ -219,8 +250,16 @@ class OpenCodeEventConverter:
             status in ("running", "completed", "error")
             or (status == "pending" and has_input)
         )
+        if tool_name == "question":
+            if should_emit_use:
+                self.emitted_tool_uses.add(call_id)
+                self.saw_activity = True
+            if status in ("completed", "error"):
+                self.emitted_tool_results.add(call_id)
+                self.saw_activity = True
+            return []
+
         if should_emit_use and call_id not in self.emitted_tool_uses:
-            tool_name = str(part.get("tool") or "unknown")
             chunks.append(
                 {
                     "type": "assistant",

--- a/src/backends/opencode/events.py
+++ b/src/backends/opencode/events.py
@@ -13,6 +13,7 @@ class OpenCodeEventConverter:
     session_id: str
     text_by_part: Dict[str, str] = field(default_factory=dict)
     text_parts: List[str] = field(default_factory=list)
+    message_roles: Dict[str, str] = field(default_factory=dict)
     emitted_tool_uses: set[str] = field(default_factory=set)
     emitted_tool_results: set[str] = field(default_factory=set)
     usage: Optional[Dict[str, int]] = None
@@ -21,6 +22,9 @@ class OpenCodeEventConverter:
     def convert(self, event: Dict[str, Any]) -> List[Dict[str, Any]]:
         """Convert one OpenCode event and update accumulated stream state."""
         if self._event_session_id(event) != self.session_id:
+            return []
+        self._record_message_role(event)
+        if event.get("type") == "message.updated":
             return []
 
         chunks: List[Dict[str, Any]] = []
@@ -65,6 +69,39 @@ class OpenCodeEventConverter:
             return part["sessionID"]
         return None
 
+    def _event_message_id(self, event: Dict[str, Any]) -> Optional[str]:
+        props = event.get("properties")
+        if not isinstance(props, dict):
+            return None
+        if isinstance(props.get("messageID"), str):
+            return props["messageID"]
+        info = props.get("info")
+        if isinstance(info, dict) and isinstance(info.get("id"), str):
+            return info["id"]
+        part = props.get("part")
+        if isinstance(part, dict) and isinstance(part.get("messageID"), str):
+            return part["messageID"]
+        return None
+
+    def _record_message_role(self, event: Dict[str, Any]) -> None:
+        if event.get("type") != "message.updated":
+            return
+        props = event.get("properties") if isinstance(event.get("properties"), dict) else {}
+        info = props.get("info")
+        if not isinstance(info, dict):
+            return
+        message_id = info.get("id")
+        role = info.get("role")
+        if isinstance(message_id, str) and isinstance(role, str):
+            self.message_roles[message_id] = role
+
+    def _is_assistant_output_event(self, event: Dict[str, Any]) -> bool:
+        message_id = self._event_message_id(event)
+        if not message_id:
+            return True
+        role = self.message_roles.get(message_id)
+        return role in (None, "assistant")
+
     def _text_delta_chunk(self, delta: str) -> Dict[str, Any]:
         return {
             "type": "stream_event",
@@ -75,6 +112,8 @@ class OpenCodeEventConverter:
         }
 
     def _convert_text_event(self, event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        if not self._is_assistant_output_event(event):
+            return None
         event_type = event.get("type")
         props = event.get("properties") if isinstance(event.get("properties"), dict) else {}
 
@@ -126,6 +165,8 @@ class OpenCodeEventConverter:
         return self._text_delta_chunk(computed_delta)
 
     def _convert_usage_event(self, event: Dict[str, Any]) -> None:
+        if not self._is_assistant_output_event(event):
+            return
         if event.get("type") != "message.part.updated":
             return
         props = event.get("properties") if isinstance(event.get("properties"), dict) else {}
@@ -154,6 +195,8 @@ class OpenCodeEventConverter:
         self.saw_activity = True
 
     def _convert_tool_event(self, event: Dict[str, Any]) -> List[Dict[str, Any]]:
+        if not self._is_assistant_output_event(event):
+            return []
         if event.get("type") != "message.part.updated":
             return []
         props = event.get("properties") if isinstance(event.get("properties"), dict) else {}

--- a/src/backends/opencode/events.py
+++ b/src/backends/opencode/events.py
@@ -19,7 +19,7 @@ class OpenCodeEventConverter:
     saw_activity: bool = False
 
     def convert(self, event: Dict[str, Any]) -> List[Dict[str, Any]]:
-        """Convert one OpenCode event into zero or more backend chunks."""
+        """Convert one OpenCode event and update accumulated stream state."""
         if self._event_session_id(event) != self.session_id:
             return []
 

--- a/src/backends/opencode/events.py
+++ b/src/backends/opencode/events.py
@@ -26,6 +26,9 @@ class OpenCodeEventConverter:
         question_chunk = self._convert_question_event(event)
         if question_chunk:
             return [question_chunk]
+        permission_chunk = self._convert_permission_event(event)
+        if permission_chunk:
+            return [permission_chunk]
         self._record_message_role(event)
         if event.get("type") == "message.updated":
             return []
@@ -141,6 +144,46 @@ class OpenCodeEventConverter:
             ],
         }
 
+    def _convert_permission_event(self, event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        if event.get("type") != "permission.asked":
+            return None
+        props = event.get("properties") if isinstance(event.get("properties"), dict) else {}
+        request_id = props.get("id")
+        permission = props.get("permission")
+        if not isinstance(request_id, str) or not request_id:
+            return None
+        if not isinstance(permission, str) or not permission:
+            return None
+
+        patterns = props.get("patterns")
+        always = props.get("always")
+        metadata_value = props.get("metadata")
+        input_value = {
+            "permission": permission,
+            "patterns": patterns if isinstance(patterns, list) else [],
+            "always": always if isinstance(always, list) else [],
+            "metadata": metadata_value if isinstance(metadata_value, dict) else {},
+        }
+        metadata = {"opencode_permission_request_id": request_id}
+        tool = props.get("tool") if isinstance(props.get("tool"), dict) else {}
+        tool_call_id = tool.get("callID")
+        if isinstance(tool_call_id, str) and tool_call_id:
+            metadata["opencode_tool_call_id"] = tool_call_id
+
+        self.saw_activity = True
+        return {
+            "type": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": request_id,
+                    "name": "permission",
+                    "input": input_value,
+                    "metadata": metadata,
+                }
+            ],
+        }
+
     def _convert_text_event(self, event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         if not self._is_assistant_output_event(event):
             return None
@@ -246,9 +289,8 @@ class OpenCodeEventConverter:
 
         input_value = tool_state.get("input")
         has_input = bool(input_value)
-        should_emit_use = (
-            status in ("running", "completed", "error")
-            or (status == "pending" and has_input)
+        should_emit_use = status in ("running", "completed", "error") or (
+            status == "pending" and has_input
         )
         if tool_name == "question":
             if should_emit_use:

--- a/src/chat_page.py
+++ b/src/chat_page.py
@@ -326,6 +326,9 @@ body::after {
   font-weight: 600;
   margin-bottom: 0.4rem;
 }
+.ask-prompt .ask-question {
+  margin-bottom: 0.65rem;
+}
 .ask-prompt .ask-options {
   display: flex;
   flex-direction: column;
@@ -345,6 +348,11 @@ body::after {
   cursor: pointer;
   transition: all 0.15s;
 }
+.ask-prompt .ask-option-btn.multi {
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-start;
+}
 .ask-prompt .ask-option-btn:hover {
   border-color: var(--magenta);
   background: rgba(255, 0, 255, 0.08);
@@ -354,7 +362,15 @@ body::after {
   background: rgba(255, 0, 255, 0.15);
   color: var(--magenta);
 }
+.ask-prompt .ask-option-marker {
+  flex: 0 0 auto;
+  color: var(--magenta);
+}
+.ask-prompt .ask-option-main {
+  min-width: 0;
+}
 .ask-prompt .ask-option-desc {
+  display: block;
   font-size: var(--fs-xs);
   color: var(--text-dim);
   margin-top: 2px;
@@ -784,25 +800,36 @@ function showAskPrompt(argsObj, callId, responseId) {
   div.id = 'ask-prompt-' + callId;
 
   // Parse structured questions with options
-  const questions = argsObj.questions;
+  let questions = argsObj.questions;
+  if ((!Array.isArray(questions) || questions.length === 0) && argsObj.question && Array.isArray(argsObj.options)) {
+    questions = [argsObj];
+  }
   if (questions && Array.isArray(questions) && questions.length > 0) {
     // Structured format: { questions: [{ question, header, options }] }
     let html = '<div class="role">AskUserQuestion</div>';
-    for (const q of questions) {
+    for (let i = 0; i < questions.length; i++) {
+      const q = questions[i];
+      const multiple = q.multiple === true;
+      html += '<div class="ask-question" data-index="' + i + '" data-multiple="' + (multiple ? 'true' : 'false') + '">';
       if (q.header) html += '<div class="ask-header">' + escapeHtml(q.header) + '</div>';
       if (q.question) html += '<div class="ask-bubble">' + escapeHtml(q.question) + '</div>';
       if (q.options && Array.isArray(q.options)) {
         html += '<div class="ask-options">';
         for (const opt of q.options) {
-          const label = opt.label || opt;
-          const desc = opt.description || '';
-          html += '<button class="ask-option-btn" data-label="' + escapeAttr(label) + '">' +
-            escapeHtml(label) +
-            (desc ? '<div class="ask-option-desc">' + escapeHtml(desc) + '</div>' : '') +
+          const isObjectOption = typeof opt === 'object' && opt !== null;
+          const label = typeof opt === 'string' ? opt : (isObjectOption ? (opt.label || '') : '');
+          const desc = isObjectOption ? (opt.description || '') : '';
+          if (!label) continue;
+          html += '<button type="button" class="ask-option-btn' + (multiple ? ' multi' : '') + '" data-label="' + escapeAttr(label) + '" aria-pressed="false">' +
+            (multiple ? '<span class="ask-option-marker" aria-hidden="true">[ ]</span>' : '') +
+            '<span class="ask-option-main"><span class="ask-option-label">' + escapeHtml(label) + '</span>' +
+            (desc ? '<span class="ask-option-desc">' + escapeHtml(desc) + '</span>' : '') +
+            '</span>' +
             '</button>';
         }
         html += '</div>';
       }
+      html += '</div>';
     }
     html += '<div class="ask-input-row">' +
       '<input type="text" class="ask-input" placeholder="직접 입력...">' +
@@ -822,12 +849,26 @@ function showAskPrompt(argsObj, callId, responseId) {
   chatEl.appendChild(div);
   scrollToBottom();
 
-  // Option button click → fill input
+  // Option button click -> update selected answers
   div.querySelectorAll('.ask-option-btn').forEach(btn => {
     btn.addEventListener('click', () => {
-      div.querySelectorAll('.ask-option-btn').forEach(b => b.classList.remove('selected'));
-      btn.classList.add('selected');
-      div.querySelector('.ask-input').value = btn.dataset.label;
+      const question = btn.closest('.ask-question');
+      const multiple = question && question.dataset.multiple === 'true';
+      if (multiple) {
+        btn.classList.toggle('selected');
+        const selected = btn.classList.contains('selected');
+        btn.setAttribute('aria-pressed', selected ? 'true' : 'false');
+        const marker = btn.querySelector('.ask-option-marker');
+        if (marker) marker.textContent = selected ? '[x]' : '[ ]';
+      } else if (question) {
+        question.querySelectorAll('.ask-option-btn').forEach(b => {
+          b.classList.remove('selected');
+          b.setAttribute('aria-pressed', 'false');
+        });
+        btn.classList.add('selected');
+        btn.setAttribute('aria-pressed', 'true');
+      }
+      syncAskInputPreview(div);
     });
   });
 
@@ -841,11 +882,51 @@ function showAskPrompt(argsObj, callId, responseId) {
   askInput.focus();
 }
 
+function selectedLabelsForQuestion(questionEl) {
+  return Array.from(questionEl.querySelectorAll('.ask-option-btn.selected'))
+    .map(btn => btn.dataset.label || '')
+    .filter(Boolean);
+}
+
+function syncAskInputPreview(container) {
+  const input = container.querySelector('.ask-input');
+  if (!input) return;
+  const questions = Array.from(container.querySelectorAll('.ask-question'));
+  if (!questions.length) return;
+  const labels = questions.flatMap(selectedLabelsForQuestion);
+  input.value = labels.join(', ');
+}
+
+function collectAskAnswer(container) {
+  const input = container.querySelector('.ask-input');
+  const typed = input ? input.value.trim() : '';
+  const questions = Array.from(container.querySelectorAll('.ask-question'));
+  if (!questions.length) return { payload: typed, display: typed };
+
+  const answersByQuestion = questions.map(selectedLabelsForQuestion);
+  const hasSelected = answersByQuestion.some(answers => answers.length > 0);
+  if (!hasSelected) return { payload: typed, display: typed };
+
+  const display = answersByQuestion
+    .map(answers => answers.join(', '))
+    .filter(Boolean)
+    .join(' / ');
+  if (questions.length === 1) {
+    const multiple = questions[0].dataset.multiple === 'true';
+    const answers = answersByQuestion[0];
+    return {
+      payload: multiple ? JSON.stringify(answers) : answers[0],
+      display,
+    };
+  }
+  return { payload: JSON.stringify(answersByQuestion), display };
+}
+
 async function doSubmitAsk(container) {
   if (!pendingAsk) return;
   const input = container.querySelector('.ask-input');
-  const answer = input.value.trim();
-  if (!answer) return;
+  const answer = collectAskAnswer(container);
+  if (!answer.payload) return;
 
   const { call_id, response_id } = pendingAsk;
   pendingAsk = null;
@@ -856,11 +937,11 @@ async function doSubmitAsk(container) {
   container.querySelector('.ask-submit').textContent = 'SENT';
   container.querySelectorAll('.ask-option-btn').forEach(b => { b.disabled = true; });
 
-  addMessage('user', answer);
+  addMessage('user', answer.display || answer.payload);
 
   await streamRequest({
     model: modelSelect.value,
-    input: [{ type: 'function_call_output', call_id, output: answer }],
+    input: [{ type: 'function_call_output', call_id, output: answer.payload }],
     previous_response_id: response_id,
     stream: true,
   });

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 import os
 import json
 import asyncio
+import inspect
 import logging
 import secrets
 import string
@@ -180,6 +181,20 @@ async def _verify_backends() -> None:
             logger.error(f"⚠️  {name} backend verification failed: {e}")
 
 
+async def _shutdown_backends() -> None:
+    """Close backend-owned resources such as managed child processes."""
+    for name, backend in BackendRegistry.all_backends().items():
+        close = getattr(backend, "close", None) or getattr(backend, "shutdown", None)
+        if close is None:
+            continue
+        try:
+            result = close()
+            if inspect.isawaitable(result):
+                await result
+        except Exception:
+            logger.warning("Backend %s shutdown failed", name, exc_info=True)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Initialize backends, verify authentication, and start background tasks."""
@@ -274,6 +289,7 @@ async def lifespan(app: FastAPI):
     # Cleanup on shutdown (async to disconnect SDK clients)
     logger.info("Shutting down session manager...")
     await session_manager.async_shutdown()
+    await _shutdown_backends()
     await usage_logger.close()
 
 

--- a/src/mcp_config.py
+++ b/src/mcp_config.py
@@ -3,6 +3,7 @@
 Loads server-level MCP config from the MCP_CONFIG environment variable.
 """
 
+import copy
 import json
 import logging
 from pathlib import Path
@@ -100,3 +101,8 @@ _server_mcp_config: McpServersDict = load_mcp_config()
 def get_mcp_servers() -> McpServersDict:
     """Get the pre-loaded server-level MCP server config."""
     return _server_mcp_config
+
+
+def get_validated_mcp_config() -> McpServersDict:
+    """Return a copy of the already validated wrapper MCP config."""
+    return copy.deepcopy(_server_mcp_config)

--- a/src/routes/deps.py
+++ b/src/routes/deps.py
@@ -83,6 +83,9 @@ def validate_image_request(request: Any, backend: BackendClient) -> None:
     if not request_has_images(request):
         return
 
+    if getattr(backend, "name", None) == "opencode":
+        return
+
     # Check backend supports images
     if not hasattr(backend, "image_handler"):
         raise HTTPException(

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -462,10 +462,10 @@ async def _unblock_pending_tool_call(
         raise
 
 
-async def _prepare_opencode_question_continuation(
+async def _prepare_opencode_tool_continuation(
     session, backend: "BackendClient", fc_output: Dict[str, str]
-) -> None:
-    """Validate and reserve an OpenCode pending question continuation."""
+) -> str:
+    """Validate and reserve an OpenCode pending tool continuation."""
     await session.lock.acquire()
     try:
         if session.pending_tool_call is None:
@@ -484,11 +484,23 @@ async def _prepare_opencode_question_continuation(
                 ),
             )
 
-        resume = getattr(backend, "resume_question_with_client", None)
+        pending = session.pending_tool_call
+        resume_kind = pending.get("opencode_resume")
+        if resume_kind is None:
+            resume_kind = "question"
+        if resume_kind not in ("question", "permission"):
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unsupported OpenCode resume kind: {resume_kind}",
+            )
+        if resume_kind == "permission":
+            resume = getattr(backend, "resume_permission_with_client", None)
+        else:
+            resume = getattr(backend, "resume_question_with_client", None)
         if not callable(resume):
             raise HTTPException(
                 status_code=400,
-                detail="OpenCode question continuation is not supported by this backend",
+                detail=f"OpenCode {resume_kind} continuation is not supported by this backend",
             )
 
         if session.client is None:
@@ -498,43 +510,10 @@ async def _prepare_opencode_question_continuation(
             )
 
         session.pending_tool_call = None
+        return resume_kind
     except Exception:
         session.lock.release()
         raise
-
-
-def _store_opencode_pending_question(
-    resolved: ResolvedModel,
-    session,
-    chunk: Dict[str, Any],
-) -> bool:
-    """Capture OpenCode question tool_use chunks as pending Responses actions."""
-    if resolved.backend != "opencode" or not isinstance(chunk, dict):
-        return False
-    content = chunk.get("content")
-    if not isinstance(content, list):
-        return False
-    for block in content:
-        if not isinstance(block, dict):
-            continue
-        if block.get("type") != "tool_use" or block.get("name") != "question":
-            continue
-        metadata = block.get("metadata") if isinstance(block.get("metadata"), dict) else {}
-        request_id = metadata.get("opencode_question_request_id")
-        if not isinstance(request_id, str) or not request_id:
-            continue
-        input_value = block.get("input") if isinstance(block.get("input"), dict) else {}
-        arguments = _normalize_opencode_question_arguments(input_value)
-        if arguments is None:
-            continue
-        session.pending_tool_call = {
-            "call_id": request_id,
-            "name": ASK_USER_QUESTION_TOOL_NAME,
-            "arguments": arguments,
-            "backend": "opencode",
-        }
-        return True
-    return False
 
 
 def _normalize_opencode_question_arguments(input_value: Dict[str, Any]) -> Optional[Dict[str, Any]]:
@@ -552,6 +531,95 @@ def _normalize_opencode_question_arguments(input_value: Dict[str, Any]) -> Optio
     return None
 
 
+def _normalize_opencode_permission_arguments(
+    input_value: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    """Return OpenCode permission input in the public AskUserQuestion shape."""
+    permission = input_value.get("permission")
+    if not isinstance(permission, str) or not permission:
+        return None
+
+    raw_patterns = input_value.get("patterns")
+    patterns = (
+        [item for item in raw_patterns if isinstance(item, str)]
+        if isinstance(raw_patterns, list)
+        else []
+    )
+    raw_always = input_value.get("always")
+    always = (
+        [item for item in raw_always if isinstance(item, str)]
+        if isinstance(raw_always, list)
+        else []
+    )
+    metadata = input_value.get("metadata") if isinstance(input_value.get("metadata"), dict) else {}
+    target = ", ".join(patterns) if patterns else "(no patterns specified)"
+    allowed_context = f"; already allowed: {', '.join(always)}" if always else ""
+    return {
+        "question": f"OpenCode requests permission '{permission}' for: {target}{allowed_context}",
+        "options": [
+            {"label": "once", "description": "Allow this request once."},
+            {"label": "always", "description": "Always allow matching requests."},
+            {"label": "reject", "description": "Reject this request."},
+        ],
+        "permission": permission,
+        "patterns": patterns,
+        "always": always,
+        "metadata": metadata,
+    }
+
+
+def _store_opencode_pending_tool_call(
+    resolved: ResolvedModel,
+    session,
+    chunk: Dict[str, Any],
+) -> bool:
+    """Capture the first resumable OpenCode tool_use from a backend chunk."""
+    if resolved.backend != "opencode" or not isinstance(chunk, dict):
+        return False
+    content = chunk.get("content")
+    if not isinstance(content, list):
+        return False
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") != "tool_use":
+            continue
+        tool_name = block.get("name")
+        metadata = block.get("metadata") if isinstance(block.get("metadata"), dict) else {}
+        input_value = block.get("input") if isinstance(block.get("input"), dict) else {}
+        if tool_name == "question":
+            request_id = metadata.get("opencode_question_request_id")
+            if not isinstance(request_id, str) or not request_id:
+                continue
+            arguments = _normalize_opencode_question_arguments(input_value)
+            if arguments is None:
+                continue
+            session.pending_tool_call = {
+                "call_id": request_id,
+                "name": ASK_USER_QUESTION_TOOL_NAME,
+                "arguments": arguments,
+                "backend": "opencode",
+                "opencode_resume": "question",
+            }
+            return True
+        if tool_name == "permission":
+            request_id = metadata.get("opencode_permission_request_id")
+            if not isinstance(request_id, str) or not request_id:
+                continue
+            arguments = _normalize_opencode_permission_arguments(input_value)
+            if arguments is None:
+                continue
+            session.pending_tool_call = {
+                "call_id": request_id,
+                "name": ASK_USER_QUESTION_TOOL_NAME,
+                "arguments": arguments,
+                "backend": "opencode",
+                "opencode_resume": "permission",
+            }
+            return True
+    return False
+
+
 async def _capture_opencode_pending_questions(chunk_source, resolved: ResolvedModel, session):
     async for chunk in chunk_source:
         if resolved.backend == "opencode" and isinstance(chunk, dict):
@@ -559,10 +627,10 @@ async def _capture_opencode_pending_questions(chunk_source, resolved: ResolvedMo
             if isinstance(content, list) and any(
                 isinstance(block, dict)
                 and block.get("type") == "tool_use"
-                and block.get("name") == "question"
+                and block.get("name") in ("question", "permission")
                 for block in content
             ):
-                if _store_opencode_pending_question(resolved, session, chunk):
+                if _store_opencode_pending_tool_call(resolved, session, chunk):
                     close = getattr(chunk_source, "aclose", None)
                     if callable(close):
                         await close()
@@ -689,9 +757,7 @@ async def create_response(
                 chunks_buffer = []
 
                 _configure_client_streaming(session.client, True)
-                backend_source = backend.run_completion_with_client(
-                    session.client, prompt, session
-                )
+                backend_source = backend.run_completion_with_client(session.client, prompt, session)
                 chunk_source = _capture_opencode_pending_questions(
                     backend_source, resolved, session
                 )
@@ -948,8 +1014,11 @@ async def _handle_function_call_output(
     # --- Validate + unblock under session lock, then keep the lock through
     # the continuation read so no concurrent request can mutate session state
     # between the tool output and SDK resume.
+    opencode_resume_kind = "question"
     if resolved.backend == "opencode":
-        await _prepare_opencode_question_continuation(session, backend, fc_output)
+        opencode_resume_kind = await _prepare_opencode_tool_continuation(
+            session, backend, fc_output
+        )
     else:
         await _unblock_pending_tool_call(session, backend, fc_output)
 
@@ -970,12 +1039,20 @@ async def _handle_function_call_output(
                 # processing from where it left off.  Use receive_response_from_client
                 # when available; do not start a new prompt.
                 if resolved.backend == "opencode":
-                    backend_source = backend.resume_question_with_client(
-                        active_client,
-                        fc_output["call_id"],
-                        fc_output["output"],
-                        session,
-                    )
+                    if opencode_resume_kind == "permission":
+                        backend_source = backend.resume_permission_with_client(
+                            active_client,
+                            fc_output["call_id"],
+                            fc_output["output"],
+                            session,
+                        )
+                    else:
+                        backend_source = backend.resume_question_with_client(
+                            active_client,
+                            fc_output["call_id"],
+                            fc_output["output"],
+                            session,
+                        )
                 else:
                     receiver = getattr(backend, "receive_response_from_client", None)
                     if receiver is not None:
@@ -1068,12 +1145,20 @@ async def _handle_function_call_output(
         # processing from where it left off — no new query needed.
         _configure_client_streaming(active_client, False)
         if resolved.backend == "opencode":
-            backend_source = backend.resume_question_with_client(
-                active_client,
-                fc_output["call_id"],
-                fc_output["output"],
-                session,
-            )
+            if opencode_resume_kind == "permission":
+                backend_source = backend.resume_permission_with_client(
+                    active_client,
+                    fc_output["call_id"],
+                    fc_output["output"],
+                    session,
+                )
+            else:
+                backend_source = backend.resume_question_with_client(
+                    active_client,
+                    fc_output["call_id"],
+                    fc_output["output"],
+                    session,
+                )
         else:
             receiver = getattr(backend, "receive_response_from_client", None)
             if receiver is not None:

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -938,8 +938,7 @@ async def _handle_function_call_output(
                 # processing from where it left off.  Use receive_response_from_client
                 # when available; do not start a new prompt.
                 if resolved.backend == "opencode":
-                    resume = getattr(backend, "resume_question_with_client")
-                    backend_source = resume(
+                    backend_source = backend.resume_question_with_client(
                         active_client,
                         fc_output["call_id"],
                         fc_output["output"],
@@ -1036,8 +1035,7 @@ async def _handle_function_call_output(
         # processing from where it left off — no new query needed.
         _configure_client_streaming(active_client, False)
         if resolved.backend == "opencode":
-            resume = getattr(backend, "resume_question_with_client")
-            backend_source = resume(
+            backend_source = backend.resume_question_with_client(
                 active_client,
                 fc_output["call_id"],
                 fc_output["output"],

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -554,7 +554,10 @@ def _normalize_opencode_question_arguments(input_value: Dict[str, Any]) -> Optio
 async def _capture_opencode_pending_questions(chunk_source, resolved: ResolvedModel, session):
     async for chunk in chunk_source:
         if _store_opencode_pending_question(resolved, session, chunk):
-            continue
+            close = getattr(chunk_source, "aclose", None)
+            if callable(close):
+                await close()
+            return
         yield chunk
 
 

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -545,7 +545,7 @@ async def create_response(
             await session_manager.delete_session_async(session_id)
             raise HTTPException(
                 status_code=503,
-                detail="Claude Code SDK unavailable; retry shortly",
+                detail=f"{resolved.backend} backend unavailable; retry shortly",
             )
 
     if body.stream:

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -460,6 +460,85 @@ async def _unblock_pending_tool_call(
         raise
 
 
+async def _prepare_opencode_question_continuation(
+    session, backend: "BackendClient", fc_output: Dict[str, str]
+) -> None:
+    """Validate and reserve an OpenCode pending question continuation."""
+    await session.lock.acquire()
+    try:
+        if session.pending_tool_call is None:
+            raise HTTPException(
+                status_code=400,
+                detail="function_call_output received but no pending tool call in session",
+            )
+
+        if session.pending_tool_call["call_id"] != fc_output["call_id"]:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"call_id mismatch: pending tool call has "
+                    f"'{session.pending_tool_call['call_id']}', "
+                    f"but received '{fc_output['call_id']}'"
+                ),
+            )
+
+        resume = getattr(backend, "resume_question_with_client", None)
+        if not callable(resume):
+            raise HTTPException(
+                status_code=400,
+                detail="OpenCode question continuation is not supported by this backend",
+            )
+
+        if session.client is None:
+            raise HTTPException(
+                status_code=400,
+                detail="function_call_output received but session has no active SDK client",
+            )
+
+        session.pending_tool_call = None
+    except Exception:
+        session.lock.release()
+        raise
+
+
+def _store_opencode_pending_question(
+    resolved: ResolvedModel,
+    session,
+    chunk: Dict[str, Any],
+) -> None:
+    """Capture OpenCode question tool_use chunks as pending Responses actions."""
+    if resolved.backend != "opencode" or not isinstance(chunk, dict):
+        return
+    content = chunk.get("content")
+    if not isinstance(content, list):
+        return
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") != "tool_use" or block.get("name") != "question":
+            continue
+        input_value = block.get("input") if isinstance(block.get("input"), dict) else {}
+        question = input_value.get("question")
+        call_id = block.get("id")
+        if not isinstance(call_id, str) or not call_id:
+            continue
+        if not isinstance(question, str) or not question:
+            continue
+        session.pending_tool_call = {
+            "call_id": call_id,
+            "name": "question",
+            "arguments": input_value,
+            "backend": "opencode",
+        }
+        return
+
+
+async def _capture_opencode_pending_questions(chunk_source, resolved: ResolvedModel, session):
+    async for chunk in chunk_source:
+        _store_opencode_pending_question(resolved, session, chunk)
+        yield chunk
+
+
 @router.post("/v1/responses")
 @rate_limit_endpoint("responses")
 async def create_response(
@@ -578,7 +657,12 @@ async def create_response(
                 chunks_buffer = []
 
                 _configure_client_streaming(session.client, True)
-                chunk_source = backend.run_completion_with_client(session.client, prompt, session)
+                backend_source = backend.run_completion_with_client(
+                    session.client, prompt, session
+                )
+                chunk_source = _capture_opencode_pending_questions(
+                    backend_source, resolved, session
+                )
 
                 # Bridge SDK iteration through a background task to keep
                 # anyio cancel scopes task-local.
@@ -713,7 +797,10 @@ async def create_response(
             chunks = []
             active_client = session.client
             _configure_client_streaming(active_client, False)
-            async for chunk in backend.run_completion_with_client(active_client, prompt, session):
+            backend_source = backend.run_completion_with_client(active_client, prompt, session)
+            async for chunk in _capture_opencode_pending_questions(
+                backend_source, resolved, session
+            ):
                 chunks.append(chunk)
 
             # Check for backend errors (run_completion wraps exceptions as error chunks)
@@ -829,7 +916,10 @@ async def _handle_function_call_output(
     # --- Validate + unblock under session lock, then keep the lock through
     # the continuation read so no concurrent request can mutate session state
     # between the tool output and SDK resume.
-    await _unblock_pending_tool_call(session, backend, fc_output)
+    if resolved.backend == "opencode":
+        await _prepare_opencode_question_continuation(session, backend, fc_output)
+    else:
+        await _unblock_pending_tool_call(session, backend, fc_output)
 
     # --- Stream continuation from the client ---
     next_turn = session.turn_counter + 1
@@ -847,11 +937,25 @@ async def _handle_function_call_output(
                 # After the hook returns deny+reason, the SDK continues
                 # processing from where it left off.  Use receive_response_from_client
                 # when available; do not start a new prompt.
-                receiver = getattr(backend, "receive_response_from_client", None)
-                if receiver is not None:
-                    chunk_source = receiver(active_client, session)
+                if resolved.backend == "opencode":
+                    resume = getattr(backend, "resume_question_with_client")
+                    backend_source = resume(
+                        active_client,
+                        fc_output["call_id"],
+                        fc_output["output"],
+                        session,
+                    )
                 else:
-                    chunk_source = backend.run_completion_with_client(active_client, "", session)
+                    receiver = getattr(backend, "receive_response_from_client", None)
+                    if receiver is not None:
+                        backend_source = receiver(active_client, session)
+                    else:
+                        backend_source = backend.run_completion_with_client(
+                            active_client, "", session
+                        )
+                chunk_source = _capture_opencode_pending_questions(
+                    backend_source, resolved, session
+                )
 
                 sse_source = streaming_utils.stream_response_chunks(
                     chunk_source=chunk_source,
@@ -930,13 +1034,22 @@ async def _handle_function_call_output(
         chunks = []
         # After the hook returns deny+reason, the SDK continues
         # processing from where it left off — no new query needed.
-        receiver = getattr(backend, "receive_response_from_client", None)
         _configure_client_streaming(active_client, False)
-        if receiver is not None:
-            chunk_source = receiver(active_client, session)
+        if resolved.backend == "opencode":
+            resume = getattr(backend, "resume_question_with_client")
+            backend_source = resume(
+                active_client,
+                fc_output["call_id"],
+                fc_output["output"],
+                session,
+            )
         else:
-            chunk_source = backend.run_completion_with_client(active_client, "", session)
-        async for chunk in chunk_source:
+            receiver = getattr(backend, "receive_response_from_client", None)
+            if receiver is not None:
+                backend_source = receiver(active_client, session)
+            else:
+                backend_source = backend.run_completion_with_client(active_client, "", session)
+        async for chunk in _capture_opencode_pending_questions(backend_source, resolved, session):
             chunks.append(chunk)
 
         # Check for another pending_tool_call

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -48,6 +48,8 @@ from src.routes.deps import (
 logger = logging.getLogger(__name__)
 router = APIRouter()
 
+ASK_USER_QUESTION_TOOL_NAME = "AskUserQuestion"
+
 
 def _generate_msg_id() -> str:
     """Generate an output item ID: msg_<hex>."""
@@ -505,37 +507,54 @@ def _store_opencode_pending_question(
     resolved: ResolvedModel,
     session,
     chunk: Dict[str, Any],
-) -> None:
+) -> bool:
     """Capture OpenCode question tool_use chunks as pending Responses actions."""
     if resolved.backend != "opencode" or not isinstance(chunk, dict):
-        return
+        return False
     content = chunk.get("content")
     if not isinstance(content, list):
-        return
+        return False
     for block in content:
         if not isinstance(block, dict):
             continue
         if block.get("type") != "tool_use" or block.get("name") != "question":
             continue
         input_value = block.get("input") if isinstance(block.get("input"), dict) else {}
-        question = input_value.get("question")
+        arguments = _normalize_opencode_question_arguments(input_value)
+        if arguments is None:
+            continue
         call_id = block.get("id")
         if not isinstance(call_id, str) or not call_id:
             continue
-        if not isinstance(question, str) or not question:
-            continue
         session.pending_tool_call = {
             "call_id": call_id,
-            "name": "question",
-            "arguments": input_value,
+            "name": ASK_USER_QUESTION_TOOL_NAME,
+            "arguments": arguments,
             "backend": "opencode",
         }
-        return
+        return True
+    return False
+
+
+def _normalize_opencode_question_arguments(input_value: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Return OpenCode question input in the public AskUserQuestion argument shape."""
+    question = input_value.get("question")
+    if isinstance(question, str) and question:
+        return input_value
+
+    questions = input_value.get("questions")
+    if not isinstance(questions, list):
+        return None
+    for item in questions:
+        if isinstance(item, dict) and isinstance(item.get("question"), str) and item["question"]:
+            return input_value
+    return None
 
 
 async def _capture_opencode_pending_questions(chunk_source, resolved: ResolvedModel, session):
     async for chunk in chunk_source:
-        _store_opencode_pending_question(resolved, session, chunk)
+        if _store_opencode_pending_question(resolved, session, chunk):
+            continue
         yield chunk
 
 

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -975,6 +975,7 @@ async def _handle_function_call_output(
                         "previous_response_id": body.previous_response_id,
                         "turn": next_turn,
                         "continuation": True,
+                        "function_call_output_call_id": fc_output["call_id"],
                     },
                 )
                 async for line in streaming_utils.bridge_sse_stream(sse_source, chunk_source):

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -223,6 +223,12 @@ async def _disconnect_session_client(session, reason: str, client=None) -> None:
         logger.debug("SDK client disconnect failed after %s", reason, exc_info=True)
 
 
+def _configure_client_streaming(client: Any, enabled: bool) -> None:
+    """Enable backend-specific event streaming when a client supports it."""
+    if client is not None and hasattr(client, "stream_events"):
+        setattr(client, "stream_events", enabled)
+
+
 async def _responses_streaming_preflight(
     body: ResponseCreateRequest,
     resolved: ResolvedModel,
@@ -571,6 +577,7 @@ async def create_response(
             try:
                 chunks_buffer = []
 
+                _configure_client_streaming(session.client, True)
                 chunk_source = backend.run_completion_with_client(session.client, prompt, session)
 
                 # Bridge SDK iteration through a background task to keep
@@ -705,6 +712,7 @@ async def create_response(
             # Execute backend through the persistent client.
             chunks = []
             active_client = session.client
+            _configure_client_streaming(active_client, False)
             async for chunk in backend.run_completion_with_client(active_client, prompt, session):
                 chunks.append(chunk)
 
@@ -835,6 +843,7 @@ async def _handle_function_call_output(
             stream_result = {"success": False}
             try:
                 chunks_buffer = []
+                _configure_client_streaming(active_client, True)
                 # After the hook returns deny+reason, the SDK continues
                 # processing from where it left off.  Use receive_response_from_client
                 # when available; do not start a new prompt.
@@ -922,6 +931,7 @@ async def _handle_function_call_output(
         # After the hook returns deny+reason, the SDK continues
         # processing from where it left off — no new query needed.
         receiver = getattr(backend, "receive_response_from_client", None)
+        _configure_client_streaming(active_client, False)
         if receiver is not None:
             chunk_source = receiver(active_client, session)
         else:

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -519,15 +519,16 @@ def _store_opencode_pending_question(
             continue
         if block.get("type") != "tool_use" or block.get("name") != "question":
             continue
+        metadata = block.get("metadata") if isinstance(block.get("metadata"), dict) else {}
+        request_id = metadata.get("opencode_question_request_id")
+        if not isinstance(request_id, str) or not request_id:
+            continue
         input_value = block.get("input") if isinstance(block.get("input"), dict) else {}
         arguments = _normalize_opencode_question_arguments(input_value)
         if arguments is None:
             continue
-        call_id = block.get("id")
-        if not isinstance(call_id, str) or not call_id:
-            continue
         session.pending_tool_call = {
-            "call_id": call_id,
+            "call_id": request_id,
             "name": ASK_USER_QUESTION_TOOL_NAME,
             "arguments": arguments,
             "backend": "opencode",
@@ -553,11 +554,20 @@ def _normalize_opencode_question_arguments(input_value: Dict[str, Any]) -> Optio
 
 async def _capture_opencode_pending_questions(chunk_source, resolved: ResolvedModel, session):
     async for chunk in chunk_source:
-        if _store_opencode_pending_question(resolved, session, chunk):
-            close = getattr(chunk_source, "aclose", None)
-            if callable(close):
-                await close()
-            return
+        if resolved.backend == "opencode" and isinstance(chunk, dict):
+            content = chunk.get("content")
+            if isinstance(content, list) and any(
+                isinstance(block, dict)
+                and block.get("type") == "tool_use"
+                and block.get("name") == "question"
+                for block in content
+            ):
+                if _store_opencode_pending_question(resolved, session, chunk):
+                    close = getattr(chunk_source, "aclose", None)
+                    if callable(close):
+                        await close()
+                    return
+                continue
         yield chunk
 
 

--- a/src/streaming_utils.py
+++ b/src/streaming_utils.py
@@ -44,6 +44,9 @@ from src.chunk_processing import (  # noqa: F401
 )
 
 
+_ASK_USER_RESPONSE_PREFIX = "User responded:"
+
+
 # ---------------------------------------------------------------------------
 # Error-logging helpers
 # ---------------------------------------------------------------------------
@@ -399,11 +402,41 @@ def _record_tool_result(tool_stats: ToolStatsCollector, tool_block: Dict[str, An
     )
 
 
+def _remember_tool_use(tool_names_by_id: Dict[str, str], tool_block: Dict[str, Any]) -> None:
+    tool_use_id = _block_field(tool_block, "id") or _block_field(tool_block, "tool_use_id")
+    name = _block_field(tool_block, "name")
+    if isinstance(tool_use_id, str) and tool_use_id and isinstance(name, str) and name:
+        tool_names_by_id[tool_use_id] = name
+
+
+def _is_synthetic_ask_user_response_result(
+    result_block: Dict[str, Any],
+    tool_names_by_id: Dict[str, str],
+    request_context: Optional[Dict[str, Any]],
+) -> bool:
+    content = result_block.get("content")
+    if not isinstance(content, str) or not content.startswith(_ASK_USER_RESPONSE_PREFIX):
+        return False
+
+    tool_use_id = result_block.get("tool_use_id")
+    if not isinstance(tool_use_id, str) or not tool_use_id:
+        return False
+
+    if tool_names_by_id.get(tool_use_id) == "AskUserQuestion":
+        return True
+
+    if not isinstance(request_context, dict):
+        return False
+    return request_context.get("function_call_output_call_id") == tool_use_id
+
+
 def _tool_use_events(
     tool_block: Dict[str, Any],
     tool_stats: ToolStatsCollector,
     next_seq: Callable[[], int],
+    tool_names_by_id: Dict[str, str],
 ) -> list[str]:
+    _remember_tool_use(tool_names_by_id, tool_block)
     _record_tool_use(tool_stats, tool_block)
     is_subagent_tool = tool_block.get("parent_tool_use_id") is not None
     if is_subagent_tool and not SUBAGENT_STREAM_TOOL_BLOCKS:
@@ -421,10 +454,21 @@ def _user_tool_result_events(
     chunk: Dict[str, Any],
     tool_stats: ToolStatsCollector,
     next_seq: Callable[[], int],
+    tool_names_by_id: Dict[str, str],
+    request_context: Optional[Dict[str, Any]],
 ) -> list[str]:
     tool_results, parent_id = extract_user_tool_results(chunk)
-    for tr_block in tool_results:
+    normalized_results = [_normalize_tool_result(tr_block) for tr_block in tool_results]
+    visible_results = []
+    for tr_block in normalized_results:
+        if _is_synthetic_ask_user_response_result(
+            tr_block, tool_names_by_id, request_context
+        ):
+            tr_block["is_error"] = False
+            _record_tool_result(tool_stats, tr_block)
+            continue
         _record_tool_result(tool_stats, tr_block)
+        visible_results.append(tr_block)
 
     is_subagent_result = parent_id is not None
     if is_subagent_result and not SUBAGENT_STREAM_TOOL_BLOCKS:
@@ -435,7 +479,7 @@ def _user_tool_result_events(
             sequence_number=next_seq(),
             parent_tool_use_id=parent_id,
         )
-        for tr_block in tool_results
+        for tr_block in visible_results
     ]
 
 
@@ -443,14 +487,25 @@ def _embedded_tool_events(
     chunk: Dict[str, Any],
     tool_stats: ToolStatsCollector,
     next_seq: Callable[[], int],
+    tool_names_by_id: Dict[str, str],
+    request_context: Optional[Dict[str, Any]],
 ) -> list[str]:
     events = []
     for tool_block in extract_embedded_tool_blocks(chunk):
         block_type = _block_field(tool_block, "type")
+        result_block = None
+        suppress_result = False
         if block_type == "tool_use":
+            _remember_tool_use(tool_names_by_id, tool_block)
             _record_tool_use(tool_stats, tool_block)
         elif block_type == "tool_result":
-            _record_tool_result(tool_stats, tool_block)
+            result_block = _normalize_tool_result(tool_block)
+            suppress_result = _is_synthetic_ask_user_response_result(
+                result_block, tool_names_by_id, request_context
+            )
+            if suppress_result:
+                result_block["is_error"] = False
+            _record_tool_result(tool_stats, result_block)
 
         is_subagent_block = tool_block.get("parent_tool_use_id") is not None
         if is_subagent_block and not SUBAGENT_STREAM_TOOL_BLOCKS:
@@ -464,9 +519,11 @@ def _embedded_tool_events(
                 )
             )
         elif block_type == "tool_result":
+            if suppress_result:
+                continue
             events.append(
                 make_tool_result_response_sse(
-                    tool_block,
+                    result_block if result_block is not None else tool_block,
                     sequence_number=next_seq(),
                     parent_tool_use_id=tool_block.get("parent_tool_use_id"),
                 )
@@ -512,6 +569,7 @@ async def stream_response_chunks(
     # aggregates tool-call name/count/errors/latency for the usage_tool table.
     usage_start = time.monotonic()
     tool_stats = ToolStatsCollector()
+    tool_names_by_id: Dict[str, str] = {}
 
     def _next_seq() -> int:
         nonlocal seq
@@ -679,13 +737,17 @@ async def stream_response_chunks(
             handled, tool_block = tool_acc.process_stream_event(chunk)
             if handled:
                 if tool_block:
-                    for event in _tool_use_events(tool_block, tool_stats, _next_seq):
+                    for event in _tool_use_events(
+                        tool_block, tool_stats, _next_seq, tool_names_by_id
+                    ):
                         yield event
                 continue
 
             # User chunks with tool_result blocks
             if chunk.get("type") == "user":
-                for event in _user_tool_result_events(chunk, tool_stats, _next_seq):
+                for event in _user_tool_result_events(
+                    chunk, tool_stats, _next_seq, tool_names_by_id, request_context
+                ):
                     yield event
                 chunks_buffer.append(chunk)
                 continue
@@ -694,7 +756,9 @@ async def stream_response_chunks(
             # This MUST run before the token-streaming skip below so that tool
             # blocks inside assistant content chunks are not silently dropped
             # when token_streaming is True.
-            for event in _embedded_tool_events(chunk, tool_stats, _next_seq):
+            for event in _embedded_tool_events(
+                chunk, tool_stats, _next_seq, tool_names_by_id, request_context
+            ):
                 yield event
 
             # Skip duplicate assistant text in token-streaming mode.

--- a/src/workspace_manager.py
+++ b/src/workspace_manager.py
@@ -95,7 +95,12 @@ class WorkspaceManager:
             logger.debug("Template source .claude/ not found at %s, skipping sync", src)
             return
         dst = workspace / ".claude"
-        shutil.copytree(src, dst, dirs_exist_ok=True)
+        if dst.exists():
+            if dst.is_symlink():
+                dst.unlink()
+            else:
+                shutil.rmtree(dst)
+        shutil.copytree(src, dst)
         logger.debug("Synced .claude/ template to %s", dst)
 
     def _sync_project_files(self, workspace: Path) -> None:

--- a/tests/integration/test_opencode_smoke.py
+++ b/tests/integration/test_opencode_smoke.py
@@ -1,4 +1,4 @@
-"""Optional live smoke test for an external OpenCode server."""
+"""Optional live smoke test for managed OpenCode."""
 
 import os
 
@@ -6,33 +6,37 @@ import pytest
 
 
 pytestmark = pytest.mark.skipif(
-    not os.getenv("OPENCODE_SMOKE_BASE_URL"),
-    reason="OPENCODE_SMOKE_BASE_URL is required for live OpenCode smoke tests",
+    os.getenv("OPENCODE_SMOKE_ENABLED") != "1",
+    reason="OPENCODE_SMOKE_ENABLED=1 is required for live OpenCode smoke tests",
 )
 
 
 async def test_live_opencode_health_and_prompt(monkeypatch):
-    monkeypatch.setenv("OPENCODE_BASE_URL", os.environ["OPENCODE_SMOKE_BASE_URL"])
+    monkeypatch.delenv("OPENCODE_BASE_URL", raising=False)
 
     from src.backends.opencode.client import OpenCodeClient
     from src.session_manager import Session
 
+    chunks = []
     backend = OpenCodeClient()
-    assert await backend.verify() is True
+    try:
+        assert await backend.verify() is True
 
-    session = Session(session_id="opencode-smoke")
-    client = await backend.create_client(
-        session=session,
-        model=os.getenv("OPENCODE_SMOKE_MODEL", "openai/gpt-5.5"),
-        cwd=os.getenv("OPENCODE_SMOKE_CWD") or None,
-    )
-    chunks = [
-        chunk
-        async for chunk in backend.run_completion_with_client(
-            client,
-            "Reply with exactly: smoke-ok",
-            session,
+        session = Session(session_id="opencode-smoke")
+        client = await backend.create_client(
+            session=session,
+            model=os.environ["OPENCODE_SMOKE_MODEL"],
+            cwd=os.getenv("OPENCODE_SMOKE_CWD") or None,
         )
-    ]
+        chunks = [
+            chunk
+            async for chunk in backend.run_completion_with_client(
+                client,
+                "Reply with exactly: smoke-ok",
+                session,
+            )
+        ]
+    finally:
+        backend.close()
 
     assert "smoke-ok" in (backend.parse_message(chunks) or "")

--- a/tests/integration/test_opencode_smoke.py
+++ b/tests/integration/test_opencode_smoke.py
@@ -1,0 +1,38 @@
+"""Optional live smoke test for an external OpenCode server."""
+
+import os
+
+import pytest
+
+
+pytestmark = pytest.mark.skipif(
+    not os.getenv("OPENCODE_SMOKE_BASE_URL"),
+    reason="OPENCODE_SMOKE_BASE_URL is required for live OpenCode smoke tests",
+)
+
+
+async def test_live_opencode_health_and_prompt(monkeypatch):
+    monkeypatch.setenv("OPENCODE_BASE_URL", os.environ["OPENCODE_SMOKE_BASE_URL"])
+
+    from src.backends.opencode.client import OpenCodeClient
+    from src.session_manager import Session
+
+    backend = OpenCodeClient()
+    assert await backend.verify() is True
+
+    session = Session(session_id="opencode-smoke")
+    client = await backend.create_client(
+        session=session,
+        model=os.getenv("OPENCODE_SMOKE_MODEL", "openai/gpt-5.5"),
+        cwd=os.getenv("OPENCODE_SMOKE_CWD") or None,
+    )
+    chunks = [
+        chunk
+        async for chunk in backend.run_completion_with_client(
+            client,
+            "Reply with exactly: smoke-ok",
+            session,
+        )
+    ]
+
+    assert "smoke-ok" in (backend.parse_message(chunks) or "")

--- a/tests/test_admin_routes_coverage.py
+++ b/tests/test_admin_routes_coverage.py
@@ -52,6 +52,25 @@ class TestAdminPage:
         assert "Failed to load full message" in r.text
 
 
+class TestAdminChatPage:
+    def test_get_admin_chat_page(self, admin_client):
+        r = admin_client.get("/admin/chat")
+
+        assert r.status_code == 200
+        assert "text/html" in r.headers["content-type"]
+        assert "GATEWAY CHAT" in r.text
+
+    def test_admin_chat_page_supports_multi_select_ask_questions(self, admin_client):
+        r = admin_client.get("/admin/chat")
+
+        assert r.status_code == 200
+        assert "data-multiple" in r.text
+        assert "ask-option-marker" in r.text
+        assert "aria-pressed" in r.text
+        assert "questions = [argsObj]" in r.text
+        assert "JSON.stringify(answersByQuestion)" in r.text
+
+
 class TestAdminAuth:
     def test_logout(self, admin_client):
         r = admin_client.post("/admin/api/logout")

--- a/tests/test_admin_service_unit.py
+++ b/tests/test_admin_service_unit.py
@@ -20,6 +20,50 @@ from src.admin_service import (
 )
 
 
+async def test_admin_backend_health_includes_opencode_metadata(monkeypatch):
+    """Backend health includes runtime metadata exposed by OpenCode."""
+    from src.admin_service import get_backends_health
+    from src.backends.base import BackendDescriptor, BackendRegistry, ResolvedModel
+
+    monkeypatch.setenv("OPENCODE_BASE_URL", "http://127.0.0.1:4096")
+
+    def resolve(model):
+        if model == "opencode/openai/gpt-5.5":
+            return ResolvedModel(model, "opencode", "openai/gpt-5.5")
+        return None
+
+    class FakeOpenCodeBackend:
+        name = "opencode"
+
+        def supported_models(self):
+            return ["opencode/openai/gpt-5.5"]
+
+        async def verify(self):
+            return True
+
+        def runtime_metadata(self):
+            return {
+                "mode": "external",
+                "base_url": "http://127.0.0.1:4096",
+                "agent": "general",
+                "models": ["opencode/openai/gpt-5.5"],
+                "managed_process": False,
+            }
+
+    BackendRegistry.clear()
+    BackendRegistry.register_descriptor(
+        BackendDescriptor("opencode", "opencode", ["opencode/openai/gpt-5.5"], resolve)
+    )
+    BackendRegistry.register("opencode", FakeOpenCodeBackend())
+
+    health = await get_backends_health()
+
+    opencode = next(item for item in health if item["name"] == "opencode")
+    assert opencode["metadata"]["mode"] == "external"
+    assert opencode["metadata"]["base_url"] == "http://127.0.0.1:4096"
+    assert opencode["metadata"]["models"] == ["opencode/openai/gpt-5.5"]
+
+
 @pytest.fixture
 def workspace(tmp_path):
     """Create a realistic workspace with .claude directory."""

--- a/tests/test_admin_service_unit.py
+++ b/tests/test_admin_service_unit.py
@@ -25,8 +25,6 @@ async def test_admin_backend_health_includes_opencode_metadata(monkeypatch):
     from src.admin_service import get_backends_health
     from src.backends.base import BackendDescriptor, BackendRegistry, ResolvedModel
 
-    monkeypatch.setenv("OPENCODE_BASE_URL", "http://127.0.0.1:4096")
-
     def resolve(model):
         if model == "opencode/openai/gpt-5.5":
             return ResolvedModel(model, "opencode", "openai/gpt-5.5")
@@ -43,11 +41,11 @@ async def test_admin_backend_health_includes_opencode_metadata(monkeypatch):
 
         def runtime_metadata(self):
             return {
-                "mode": "external",
+                "mode": "managed",
                 "base_url": "http://127.0.0.1:4096",
                 "agent": "general",
                 "models": ["opencode/openai/gpt-5.5"],
-                "managed_process": False,
+                "managed_process": True,
             }
 
     BackendRegistry.clear()
@@ -59,7 +57,7 @@ async def test_admin_backend_health_includes_opencode_metadata(monkeypatch):
     health = await get_backends_health()
 
     opencode = next(item for item in health if item["name"] == "opencode")
-    assert opencode["metadata"]["mode"] == "external"
+    assert opencode["metadata"]["mode"] == "managed"
     assert opencode["metadata"]["base_url"] == "http://127.0.0.1:4096"
     assert opencode["metadata"]["models"] == ["opencode/openai/gpt-5.5"]
 

--- a/tests/test_backends_init_unit.py
+++ b/tests/test_backends_init_unit.py
@@ -83,6 +83,70 @@ class TestDiscoverBackends:
             assert "claude" in FakeRegistry.descriptors
             assert "claude" in FakeRegistry.clients
 
+    def test_discover_backends_respects_backends_env(self, monkeypatch):
+        """BACKENDS=claude,opencode registers both backends in order."""
+        import src.backends.claude as claude_pkg
+        import src.backends.opencode as opencode_pkg
+
+        calls = []
+
+        def fake_claude_register(registry_cls=None):
+            calls.append(("claude", registry_cls))
+
+        def fake_opencode_register(registry_cls=None):
+            calls.append(("opencode", registry_cls))
+
+        monkeypatch.setenv("BACKENDS", "claude,opencode")
+        monkeypatch.setattr(claude_pkg, "register", fake_claude_register)
+        monkeypatch.setattr(opencode_pkg, "register", fake_opencode_register)
+
+        from src.backends import discover_backends
+
+        discover_backends(registry_cls="registry")
+
+        assert calls == [("claude", "registry"), ("opencode", "registry")]
+
+    def test_discover_backends_defaults_to_claude_only(self, monkeypatch):
+        """Unset BACKENDS preserves current Claude-only startup behavior."""
+        import src.backends.claude as claude_pkg
+        import src.backends.opencode as opencode_pkg
+
+        calls = []
+
+        monkeypatch.delenv("BACKENDS", raising=False)
+        monkeypatch.setattr(claude_pkg, "register", lambda registry_cls=None: calls.append("claude"))
+        monkeypatch.setattr(
+            opencode_pkg, "register", lambda registry_cls=None: calls.append("opencode")
+        )
+
+        from src.backends import discover_backends
+
+        discover_backends()
+
+        assert calls == ["claude"]
+
+    def test_discover_backends_skips_unknown_backend(self, monkeypatch, caplog):
+        """Unknown BACKENDS entries are warned and skipped."""
+        import logging
+        import src.backends.claude as claude_pkg
+        import src.backends.opencode as opencode_pkg
+
+        calls = []
+
+        monkeypatch.setenv("BACKENDS", "unknown,opencode")
+        monkeypatch.setattr(claude_pkg, "register", lambda registry_cls=None: calls.append("claude"))
+        monkeypatch.setattr(
+            opencode_pkg, "register", lambda registry_cls=None: calls.append("opencode")
+        )
+
+        from src.backends import discover_backends
+
+        with caplog.at_level(logging.WARNING, logger="src.backends"):
+            discover_backends()
+
+        assert calls == ["opencode"]
+        assert any("Unknown backend in BACKENDS" in record.message for record in caplog.records)
+
 
 # ===========================================================================
 # src/backends/claude/__init__.py — __getattr__ lazy imports

--- a/tests/test_docker_packaging.py
+++ b/tests/test_docker_packaging.py
@@ -1,0 +1,24 @@
+"""Docker packaging expectations."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_dockerfile_installs_opencode_binary_for_managed_mode():
+    """The gateway image should be able to start managed OpenCode itself."""
+    dockerfile = (ROOT / "Dockerfile").read_text()
+
+    assert "ARG OPENCODE_VERSION=" in dockerfile
+    assert "https://opencode.ai/install" in dockerfile
+    assert "--version ${OPENCODE_VERSION}" in dockerfile
+    assert "/root/.opencode/bin" in dockerfile
+    assert "opencode --version" in dockerfile
+
+
+def test_compose_does_not_configure_external_opencode_server():
+    """Compose should not point the gateway at a separate OpenCode service."""
+    compose = (ROOT / "docker-compose.yml").read_text()
+
+    assert "OPENCODE_BASE_URL" not in compose

--- a/tests/test_image_endpoints.py
+++ b/tests/test_image_endpoints.py
@@ -170,6 +170,14 @@ class TestValidateImageRequest:
         # Should not raise
         _validate_image_request(req, backend)
 
+    def test_validate_image_request_passes_for_opencode(self):
+        """OpenCode supports image input through request file parts."""
+        req = self._make_image_request()
+        backend = MagicMock(spec=[])
+        backend.name = "opencode"
+
+        _validate_image_request(req, backend)
+
     def test_validate_image_request_no_images_always_passes(self):
         """No error when request contains no images, regardless of backend support."""
         text_input = [{"role": "user", "content": [{"type": "input_text", "text": "no image"}]}]

--- a/tests/test_main_api_unit.py
+++ b/tests/test_main_api_unit.py
@@ -17,7 +17,7 @@ import src.routes.responses as responses_module
 import src.routes.general as general_module
 import src.routes.sessions as sessions_module
 from src.auth import auth_manager
-from src.backend_registry import BackendRegistry
+from src.backend_registry import BackendDescriptor, BackendRegistry, ResolvedModel
 from src.constants import DEFAULT_MODEL
 from src.models import SessionInfo
 
@@ -121,6 +121,84 @@ def test_models_version_and_root_endpoints():
     assert version_response.json()["service"] == "claude-code-gateway"
     assert root_response.status_code == 200
     assert "Claude Code Gateway" in root_response.text
+
+
+def test_models_endpoint_lists_opencode_models_when_registered():
+    """The model list includes registered OpenCode descriptor models."""
+
+    def resolve(model):
+        if model == "opencode/anthropic/claude-sonnet-4-5":
+            return ResolvedModel(model, "opencode", "anthropic/claude-sonnet-4-5")
+        return None
+
+    backend = MagicMock()
+    backend.name = "opencode"
+    BackendRegistry.register_descriptor(
+        BackendDescriptor(
+            name="opencode",
+            owned_by="opencode",
+            models=["opencode/anthropic/claude-sonnet-4-5"],
+            resolve_fn=resolve,
+        )
+    )
+    BackendRegistry.register("opencode", backend)
+
+    with client_context() as (client, _mock_cli):
+        response = client.get("/v1/models")
+
+    assert response.status_code == 200
+    ids = [item["id"] for item in response.json()["data"]]
+    assert "opencode/anthropic/claude-sonnet-4-5" in ids
+
+
+def test_responses_dispatches_to_opencode_backend_without_mcp():
+    """Responses requests for opencode/... models dispatch to OpenCode backend."""
+    calls = {}
+
+    def resolve(model):
+        if model == "opencode/anthropic/claude-sonnet-4-5":
+            return ResolvedModel(model, "opencode", "anthropic/claude-sonnet-4-5")
+        return None
+
+    async def create_client(**kwargs):
+        calls["create_client"] = kwargs
+        return object()
+
+    async def run_completion_with_client(client, prompt, session):
+        calls["prompt"] = prompt
+        yield {"content": [{"type": "text", "text": "OpenCode response"}]}
+        yield {"type": "result", "subtype": "success", "result": "OpenCode response"}
+
+    backend = MagicMock()
+    backend.name = "opencode"
+    backend.create_client = create_client
+    backend.run_completion_with_client = run_completion_with_client
+    backend.parse_message.return_value = "OpenCode response"
+    backend.estimate_token_usage.return_value = {
+        "prompt_tokens": 2,
+        "completion_tokens": 4,
+        "total_tokens": 6,
+    }
+    BackendRegistry.register_descriptor(
+        BackendDescriptor(
+            name="opencode",
+            owned_by="opencode",
+            models=["opencode/anthropic/claude-sonnet-4-5"],
+            resolve_fn=resolve,
+        )
+    )
+    BackendRegistry.register("opencode", backend)
+
+    with client_context() as (client, _mock_cli):
+        response = client.post(
+            "/v1/responses",
+            json={"model": "opencode/anthropic/claude-sonnet-4-5", "input": "hi"},
+        )
+
+    assert response.status_code == 200
+    assert calls["create_client"]["model"] == "anthropic/claude-sonnet-4-5"
+    assert calls["create_client"]["mcp_servers"] is None
+    assert calls["prompt"] == "hi"
 
 
 def test_list_mcp_servers_filters_safe_fields():

--- a/tests/test_main_api_unit.py
+++ b/tests/test_main_api_unit.py
@@ -514,7 +514,7 @@ def test_opencode_question_tool_use_returns_requires_action(isolated_session_man
     data = response.json()
     assert data["status"] == "requires_action"
     assert data["output"][0]["call_id"] == "q1"
-    assert data["output"][0]["name"] == "question"
+    assert data["output"][0]["name"] == "AskUserQuestion"
     assert json.loads(data["output"][0]["arguments"]) == {
         "question": "Continue?",
         "options": [{"label": "Yes"}, {"label": "No"}],
@@ -522,7 +522,7 @@ def test_opencode_question_tool_use_returns_requires_action(isolated_session_man
     session = next(iter(isolated_session_manager.sessions.values()))
     assert session.pending_tool_call == {
         "call_id": "q1",
-        "name": "question",
+        "name": "AskUserQuestion",
         "arguments": {
             "question": "Continue?",
             "options": [{"label": "Yes"}, {"label": "No"}],
@@ -530,6 +530,158 @@ def test_opencode_question_tool_use_returns_requires_action(isolated_session_man
         "backend": "opencode",
     }
     assert session.turn_counter == 1
+
+
+def test_opencode_questions_array_tool_use_returns_ask_user_question(
+    isolated_session_manager,
+):
+    """OpenCode question tool input is normalized to the AskUserQuestion interface."""
+
+    def resolve(model):
+        if model == "opencode/openai/gpt-5.5":
+            return ResolvedModel(model, "opencode", "openai/gpt-5.5")
+        return None
+
+    async def create_client(**kwargs):
+        return object()
+
+    async def run_completion_with_client(client, prompt, session):
+        yield {
+            "type": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "q1",
+                    "name": "question",
+                    "input": {
+                        "questions": [
+                            {
+                                "question": "question 도구 테스트입니다. 어떤 방식으로 진행할까요?",
+                                "header": "도구 테스트",
+                                "options": [
+                                    {
+                                        "label": "간단 응답",
+                                        "description": "선택 결과만 확인합니다.",
+                                    },
+                                    {
+                                        "label": "짧은 설명",
+                                        "description": "question 도구 사용 결과를 설명합니다.",
+                                    },
+                                ],
+                                "multiple": False,
+                            }
+                        ]
+                    },
+                }
+            ],
+        }
+
+    backend = MagicMock()
+    backend.name = "opencode"
+    backend.create_client = create_client
+    backend.run_completion_with_client = run_completion_with_client
+    backend.parse_message.return_value = None
+    backend.estimate_token_usage.return_value = {
+        "prompt_tokens": 1,
+        "completion_tokens": 1,
+        "total_tokens": 2,
+    }
+
+    BackendRegistry.clear()
+    BackendRegistry.register_descriptor(
+        BackendDescriptor("opencode", "opencode", ["opencode/openai/gpt-5.5"], resolve)
+    )
+    BackendRegistry.register("opencode", backend)
+
+    with client_context() as (client, _):
+        response = client.post(
+            "/v1/responses",
+            json={"model": "opencode/openai/gpt-5.5", "input": "hi"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "requires_action"
+    assert data["output"][0]["call_id"] == "q1"
+    assert data["output"][0]["name"] == "AskUserQuestion"
+    arguments = json.loads(data["output"][0]["arguments"])
+    assert arguments["questions"][0]["header"] == "도구 테스트"
+    assert arguments["questions"][0]["options"][0]["label"] == "간단 응답"
+
+    session = next(iter(isolated_session_manager.sessions.values()))
+    assert session.pending_tool_call == {
+        "call_id": "q1",
+        "name": "AskUserQuestion",
+        "arguments": arguments,
+        "backend": "opencode",
+    }
+    assert session.turn_counter == 1
+
+
+def test_opencode_streaming_question_tool_use_emits_ask_user_question(
+    isolated_session_manager,
+):
+    """Streaming OpenCode question tool calls use the AskUserQuestion wire name."""
+
+    def resolve(model):
+        if model == "opencode/openai/gpt-5.5":
+            return ResolvedModel(model, "opencode", "openai/gpt-5.5")
+        return None
+
+    async def create_client(**kwargs):
+        return object()
+
+    async def run_completion_with_client(client, prompt, session):
+        yield {
+            "type": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "q1",
+                    "name": "question",
+                    "input": {
+                        "questions": [
+                            {
+                                "question": "Continue?",
+                                "options": [{"label": "Yes"}, {"label": "No"}],
+                            }
+                        ]
+                    },
+                }
+            ],
+        }
+
+    backend = MagicMock()
+    backend.name = "opencode"
+    backend.create_client = create_client
+    backend.run_completion_with_client = run_completion_with_client
+    backend.parse_message.return_value = None
+    backend.estimate_token_usage.return_value = {
+        "prompt_tokens": 1,
+        "completion_tokens": 1,
+        "total_tokens": 2,
+    }
+
+    BackendRegistry.clear()
+    BackendRegistry.register_descriptor(
+        BackendDescriptor("opencode", "opencode", ["opencode/openai/gpt-5.5"], resolve)
+    )
+    BackendRegistry.register("opencode", backend)
+
+    with client_context() as (client, _):
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": "opencode/openai/gpt-5.5",
+                "input": "hi",
+                "stream": True,
+            },
+        )
+
+    assert response.status_code == 200
+    assert '"status": "requires_action"' in response.text
+    assert '"name": "AskUserQuestion"' in response.text
+    assert '"name": "question"' not in response.text
 
 
 def test_list_mcp_servers_filters_safe_fields():

--- a/tests/test_main_api_unit.py
+++ b/tests/test_main_api_unit.py
@@ -276,6 +276,59 @@ def test_responses_streaming_enables_opencode_event_streaming():
     assert calls["stream_events_at_call"] is True
 
 
+def test_opencode_streaming_disconnects_client_on_error(isolated_session_manager):
+    """Streaming OpenCode failures disconnect the persistent session client."""
+
+    class FakeOpenCodeSessionClient:
+        stream_events = False
+
+        def __init__(self):
+            self.disconnected = False
+
+        async def disconnect(self):
+            self.disconnected = True
+
+    created_client = FakeOpenCodeSessionClient()
+
+    def resolve(model):
+        if model == "opencode/openai/gpt-5.5":
+            return ResolvedModel(model, "opencode", "openai/gpt-5.5")
+        return None
+
+    async def create_client(**kwargs):
+        return created_client
+
+    async def run_completion_with_client(client, prompt, session):
+        yield {"type": "error", "is_error": True, "error_message": "stream failed"}
+
+    backend = MagicMock()
+    backend.name = "opencode"
+    backend.create_client = create_client
+    backend.run_completion_with_client = run_completion_with_client
+    backend.parse_message.return_value = None
+    backend.estimate_token_usage.return_value = {
+        "prompt_tokens": 1,
+        "completion_tokens": 1,
+        "total_tokens": 2,
+    }
+
+    BackendRegistry.clear()
+    BackendRegistry.register_descriptor(
+        BackendDescriptor("opencode", "opencode", ["opencode/openai/gpt-5.5"], resolve)
+    )
+    BackendRegistry.register("opencode", backend)
+
+    with client_context() as (client, _):
+        response = client.post(
+            "/v1/responses",
+            json={"model": "opencode/openai/gpt-5.5", "input": "hi", "stream": True},
+        )
+
+    assert response.status_code == 200
+    assert "response.failed" in response.text
+    assert created_client.disconnected is True
+
+
 def test_list_mcp_servers_filters_safe_fields():
     mcp_return = {
         "stdio-server": {

--- a/tests/test_main_api_unit.py
+++ b/tests/test_main_api_unit.py
@@ -684,6 +684,55 @@ def test_opencode_streaming_question_tool_use_emits_ask_user_question(
     assert '"name": "question"' not in response.text
 
 
+async def test_opencode_question_capture_stops_waiting_for_stream_end():
+    """OpenCode question pauses should not wait for the backend event stream to idle."""
+    resolved = ResolvedModel(
+        "opencode/openai/gpt-5.5",
+        "opencode",
+        "openai/gpt-5.5",
+    )
+    session = MagicMock()
+    session.pending_tool_call = None
+    source_closed = False
+
+    async def chunk_source():
+        nonlocal source_closed
+        try:
+            yield {
+                "type": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "q1",
+                        "name": "question",
+                        "input": {"question": "Continue?"},
+                    }
+                ],
+            }
+            await asyncio.Event().wait()
+        finally:
+            source_closed = True
+
+    captured = responses_module._capture_opencode_pending_questions(
+        chunk_source(), resolved, session
+    )
+
+    try:
+        await asyncio.wait_for(captured.__anext__(), timeout=0.05)
+    except StopAsyncIteration:
+        pass
+    finally:
+        await captured.aclose()
+
+    assert session.pending_tool_call == {
+        "call_id": "q1",
+        "name": "AskUserQuestion",
+        "arguments": {"question": "Continue?"},
+        "backend": "opencode",
+    }
+    assert source_closed is True
+
+
 def test_list_mcp_servers_filters_safe_fields():
     mcp_return = {
         "stdio-server": {

--- a/tests/test_main_api_unit.py
+++ b/tests/test_main_api_unit.py
@@ -4,6 +4,8 @@ Integration-style unit tests for FastAPI endpoints in src.main.
 """
 
 import asyncio
+import json
+import uuid
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -327,6 +329,138 @@ def test_opencode_streaming_disconnects_client_on_error(isolated_session_manager
     assert response.status_code == 200
     assert "response.failed" in response.text
     assert created_client.disconnected is True
+
+
+def test_opencode_function_call_output_resumes_question(isolated_session_manager):
+    """OpenCode function_call_output resumes a pending question via the backend API."""
+    session_id = str(uuid.uuid4())
+    session = isolated_session_manager.get_or_create_session(session_id)
+    session.backend = "opencode"
+    session.turn_counter = 1
+    session.client = object()
+    session.pending_tool_call = {
+        "call_id": "q1",
+        "name": "question",
+        "arguments": {"question": "Continue?"},
+        "backend": "opencode",
+    }
+
+    def resolve(model):
+        if model == "opencode/openai/gpt-5.5":
+            return ResolvedModel(model, "opencode", "openai/gpt-5.5")
+        return None
+
+    async def resume_question_with_client(client, call_id, output, session):
+        assert call_id == "q1"
+        assert output == "yes"
+        yield {"type": "assistant", "content": [{"type": "text", "text": "continued"}]}
+        yield {"type": "result", "subtype": "success", "result": "continued"}
+
+    backend = MagicMock()
+    backend.name = "opencode"
+    backend.resume_question_with_client = resume_question_with_client
+    backend.parse_message.return_value = "continued"
+    backend.estimate_token_usage.return_value = {
+        "prompt_tokens": 1,
+        "completion_tokens": 1,
+        "total_tokens": 2,
+    }
+
+    BackendRegistry.clear()
+    BackendRegistry.register_descriptor(
+        BackendDescriptor("opencode", "opencode", ["opencode/openai/gpt-5.5"], resolve)
+    )
+    BackendRegistry.register("opencode", backend)
+
+    with client_context() as (client, _):
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": "opencode/openai/gpt-5.5",
+                "previous_response_id": responses_module._make_response_id(session_id, 1),
+                "input": [
+                    {"type": "function_call_output", "call_id": "q1", "output": "yes"}
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "completed"
+    assert response.json()["output"][0]["content"][0]["text"] == "continued"
+    assert session.pending_tool_call is None
+    assert session.turn_counter == 2
+
+
+def test_opencode_question_tool_use_returns_requires_action(isolated_session_manager):
+    """OpenCode question tool_use chunks become Responses requires_action output."""
+
+    def resolve(model):
+        if model == "opencode/openai/gpt-5.5":
+            return ResolvedModel(model, "opencode", "openai/gpt-5.5")
+        return None
+
+    async def create_client(**kwargs):
+        return object()
+
+    async def run_completion_with_client(client, prompt, session):
+        yield {
+            "type": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "q1",
+                    "name": "question",
+                    "input": {
+                        "question": "Continue?",
+                        "options": [{"label": "Yes"}, {"label": "No"}],
+                    },
+                }
+            ],
+        }
+
+    backend = MagicMock()
+    backend.name = "opencode"
+    backend.create_client = create_client
+    backend.run_completion_with_client = run_completion_with_client
+    backend.parse_message.return_value = None
+    backend.estimate_token_usage.return_value = {
+        "prompt_tokens": 1,
+        "completion_tokens": 1,
+        "total_tokens": 2,
+    }
+
+    BackendRegistry.clear()
+    BackendRegistry.register_descriptor(
+        BackendDescriptor("opencode", "opencode", ["opencode/openai/gpt-5.5"], resolve)
+    )
+    BackendRegistry.register("opencode", backend)
+
+    with client_context() as (client, _):
+        response = client.post(
+            "/v1/responses",
+            json={"model": "opencode/openai/gpt-5.5", "input": "hi"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "requires_action"
+    assert data["output"][0]["call_id"] == "q1"
+    assert data["output"][0]["name"] == "question"
+    assert json.loads(data["output"][0]["arguments"]) == {
+        "question": "Continue?",
+        "options": [{"label": "Yes"}, {"label": "No"}],
+    }
+    session = next(iter(isolated_session_manager.sessions.values()))
+    assert session.pending_tool_call == {
+        "call_id": "q1",
+        "name": "question",
+        "arguments": {
+            "question": "Continue?",
+            "options": [{"label": "Yes"}, {"label": "No"}],
+        },
+        "backend": "opencode",
+    }
+    assert session.turn_counter == 1
 
 
 def test_list_mcp_servers_filters_safe_fields():

--- a/tests/test_main_api_unit.py
+++ b/tests/test_main_api_unit.py
@@ -201,6 +201,81 @@ def test_responses_dispatches_to_opencode_backend_without_mcp():
     assert calls["prompt"] == "hi"
 
 
+def test_responses_streaming_enables_opencode_event_streaming():
+    """Streaming OpenCode responses ask the OpenCode client to use /event."""
+    calls = {}
+
+    class FakeOpenCodeSessionClient:
+        stream_events = False
+
+    def resolve(model):
+        if model == "opencode/anthropic/claude-sonnet-4-5":
+            return ResolvedModel(model, "opencode", "anthropic/claude-sonnet-4-5")
+        return None
+
+    async def create_client(**kwargs):
+        calls["create_client"] = kwargs
+        return FakeOpenCodeSessionClient()
+
+    def run_completion_with_client(client, prompt, session):
+        calls["stream_events_at_call"] = client.stream_events
+
+        async def empty_source():
+            if False:
+                yield None
+
+        return empty_source()
+
+    async def fake_stream_response_chunks(**kwargs):
+        kwargs["stream_result"]["success"] = True
+        kwargs["stream_result"]["assistant_text"] = "OpenCode streamed"
+        yield 'event: response.created\ndata: {"type":"response.created","sequence_number":0}\n\n'
+
+    backend = MagicMock()
+    backend.name = "opencode"
+    backend.create_client = create_client
+    backend.run_completion_with_client = run_completion_with_client
+    backend.parse_message.return_value = "OpenCode streamed"
+    backend.estimate_token_usage.return_value = {
+        "prompt_tokens": 2,
+        "completion_tokens": 4,
+        "total_tokens": 6,
+    }
+    BackendRegistry.register_descriptor(
+        BackendDescriptor(
+            name="opencode",
+            owned_by="opencode",
+            models=["opencode/anthropic/claude-sonnet-4-5"],
+            resolve_fn=resolve,
+        )
+    )
+    BackendRegistry.register("opencode", backend)
+
+    with (
+        client_context() as (client, _mock_cli),
+        patch.object(
+            responses_module.streaming_utils,
+            "stream_response_chunks",
+            new=fake_stream_response_chunks,
+        ),
+    ):
+        with client.stream(
+            "POST",
+            "/v1/responses",
+            json={
+                "model": "opencode/anthropic/claude-sonnet-4-5",
+                "input": "hi",
+                "stream": True,
+            },
+        ) as response:
+            body = "".join(response.iter_text())
+
+    assert response.status_code == 200
+    assert "response.created" in body
+    assert calls["create_client"]["model"] == "anthropic/claude-sonnet-4-5"
+    assert calls["stream_events_at_call"] is True
+
+
 def test_list_mcp_servers_filters_safe_fields():
     mcp_return = {
         "stdio-server": {

--- a/tests/test_main_api_unit.py
+++ b/tests/test_main_api_unit.py
@@ -343,6 +343,7 @@ def test_opencode_function_call_output_resumes_question(isolated_session_manager
         "name": "question",
         "arguments": {"question": "Continue?"},
         "backend": "opencode",
+        "opencode_resume": "question",
     }
 
     def resolve(model):
@@ -378,9 +379,7 @@ def test_opencode_function_call_output_resumes_question(isolated_session_manager
             json={
                 "model": "opencode/openai/gpt-5.5",
                 "previous_response_id": responses_module._make_response_id(session_id, 1),
-                "input": [
-                    {"type": "function_call_output", "call_id": "q1", "output": "yes"}
-                ],
+                "input": [{"type": "function_call_output", "call_id": "q1", "output": "yes"}],
             },
         )
 
@@ -403,6 +402,7 @@ def test_opencode_streaming_function_call_output_resumes_question(isolated_sessi
         "name": "question",
         "arguments": {"question": "Continue?"},
         "backend": "opencode",
+        "opencode_resume": "question",
     }
     calls = {}
 
@@ -439,9 +439,7 @@ def test_opencode_streaming_function_call_output_resumes_question(isolated_sessi
             json={
                 "model": "opencode/openai/gpt-5.5",
                 "previous_response_id": responses_module._make_response_id(session_id, 1),
-                "input": [
-                    {"type": "function_call_output", "call_id": "q1", "output": "yes"}
-                ],
+                "input": [{"type": "function_call_output", "call_id": "q1", "output": "yes"}],
                 "stream": True,
             },
         )
@@ -456,6 +454,84 @@ def test_opencode_streaming_function_call_output_resumes_question(isolated_sessi
     assert "continued" in response.text
     assert "response.completed" in response.text
     assert "response.failed" not in response.text
+    assert session.pending_tool_call is None
+    assert session.turn_counter == 2
+
+
+def test_opencode_function_call_output_resumes_permission(isolated_session_manager):
+    """OpenCode permission outputs resume via the permission reply API."""
+    session_id = str(uuid.uuid4())
+    session = isolated_session_manager.get_or_create_session(session_id)
+    session.backend = "opencode"
+    session.turn_counter = 1
+    session.client = object()
+    session.pending_tool_call = {
+        "call_id": "perm_1",
+        "name": "AskUserQuestion",
+        "arguments": {"question": "Allow bash?", "options": [{"label": "always"}]},
+        "backend": "opencode",
+        "opencode_resume": "permission",
+    }
+    calls = {}
+
+    def resolve(model):
+        if model == "opencode/openai/gpt-5.5":
+            return ResolvedModel(model, "opencode", "openai/gpt-5.5")
+        return None
+
+    async def resume_question_with_client(client, call_id, output, session):
+        calls["question"] = {"call_id": call_id, "output": output}
+        yield {"type": "assistant", "content": [{"type": "text", "text": "wrong"}]}
+        yield {"type": "result", "subtype": "success", "result": "wrong"}
+
+    async def resume_permission_with_client(client, call_id, output, session):
+        calls["permission"] = {"client": client, "call_id": call_id, "output": output}
+        yield {"type": "assistant", "content": [{"type": "text", "text": "approved"}]}
+        yield {"type": "result", "subtype": "success", "result": "approved"}
+
+    backend = MagicMock()
+    backend.name = "opencode"
+    backend.resume_question_with_client = resume_question_with_client
+    backend.resume_permission_with_client = resume_permission_with_client
+    backend.parse_message.return_value = "approved"
+    backend.estimate_token_usage.return_value = {
+        "prompt_tokens": 1,
+        "completion_tokens": 1,
+        "total_tokens": 2,
+    }
+
+    BackendRegistry.clear()
+    BackendRegistry.register_descriptor(
+        BackendDescriptor("opencode", "opencode", ["opencode/openai/gpt-5.5"], resolve)
+    )
+    BackendRegistry.register("opencode", backend)
+
+    with client_context() as (client, _):
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": "opencode/openai/gpt-5.5",
+                "previous_response_id": responses_module._make_response_id(session_id, 1),
+                "input": [
+                    {
+                        "type": "function_call_output",
+                        "call_id": "perm_1",
+                        "output": "always",
+                    }
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "completed"
+    assert response.json()["output"][0]["content"][0]["text"] == "approved"
+    assert calls == {
+        "permission": {
+            "client": session.client,
+            "call_id": "perm_1",
+            "output": "always",
+        }
+    }
     assert session.pending_tool_call is None
     assert session.turn_counter == 2
 
@@ -529,6 +605,87 @@ def test_opencode_question_tool_use_returns_requires_action(isolated_session_man
             "options": [{"label": "Yes"}, {"label": "No"}],
         },
         "backend": "opencode",
+        "opencode_resume": "question",
+    }
+    assert session.turn_counter == 1
+
+
+def test_opencode_permission_tool_use_returns_requires_action(isolated_session_manager):
+    """OpenCode permission tool_use chunks become Responses requires_action output."""
+
+    def resolve(model):
+        if model == "opencode/openai/gpt-5.5":
+            return ResolvedModel(model, "opencode", "openai/gpt-5.5")
+        return None
+
+    async def create_client(**kwargs):
+        return object()
+
+    async def run_completion_with_client(client, prompt, session):
+        yield {
+            "type": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "perm_1",
+                    "name": "permission",
+                    "metadata": {"opencode_permission_request_id": "perm_1"},
+                    "input": {
+                        "permission": "bash",
+                        "patterns": ["npm test"],
+                        "metadata": {"command": "npm test"},
+                    },
+                }
+            ],
+        }
+
+    backend = MagicMock()
+    backend.name = "opencode"
+    backend.create_client = create_client
+    backend.run_completion_with_client = run_completion_with_client
+    backend.parse_message.return_value = None
+    backend.estimate_token_usage.return_value = {
+        "prompt_tokens": 1,
+        "completion_tokens": 1,
+        "total_tokens": 2,
+    }
+
+    BackendRegistry.clear()
+    BackendRegistry.register_descriptor(
+        BackendDescriptor("opencode", "opencode", ["opencode/openai/gpt-5.5"], resolve)
+    )
+    BackendRegistry.register("opencode", backend)
+
+    with client_context() as (client, _):
+        response = client.post(
+            "/v1/responses",
+            json={"model": "opencode/openai/gpt-5.5", "input": "hi"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "requires_action"
+    assert data["output"][0]["call_id"] == "perm_1"
+    assert data["output"][0]["name"] == "AskUserQuestion"
+    arguments = json.loads(data["output"][0]["arguments"])
+    assert "bash" in arguments["question"]
+    assert "npm test" in arguments["question"]
+    assert [option["label"] for option in arguments["options"]] == [
+        "once",
+        "always",
+        "reject",
+    ]
+    assert arguments["permission"] == "bash"
+    assert arguments["patterns"] == ["npm test"]
+    assert arguments["metadata"] == {"command": "npm test"}
+
+    session = next(iter(isolated_session_manager.sessions.values()))
+    assert session.pending_tool_call == {
+        "call_id": "perm_1",
+        "name": "AskUserQuestion",
+        "arguments": arguments,
+        "backend": "opencode",
+        "opencode_resume": "permission",
     }
     assert session.turn_counter == 1
 
@@ -616,6 +773,7 @@ def test_opencode_questions_array_tool_use_returns_ask_user_question(
         "name": "AskUserQuestion",
         "arguments": arguments,
         "backend": "opencode",
+        "opencode_resume": "question",
     }
     assert session.turn_counter == 1
 
@@ -733,8 +891,141 @@ async def test_opencode_question_capture_stops_waiting_for_stream_end():
         "name": "AskUserQuestion",
         "arguments": {"question": "Continue?"},
         "backend": "opencode",
+        "opencode_resume": "question",
     }
     assert source_closed is True
+
+
+def test_opencode_function_call_output_rejects_unknown_resume_kind(isolated_session_manager):
+    """Unknown OpenCode resume kinds should fail instead of falling back to question."""
+    session_id = str(uuid.uuid4())
+    session = isolated_session_manager.get_or_create_session(session_id)
+    session.backend = "opencode"
+    session.turn_counter = 1
+    session.client = object()
+    session.pending_tool_call = {
+        "call_id": "x1",
+        "name": "AskUserQuestion",
+        "arguments": {"question": "Continue?"},
+        "backend": "opencode",
+        "opencode_resume": "bogus",
+    }
+
+    def resolve(model):
+        if model == "opencode/openai/gpt-5.5":
+            return ResolvedModel(model, "opencode", "openai/gpt-5.5")
+        return None
+
+    async def resume_question_with_client(client, call_id, output, session):
+        yield {"type": "assistant", "content": [{"type": "text", "text": "wrong"}]}
+        yield {"type": "result", "subtype": "success", "result": "wrong"}
+
+    backend = MagicMock()
+    backend.name = "opencode"
+    backend.resume_question_with_client = resume_question_with_client
+
+    BackendRegistry.clear()
+    BackendRegistry.register_descriptor(
+        BackendDescriptor("opencode", "opencode", ["opencode/openai/gpt-5.5"], resolve)
+    )
+    BackendRegistry.register("opencode", backend)
+
+    with client_context() as (client, _):
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": "opencode/openai/gpt-5.5",
+                "previous_response_id": responses_module._make_response_id(session_id, 1),
+                "input": [{"type": "function_call_output", "call_id": "x1", "output": "yes"}],
+            },
+        )
+
+    assert response.status_code == 400
+    assert "Unsupported OpenCode resume kind" in response.json()["error"]["message"]
+
+
+def test_opencode_permission_arguments_describe_empty_patterns_and_always():
+    """Permission prompts should avoid wildcard jargon and include allow context."""
+    arguments = responses_module._normalize_opencode_permission_arguments(
+        {
+            "permission": "bash",
+            "patterns": [],
+            "always": ["npm *"],
+            "metadata": {"command": "npm test"},
+        }
+    )
+
+    assert arguments is not None
+    assert "(no patterns specified)" in arguments["question"]
+    assert "already allowed: npm *" in arguments["question"]
+    assert "*" not in arguments["question"].replace("npm *", "")
+
+
+def test_opencode_image_request_reaches_backend_as_attached_image_marker(
+    isolated_session_manager,
+):
+    """OpenCode image requests are accepted and converted before backend dispatch."""
+    tiny_png_b64 = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M8AAwUB"
+        "Acq1S9cAAAAASUVORK5CYII="
+    )
+    captured = {}
+
+    def resolve(model):
+        if model == "opencode/openai/gpt-5.5":
+            return ResolvedModel(model, "opencode", "openai/gpt-5.5")
+        return None
+
+    async def create_client(**kwargs):
+        return object()
+
+    async def run_completion_with_client(client, prompt, session):
+        captured["prompt"] = prompt
+        yield {"type": "assistant", "content": [{"type": "text", "text": "saw image"}]}
+        yield {"type": "result", "subtype": "success", "result": "saw image"}
+
+    backend = MagicMock()
+    backend.name = "opencode"
+    backend.create_client = create_client
+    backend.run_completion_with_client = run_completion_with_client
+    backend.parse_message.return_value = "saw image"
+    backend.estimate_token_usage.return_value = {
+        "prompt_tokens": 1,
+        "completion_tokens": 1,
+        "total_tokens": 2,
+    }
+
+    BackendRegistry.clear()
+    BackendRegistry.register_descriptor(
+        BackendDescriptor("opencode", "opencode", ["opencode/openai/gpt-5.5"], resolve)
+    )
+    BackendRegistry.register("opencode", backend)
+
+    with client_context() as (client, _):
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": "opencode/openai/gpt-5.5",
+                "input": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "input_text", "text": "describe"},
+                            {
+                                "type": "input_image",
+                                "image_url": f"data:image/png;base64,{tiny_png_b64}",
+                            },
+                        ],
+                    }
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "completed"
+    assert "describe" in captured["prompt"]
+    assert '<attached_image path="' in captured["prompt"]
+    assert captured["prompt"].endswith('.png" />')
 
 
 def test_list_mcp_servers_filters_safe_fields():
@@ -1158,10 +1449,12 @@ def test_create_response_streaming_empty_result_emits_failed_event(isolated_sess
     """When the inner stream ends with no text and no pending tool call
     (stream_result['empty'] = True), the route must emit response.failed so
     the client sees a definite outcome — matching non-stream's 502 path."""
+
     def fake_run_completion(client, prompt, session, **kwargs):
         async def empty_source():
             if False:
                 yield None
+
         return empty_source()
 
     async def fake_stream_response_chunks(**kwargs):

--- a/tests/test_main_api_unit.py
+++ b/tests/test_main_api_unit.py
@@ -477,8 +477,9 @@ def test_opencode_question_tool_use_returns_requires_action(isolated_session_man
             "content": [
                 {
                     "type": "tool_use",
-                    "id": "q1",
+                    "id": "que_1",
                     "name": "question",
+                    "metadata": {"opencode_question_request_id": "que_1"},
                     "input": {
                         "question": "Continue?",
                         "options": [{"label": "Yes"}, {"label": "No"}],
@@ -513,7 +514,7 @@ def test_opencode_question_tool_use_returns_requires_action(isolated_session_man
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "requires_action"
-    assert data["output"][0]["call_id"] == "q1"
+    assert data["output"][0]["call_id"] == "que_1"
     assert data["output"][0]["name"] == "AskUserQuestion"
     assert json.loads(data["output"][0]["arguments"]) == {
         "question": "Continue?",
@@ -521,7 +522,7 @@ def test_opencode_question_tool_use_returns_requires_action(isolated_session_man
     }
     session = next(iter(isolated_session_manager.sessions.values()))
     assert session.pending_tool_call == {
-        "call_id": "q1",
+        "call_id": "que_1",
         "name": "AskUserQuestion",
         "arguments": {
             "question": "Continue?",
@@ -551,8 +552,9 @@ def test_opencode_questions_array_tool_use_returns_ask_user_question(
             "content": [
                 {
                     "type": "tool_use",
-                    "id": "q1",
+                    "id": "que_1",
                     "name": "question",
+                    "metadata": {"opencode_question_request_id": "que_1"},
                     "input": {
                         "questions": [
                             {
@@ -602,7 +604,7 @@ def test_opencode_questions_array_tool_use_returns_ask_user_question(
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "requires_action"
-    assert data["output"][0]["call_id"] == "q1"
+    assert data["output"][0]["call_id"] == "que_1"
     assert data["output"][0]["name"] == "AskUserQuestion"
     arguments = json.loads(data["output"][0]["arguments"])
     assert arguments["questions"][0]["header"] == "도구 테스트"
@@ -610,7 +612,7 @@ def test_opencode_questions_array_tool_use_returns_ask_user_question(
 
     session = next(iter(isolated_session_manager.sessions.values()))
     assert session.pending_tool_call == {
-        "call_id": "q1",
+        "call_id": "que_1",
         "name": "AskUserQuestion",
         "arguments": arguments,
         "backend": "opencode",
@@ -637,8 +639,9 @@ def test_opencode_streaming_question_tool_use_emits_ask_user_question(
             "content": [
                 {
                     "type": "tool_use",
-                    "id": "q1",
+                    "id": "que_1",
                     "name": "question",
+                    "metadata": {"opencode_question_request_id": "que_1"},
                     "input": {
                         "questions": [
                             {
@@ -703,8 +706,9 @@ async def test_opencode_question_capture_stops_waiting_for_stream_end():
                 "content": [
                     {
                         "type": "tool_use",
-                        "id": "q1",
+                        "id": "que_1",
                         "name": "question",
+                        "metadata": {"opencode_question_request_id": "que_1"},
                         "input": {"question": "Continue?"},
                     }
                 ],
@@ -725,7 +729,7 @@ async def test_opencode_question_capture_stops_waiting_for_stream_end():
         await captured.aclose()
 
     assert session.pending_tool_call == {
-        "call_id": "q1",
+        "call_id": "que_1",
         "name": "AskUserQuestion",
         "arguments": {"question": "Continue?"},
         "backend": "opencode",

--- a/tests/test_main_api_unit.py
+++ b/tests/test_main_api_unit.py
@@ -391,6 +391,75 @@ def test_opencode_function_call_output_resumes_question(isolated_session_manager
     assert session.turn_counter == 2
 
 
+def test_opencode_streaming_function_call_output_resumes_question(isolated_session_manager):
+    """Streaming OpenCode function_call_output uses the backend question resume API."""
+    session_id = str(uuid.uuid4())
+    session = isolated_session_manager.get_or_create_session(session_id)
+    session.backend = "opencode"
+    session.turn_counter = 1
+    session.client = object()
+    session.pending_tool_call = {
+        "call_id": "q1",
+        "name": "question",
+        "arguments": {"question": "Continue?"},
+        "backend": "opencode",
+    }
+    calls = {}
+
+    def resolve(model):
+        if model == "opencode/openai/gpt-5.5":
+            return ResolvedModel(model, "opencode", "openai/gpt-5.5")
+        return None
+
+    async def resume_question_with_client(client, call_id, output, session):
+        calls["resume"] = {"client": client, "call_id": call_id, "output": output}
+        yield {"type": "assistant", "content": [{"type": "text", "text": "continued"}]}
+        yield {"type": "result", "subtype": "success", "result": "continued"}
+
+    backend = MagicMock()
+    backend.name = "opencode"
+    backend.verify = AsyncMock(return_value=True)
+    backend.resume_question_with_client = resume_question_with_client
+    backend.parse_message.return_value = "continued"
+    backend.estimate_token_usage.return_value = {
+        "prompt_tokens": 1,
+        "completion_tokens": 1,
+        "total_tokens": 2,
+    }
+
+    BackendRegistry.clear()
+    BackendRegistry.register_descriptor(
+        BackendDescriptor("opencode", "opencode", ["opencode/openai/gpt-5.5"], resolve)
+    )
+    BackendRegistry.register("opencode", backend)
+
+    with client_context() as (client, _):
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": "opencode/openai/gpt-5.5",
+                "previous_response_id": responses_module._make_response_id(session_id, 1),
+                "input": [
+                    {"type": "function_call_output", "call_id": "q1", "output": "yes"}
+                ],
+                "stream": True,
+            },
+        )
+
+    assert response.status_code == 200
+    assert calls["resume"] == {
+        "client": session.client,
+        "call_id": "q1",
+        "output": "yes",
+    }
+    assert "response.output_text.delta" in response.text
+    assert "continued" in response.text
+    assert "response.completed" in response.text
+    assert "response.failed" not in response.text
+    assert session.pending_tool_call is None
+    assert session.turn_counter == 2
+
+
 def test_opencode_question_tool_use_returns_requires_action(isolated_session_manager):
     """OpenCode question tool_use chunks become Responses requires_action output."""
 

--- a/tests/test_main_coverage_unit.py
+++ b/tests/test_main_coverage_unit.py
@@ -283,6 +283,7 @@ class TestResponsesApiSessionValidation:
             )
 
         assert response.status_code == 503
+        assert "Claude Code SDK" not in response.json()["error"]["message"]
         # Session was created then cleaned up by the failing path.
         assert session_manager.get_stats()["active_sessions"] == active_before
 

--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -186,3 +186,90 @@ class TestGetMcpServers:
     def test_returns_dict(self):
         result = get_mcp_servers()
         assert isinstance(result, dict)
+
+
+class TestValidatedMcpConfig:
+    """Test reusable validated MCP config access."""
+
+    def test_returns_copy_of_loaded_servers(self, monkeypatch):
+        import src.mcp_config as mcp_config
+
+        monkeypatch.setattr(
+            mcp_config,
+            "_server_mcp_config",
+            {"demo": {"type": "stdio", "command": "uvx"}},
+        )
+
+        result = mcp_config.get_validated_mcp_config()
+        result["demo"]["command"] = "changed"
+
+        assert mcp_config.get_validated_mcp_config()["demo"]["command"] == "uvx"
+
+
+class TestOpenCodeConfigGeneration:
+    """Test conversion from wrapper MCP config into OpenCode config."""
+
+    def test_build_opencode_config_includes_safe_defaults_and_mcp_servers(self):
+        from src.backends.opencode.config import build_opencode_config
+
+        config = build_opencode_config(
+            base_config={},
+            mcp_servers={
+                "filesystem": {
+                    "type": "stdio",
+                    "command": "npx",
+                    "args": ["-y", "@modelcontextprotocol/server-filesystem", "/workspace"],
+                    "env": {"ROOT": "/workspace"},
+                },
+                "docs": {
+                    "type": "streamable-http",
+                    "url": "http://localhost:3000/mcp",
+                    "headers": {"Authorization": "Bearer token"},
+                },
+            },
+            default_model="openai/gpt-5.5",
+            question_permission="ask",
+        )
+
+        assert config["permission"]["question"] == "ask"
+        assert config["share"] == "disabled"
+        assert config["model"] == "openai/gpt-5.5"
+        assert config["mcp"]["filesystem"] == {
+            "type": "local",
+            "command": ["npx", "-y", "@modelcontextprotocol/server-filesystem", "/workspace"],
+            "environment": {"ROOT": "/workspace"},
+        }
+        assert config["mcp"]["docs"] == {
+            "type": "remote",
+            "url": "http://localhost:3000/mcp",
+            "headers": {"Authorization": "Bearer token"},
+        }
+
+    def test_build_opencode_config_preserves_explicit_base_config_over_defaults(self):
+        from src.backends.opencode.config import build_opencode_config
+
+        config = build_opencode_config(
+            base_config={
+                "share": "enabled",
+                "permission": {"question": "deny"},
+                "mcp": {"filesystem": {"enabled": False}},
+            },
+            mcp_servers={"filesystem": {"type": "stdio", "command": "npx", "args": ["demo"]}},
+            default_model="openai/gpt-5.5",
+            question_permission="ask",
+        )
+
+        assert config["share"] == "enabled"
+        assert config["permission"]["question"] == "deny"
+        assert config["model"] == "openai/gpt-5.5"
+        assert config["mcp"]["filesystem"] == {"enabled": False}
+
+    def test_parse_opencode_config_content_adds_env_context_to_json_errors(self):
+        from src.backends.opencode.config import parse_opencode_config_content
+
+        try:
+            parse_opencode_config_content("{ invalid json }")
+        except ValueError as exc:
+            assert "OPENCODE_CONFIG_CONTENT is not valid JSON" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")

--- a/tests/test_opencode_backend.py
+++ b/tests/test_opencode_backend.py
@@ -2,6 +2,8 @@
 
 import importlib
 import json
+import logging
+from pathlib import Path
 
 import pytest
 
@@ -111,17 +113,13 @@ def test_opencode_descriptor_resolves_prefixed_model(monkeypatch):
 
     opencode_pkg = importlib.reload(opencode_pkg)
 
-    resolved = opencode_pkg.OPENCODE_DESCRIPTOR.resolve_fn(
-        "opencode/anthropic/claude-sonnet-4-5"
-    )
+    resolved = opencode_pkg.OPENCODE_DESCRIPTOR.resolve_fn("opencode/anthropic/claude-sonnet-4-5")
 
     assert resolved is not None
     assert resolved.public_model == "opencode/anthropic/claude-sonnet-4-5"
     assert resolved.backend == "opencode"
     assert resolved.provider_model == "anthropic/claude-sonnet-4-5"
-    assert opencode_pkg.OPENCODE_DESCRIPTOR.models == [
-        "opencode/anthropic/claude-sonnet-4-5"
-    ]
+    assert opencode_pkg.OPENCODE_DESCRIPTOR.models == ["opencode/anthropic/claude-sonnet-4-5"]
 
 
 def test_opencode_descriptor_rejects_unprefixed_model(monkeypatch):
@@ -508,6 +506,50 @@ def test_opencode_event_converter_emits_question_request_tool_use():
     ]
 
 
+def test_opencode_event_converter_emits_permission_request_tool_use():
+    """Permission requests are exposed as resumable OpenCode tool_use chunks."""
+    from src.backends.opencode.events import OpenCodeEventConverter
+
+    converter = OpenCodeEventConverter(session_id="oc-session")
+    chunks = converter.convert(
+        {
+            "type": "permission.asked",
+            "properties": {
+                "id": "perm_1",
+                "sessionID": "oc-session",
+                "permission": "bash",
+                "patterns": ["npm test"],
+                "always": ["npm *"],
+                "metadata": {"command": "npm test"},
+                "tool": {"messageID": "msg_1", "callID": "call_1"},
+            },
+        }
+    )
+
+    assert chunks == [
+        {
+            "type": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "perm_1",
+                    "name": "permission",
+                    "input": {
+                        "permission": "bash",
+                        "patterns": ["npm test"],
+                        "always": ["npm *"],
+                        "metadata": {"command": "npm test"},
+                    },
+                    "metadata": {
+                        "opencode_permission_request_id": "perm_1",
+                        "opencode_tool_call_id": "call_1",
+                    },
+                }
+            ],
+        }
+    ]
+
+
 def test_opencode_event_converter_suppresses_question_tool_part_updates():
     """Question tool part updates should not be exposed before question.asked."""
     from src.backends.opencode.events import OpenCodeEventConverter
@@ -596,9 +638,10 @@ def test_opencode_event_converter_finishes_only_after_activity():
         }
     )
 
-    assert converter.finished(
-        {"type": "session.idle", "properties": {"sessionID": "other-session"}}
-    ) is False
+    assert (
+        converter.finished({"type": "session.idle", "properties": {"sessionID": "other-session"}})
+        is False
+    )
     assert converter.finished(idle_event) is True
 
 
@@ -840,7 +883,7 @@ async def test_opencode_client_resumes_question_with_reply_endpoint(monkeypatch)
                 },
                 "params": {"directory": "/tmp/work"},
             },
-        )
+        ),
     ]
     assert chunks == [
         {
@@ -853,6 +896,285 @@ async def test_opencode_client_resumes_question_with_reply_endpoint(monkeypatch)
         {"type": "assistant", "content": [{"type": "text", "text": "continued"}]},
         {"type": "result", "subtype": "success", "result": "continued"},
     ]
+
+
+async def test_opencode_client_resumes_permission_with_reply_endpoint(monkeypatch):
+    """OpenCode permission continuation replies to the pending permission request."""
+    calls = []
+    events = [
+        {
+            "type": "message.part.delta",
+            "properties": {
+                "sessionID": "oc-session",
+                "messageID": "msg-2",
+                "partID": "part-text",
+                "field": "text",
+                "delta": "approved",
+            },
+        },
+        {"type": "session.idle", "properties": {"sessionID": "oc-session"}},
+    ]
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+    class FakeStreamResponse:
+        def raise_for_status(self):
+            return None
+
+        async def aiter_lines(self):
+            for event in events:
+                yield f"event: {event['type']}"
+                yield "data: " + json.dumps(event)
+                yield ""
+
+    class FakeStreamContext:
+        async def __aenter__(self):
+            return FakeStreamResponse()
+
+        async def __aexit__(self, *args):
+            return None
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        def stream(self, method, path, **kwargs):
+            calls.append(("STREAM", method, path, kwargs))
+            return FakeStreamContext()
+
+        async def post(self, path, **kwargs):
+            calls.append(("POST", path, kwargs))
+            return FakeResponse()
+
+    monkeypatch.setattr("src.backends.opencode.client.httpx.AsyncClient", FakeAsyncClient)
+
+    from src.backends.opencode.client import OpenCodeClient, OpenCodeSessionClient
+    from src.session_manager import Session
+
+    backend = OpenCodeClient()
+    client = OpenCodeSessionClient(
+        session_id="oc-session",
+        cwd="/tmp/work",
+        model="openai/gpt-5.5",
+        system_prompt=None,
+    )
+    chunks = [
+        chunk
+        async for chunk in backend.resume_permission_with_client(
+            client,
+            "perm_1",
+            "always",
+            Session(session_id="gw-session"),
+        )
+    ]
+
+    assert calls == [
+        (
+            "STREAM",
+            "GET",
+            "/event",
+            {"params": {"directory": "/tmp/work"}},
+        ),
+        (
+            "POST",
+            "/permission/perm_1/reply",
+            {
+                "json": {"reply": "always"},
+                "params": {"directory": "/tmp/work"},
+            },
+        ),
+    ]
+    assert chunks == [
+        {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "approved"},
+            },
+        },
+        {"type": "assistant", "content": [{"type": "text", "text": "approved"}]},
+        {"type": "result", "subtype": "success", "result": "approved"},
+    ]
+
+
+async def test_opencode_session_client_disconnect_deletes_server_session(monkeypatch):
+    """OpenCode session cleanup deletes the corresponding server-side session."""
+    calls = []
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs):
+            calls.append(("CLIENT", kwargs))
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def delete(self, path, **kwargs):
+            calls.append(("DELETE", path, kwargs))
+            return FakeResponse()
+
+    monkeypatch.setattr("src.backends.opencode.client.httpx.AsyncClient", FakeAsyncClient)
+
+    from src.backends.opencode.client import OpenCodeSessionClient
+
+    client = OpenCodeSessionClient(
+        session_id="oc-session",
+        cwd="/tmp/work",
+        model="openai/gpt-5.5",
+        system_prompt=None,
+        base_url="http://127.0.0.1:4096",
+        timeout=12.5,
+    )
+
+    await client.disconnect()
+
+    assert calls == [
+        ("CLIENT", {"base_url": "http://127.0.0.1:4096", "timeout": 12.5}),
+        (
+            "DELETE",
+            "/session/oc-session",
+            {"params": {"directory": "/tmp/work"}},
+        ),
+    ]
+
+
+async def test_opencode_session_client_disconnect_logs_warning_on_failure(
+    monkeypatch,
+    caplog,
+):
+    """OpenCode cleanup failures should be visible in operator logs."""
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def delete(self, path, **kwargs):
+            raise RuntimeError("delete failed")
+
+    monkeypatch.setattr("src.backends.opencode.client.httpx.AsyncClient", FakeAsyncClient)
+
+    from src.backends.opencode.client import OpenCodeSessionClient
+
+    client = OpenCodeSessionClient(
+        session_id="oc-session",
+        cwd="/tmp/work",
+        model="openai/gpt-5.5",
+        system_prompt=None,
+        base_url="http://127.0.0.1:4096",
+        timeout=12.5,
+    )
+
+    with caplog.at_level(logging.WARNING, logger="src.backends.opencode.client"):
+        await client.disconnect()
+
+    assert "OpenCode session delete failed for oc-session" in caplog.text
+
+
+def test_opencode_prompt_body_converts_attached_image_markers_to_file_parts(tmp_path):
+    """Responses image markers are sent to OpenCode as file parts."""
+    from src.backends.opencode.client import OpenCodeClient, OpenCodeSessionClient
+
+    image_dir = tmp_path / ".claude_images"
+    image_dir.mkdir()
+    image_path = image_dir / "img_0123456789abcdef.png"
+    image_path.write_bytes(b"\x89PNG\r\n\x1a\nfake")
+
+    backend = OpenCodeClient()
+    client = OpenCodeSessionClient(
+        session_id="oc-session",
+        cwd=str(tmp_path),
+        model="openai/gpt-5.5",
+        system_prompt=None,
+    )
+
+    body = backend._prompt_body(
+        client,
+        f'describe this\n<attached_image path="{image_path}" />\nthanks',
+    )
+
+    assert body["parts"] == [
+        {"type": "text", "text": "describe this\n"},
+        {
+            "type": "file",
+            "mime": "image/png",
+            "filename": Path(image_path).name,
+            "url": "data:image/png;base64,iVBORw0KGgpmYWtl",
+        },
+        {"type": "text", "text": "\nthanks"},
+    ]
+
+
+def test_opencode_prompt_body_treats_untrusted_attached_image_marker_as_text(
+    tmp_path,
+    caplog,
+):
+    """User-authored image markers must not trigger arbitrary local file reads."""
+    from src.backends.opencode.client import OpenCodeClient, OpenCodeSessionClient
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    secret_path = tmp_path / "secret.txt"
+    secret_path.write_text("do not read", encoding="utf-8")
+
+    backend = OpenCodeClient()
+    client = OpenCodeSessionClient(
+        session_id="oc-session",
+        cwd=str(workspace),
+        model="openai/gpt-5.5",
+        system_prompt=None,
+    )
+
+    prompt = f'before <attached_image path="{secret_path}" /> after'
+    with caplog.at_level(logging.WARNING, logger="src.backends.opencode.client"):
+        body = backend._prompt_body(client, prompt)
+
+    assert body["parts"] == [{"type": "text", "text": prompt}]
+    assert "OpenCode dropped untrusted attached_image marker" in caplog.text
+
+
+def test_opencode_permission_reply_body_fails_closed_for_unknown_inputs():
+    """Unknown permission outputs must reject instead of allowing once."""
+    from src.backends.opencode.client import OpenCodeClient
+
+    backend = OpenCodeClient()
+
+    assert backend._permission_reply_body("") == {"reply": "reject"}
+    assert backend._permission_reply_body("maybe") == {"reply": "reject"}
+    assert backend._permission_reply_body('{"reply":"later"}') == {"reply": "reject"}
+
+
+def test_opencode_permission_reply_body_normalizes_known_inputs():
+    """Known permission outputs map to OpenCode's reply enum."""
+    from src.backends.opencode.client import OpenCodeClient
+
+    backend = OpenCodeClient()
+
+    assert backend._permission_reply_body("yes") == {"reply": "once"}
+    assert backend._permission_reply_body("no") == {"reply": "reject"}
+    assert backend._permission_reply_body('{"reply":"always","message":"remember"}') == {
+        "reply": "always",
+        "message": "remember",
+    }
 
 
 async def test_opencode_client_reports_empty_json_response(monkeypatch):

--- a/tests/test_opencode_backend.py
+++ b/tests/test_opencode_backend.py
@@ -3,32 +3,28 @@
 import importlib
 import json
 
-
-def test_opencode_client_exposes_runtime_metadata(monkeypatch):
-    """OpenCode client reports operational metadata for diagnostics."""
-    monkeypatch.setenv("OPENCODE_BASE_URL", "http://127.0.0.1:4096")
-    monkeypatch.setenv("OPENCODE_MODELS", "openai/gpt-5.5")
-
-    import src.backends.opencode.client as client_module
-    import src.backends.opencode.constants as constants_module
-
-    importlib.reload(constants_module)
-    client_module = importlib.reload(client_module)
-
-    client = client_module.OpenCodeClient()
-
-    assert client.runtime_metadata() == {
-        "mode": "external",
-        "base_url": "http://127.0.0.1:4096",
-        "agent": "general",
-        "models": ["opencode/openai/gpt-5.5"],
-        "managed_process": False,
-    }
+import pytest
 
 
-def test_opencode_runtime_metadata_treats_explicit_base_url_as_external(monkeypatch):
-    """Direct base_url construction is external mode even without OPENCODE_BASE_URL."""
+@pytest.fixture(autouse=True)
+def stub_opencode_managed_server(monkeypatch):
+    """Avoid starting a real OpenCode process in unit tests."""
     monkeypatch.delenv("OPENCODE_BASE_URL", raising=False)
+
+    def fail_if_process_starts(*args, **kwargs):
+        raise AssertionError("unit tests must not start a real opencode process")
+
+    monkeypatch.setattr("src.backends.opencode.client.subprocess.Popen", fail_if_process_starts)
+    monkeypatch.setattr(
+        "src.backends.opencode.client.OpenCodeClient._start_managed_server",
+        lambda self: "http://127.0.0.1:4096",
+        raising=False,
+    )
+
+
+def test_opencode_client_rejects_legacy_base_url_env(monkeypatch):
+    """OPENCODE_BASE_URL is rejected instead of silently changing backend behavior."""
+    monkeypatch.setenv("OPENCODE_BASE_URL", "http://external.example:4096")
     monkeypatch.setenv("OPENCODE_MODELS", "openai/gpt-5.5")
 
     import src.backends.opencode.client as client_module
@@ -36,11 +32,24 @@ def test_opencode_runtime_metadata_treats_explicit_base_url_as_external(monkeypa
 
     importlib.reload(constants_module)
     client_module = importlib.reload(client_module)
+    # Safety net: if the fail-fast branch is removed later, keep this reloaded
+    # class from starting a real OpenCode process.
+    monkeypatch.setattr(
+        client_module.OpenCodeClient,
+        "_start_managed_server",
+        lambda self: "http://127.0.0.1:15555",
+    )
 
-    client = client_module.OpenCodeClient(base_url="http://127.0.0.1:4096")
+    with pytest.raises(RuntimeError, match="OPENCODE_BASE_URL is no longer supported"):
+        client_module.OpenCodeClient()
 
-    assert client.runtime_metadata()["mode"] == "external"
-    assert client.runtime_metadata()["managed_process"] is False
+
+def test_opencode_client_constructor_rejects_external_base_url():
+    """External OpenCode servers are no longer a supported backend mode."""
+    from src.backends.opencode.client import OpenCodeClient
+
+    with pytest.raises(TypeError):
+        OpenCodeClient(base_url="http://127.0.0.1:4096")
 
 
 def test_opencode_managed_config_enables_question_tool_by_default(monkeypatch):
@@ -51,7 +60,7 @@ def test_opencode_managed_config_enables_question_tool_by_default(monkeypatch):
 
     from src.backends.opencode.client import OpenCodeClient
 
-    client = OpenCodeClient(base_url="http://127.0.0.1:4096")
+    client = OpenCodeClient()
 
     config = json.loads(client._managed_config_content())
 
@@ -66,7 +75,7 @@ def test_opencode_managed_config_allows_question_permission_override(monkeypatch
 
     from src.backends.opencode.client import OpenCodeClient
 
-    client = OpenCodeClient(base_url="http://127.0.0.1:4096")
+    client = OpenCodeClient()
 
     config = json.loads(client._managed_config_content())
 
@@ -86,7 +95,7 @@ def test_opencode_managed_config_can_include_wrapper_mcp(monkeypatch):
 
     from src.backends.opencode.client import OpenCodeClient
 
-    client = OpenCodeClient(base_url="http://127.0.0.1:4096")
+    client = OpenCodeClient()
     config = json.loads(client._managed_config_content())
 
     assert config["model"] == "openai/gpt-5.5"
@@ -129,7 +138,6 @@ def test_opencode_descriptor_rejects_unprefixed_model(monkeypatch):
 
 def test_opencode_auth_provider_validates_managed_binary(monkeypatch):
     """Managed mode is valid when the opencode binary is available."""
-    monkeypatch.delenv("OPENCODE_BASE_URL", raising=False)
     monkeypatch.setattr("src.backends.opencode.auth.shutil.which", lambda name: "/bin/opencode")
 
     from src.backends.opencode.auth import OpenCodeAuthProvider
@@ -139,6 +147,35 @@ def test_opencode_auth_provider_validates_managed_binary(monkeypatch):
     assert status["valid"] is True
     assert status["errors"] == []
     assert status["config"]["mode"] == "managed"
+
+
+def test_opencode_auth_provider_rejects_legacy_base_url_regardless_of_binary(monkeypatch):
+    """OPENCODE_BASE_URL fails auth validation instead of selecting external mode."""
+    monkeypatch.setenv("OPENCODE_BASE_URL", "http://127.0.0.1:4096")
+    monkeypatch.setattr("src.backends.opencode.auth.shutil.which", lambda name: "/bin/opencode")
+
+    from src.backends.opencode.auth import OpenCodeAuthProvider
+
+    status = OpenCodeAuthProvider().validate()
+
+    assert status["valid"] is False
+    assert status["errors"] == [
+        "OPENCODE_BASE_URL is no longer supported; unset it to use managed OpenCode"
+    ]
+    assert status["config"]["mode"] == "managed"
+
+
+def test_opencode_auth_env_excludes_legacy_base_url(monkeypatch):
+    """Backend env passthrough should not advertise an external-server mode."""
+    monkeypatch.setenv("OPENCODE_BASE_URL", "http://127.0.0.1:4096")
+    monkeypatch.setenv("OPENCODE_DEFAULT_MODEL", "openai/gpt-5.5")
+
+    from src.backends.opencode.auth import OpenCodeAuthProvider
+
+    env = OpenCodeAuthProvider().build_env()
+
+    assert "OPENCODE_BASE_URL" not in env
+    assert env["OPENCODE_DEFAULT_MODEL"] == "openai/gpt-5.5"
 
 
 def test_auth_manager_returns_opencode_provider():
@@ -612,7 +649,6 @@ async def test_opencode_client_sends_prompt_to_existing_server(monkeypatch):
                 }
             )
 
-    monkeypatch.setenv("OPENCODE_BASE_URL", "http://127.0.0.1:4096")
     monkeypatch.setattr("src.backends.opencode.client.httpx.AsyncClient", FakeAsyncClient)
 
     from src.backends.opencode.client import OpenCodeClient
@@ -687,7 +723,6 @@ async def test_opencode_client_uses_configured_agent(monkeypatch):
                 }
             )
 
-    monkeypatch.setenv("OPENCODE_BASE_URL", "http://127.0.0.1:4096")
     monkeypatch.setenv("OPENCODE_AGENT", "plan")
     monkeypatch.setattr("src.backends.opencode.client.httpx.AsyncClient", FakeAsyncClient)
 
@@ -766,7 +801,6 @@ async def test_opencode_client_resumes_question_with_reply_endpoint(monkeypatch)
             calls.append(("POST", path, kwargs))
             return FakeResponse()
 
-    monkeypatch.setenv("OPENCODE_BASE_URL", "http://127.0.0.1:4096")
     monkeypatch.setenv("OPENCODE_AGENT", "plan")
     monkeypatch.setattr("src.backends.opencode.client.httpx.AsyncClient", FakeAsyncClient)
 
@@ -860,7 +894,6 @@ async def test_opencode_client_reports_empty_json_response(monkeypatch):
                 return FakeResponse({"id": "oc-session"})
             return EmptyResponse()
 
-    monkeypatch.setenv("OPENCODE_BASE_URL", "http://127.0.0.1:4096")
     monkeypatch.setattr("src.backends.opencode.client.httpx.AsyncClient", FakeAsyncClient)
 
     from src.backends.opencode.client import OpenCodeClient
@@ -959,7 +992,6 @@ async def test_opencode_client_streams_text_deltas_from_event_sse(monkeypatch):
                 return FakeResponse({"id": "oc-session"})
             return FakeResponse()
 
-    monkeypatch.setenv("OPENCODE_BASE_URL", "http://127.0.0.1:4096")
     monkeypatch.setattr("src.backends.opencode.client.httpx.AsyncClient", FakeAsyncClient)
 
     from src.backends.opencode.client import OpenCodeClient
@@ -1081,7 +1113,6 @@ async def test_opencode_client_streams_tool_use_and_result_from_event_sse(monkey
                 return FakeResponse({"id": "oc-session"})
             return FakeResponse()
 
-    monkeypatch.setenv("OPENCODE_BASE_URL", "http://127.0.0.1:4096")
     monkeypatch.setattr("src.backends.opencode.client.httpx.AsyncClient", FakeAsyncClient)
 
     from src.backends.opencode.client import OpenCodeClient
@@ -1200,7 +1231,6 @@ async def test_opencode_streaming_aggregates_step_finish_usage(monkeypatch):
                 return FakeResponse({"id": "oc-session"})
             return FakeResponse()
 
-    monkeypatch.setenv("OPENCODE_BASE_URL", "http://127.0.0.1:4096")
     monkeypatch.setattr("src.backends.opencode.client.httpx.AsyncClient", FakeAsyncClient)
 
     from src.backends.opencode.client import OpenCodeClient
@@ -1279,7 +1309,6 @@ async def test_opencode_streaming_ignores_initial_idle_until_activity(monkeypatc
                 return FakeResponse({"id": "oc-session"})
             return FakeResponse()
 
-    monkeypatch.setenv("OPENCODE_BASE_URL", "http://127.0.0.1:4096")
     monkeypatch.setattr("src.backends.opencode.client.httpx.AsyncClient", FakeAsyncClient)
 
     from src.backends.opencode.client import OpenCodeClient
@@ -1342,7 +1371,6 @@ async def test_opencode_streaming_event_client_disables_read_timeout(monkeypatch
                 return FakeResponse({"id": "oc-session"})
             return FakeResponse()
 
-    monkeypatch.setenv("OPENCODE_BASE_URL", "http://127.0.0.1:4096")
     monkeypatch.setattr("src.backends.opencode.client.httpx.AsyncClient", FakeAsyncClient)
 
     from src.backends.opencode.client import OpenCodeClient
@@ -1436,7 +1464,6 @@ async def test_opencode_streaming_waits_for_non_empty_tool_input(monkeypatch):
                 return FakeResponse({"id": "oc-session"})
             return FakeResponse()
 
-    monkeypatch.setenv("OPENCODE_BASE_URL", "http://127.0.0.1:4096")
     monkeypatch.setattr("src.backends.opencode.client.httpx.AsyncClient", FakeAsyncClient)
 
     from src.backends.opencode.client import OpenCodeClient

--- a/tests/test_opencode_backend.py
+++ b/tests/test_opencode_backend.py
@@ -271,6 +271,58 @@ def test_opencode_event_converter_emits_error_tool_result():
     ]
 
 
+def test_opencode_event_converter_emits_question_tool_use():
+    """Question tool updates are exposed as Responses-compatible tool_use chunks."""
+    from src.backends.opencode.events import OpenCodeEventConverter
+
+    converter = OpenCodeEventConverter(session_id="oc-session")
+    chunks = converter.convert(
+        {
+            "type": "message.part.updated",
+            "properties": {
+                "part": {
+                    "sessionID": "oc-session",
+                    "type": "tool",
+                    "tool": "question",
+                    "callID": "q1",
+                    "state": {
+                        "status": "running",
+                        "input": {
+                            "question": "Continue?",
+                            "options": [{"label": "Yes"}, {"label": "No"}],
+                        },
+                    },
+                }
+            },
+        }
+    )
+
+    assert chunks == [
+        {
+            "type": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "q1",
+                    "name": "question",
+                    "input": {
+                        "question": "Continue?",
+                        "options": [{"label": "Yes"}, {"label": "No"}],
+                    },
+                }
+            ],
+        }
+    ]
+    assert converter.pending_question == {
+        "call_id": "q1",
+        "name": "question",
+        "arguments": {
+            "question": "Continue?",
+            "options": [{"label": "Yes"}, {"label": "No"}],
+        },
+    }
+
+
 def test_opencode_event_converter_accumulates_step_finish_usage():
     """OpenCode event converter accumulates usage from step-finish parts."""
     from src.backends.opencode.events import OpenCodeEventConverter
@@ -468,6 +520,84 @@ async def test_opencode_client_uses_configured_agent(monkeypatch):
 
     assert calls[1][1]["json"]["agent"] == "plan"
     assert chunks[-1]["result"] == "ok"
+
+
+async def test_opencode_client_resumes_question_with_tool_output(monkeypatch):
+    """OpenCode question continuation sends a completed question tool part."""
+    calls = []
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "info": {"role": "assistant"},
+                "parts": [{"type": "text", "text": "continued"}],
+            }
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def post(self, path, **kwargs):
+            calls.append((path, kwargs))
+            return FakeResponse()
+
+    monkeypatch.setenv("OPENCODE_BASE_URL", "http://127.0.0.1:4096")
+    monkeypatch.setenv("OPENCODE_AGENT", "plan")
+    monkeypatch.setattr("src.backends.opencode.client.httpx.AsyncClient", FakeAsyncClient)
+
+    from src.backends.opencode.client import OpenCodeClient, OpenCodeSessionClient
+    from src.session_manager import Session
+
+    backend = OpenCodeClient()
+    client = OpenCodeSessionClient(
+        session_id="oc-session",
+        cwd="/tmp/work",
+        model="openai/gpt-5.5",
+        system_prompt=None,
+    )
+    chunks = [
+        chunk
+        async for chunk in backend.resume_question_with_client(
+            client,
+            "q1",
+            "yes",
+            Session(session_id="gw-session"),
+        )
+    ]
+
+    assert calls == [
+        (
+            "/session/oc-session/message",
+            {
+                "json": {
+                    "agent": "plan",
+                    "parts": [
+                        {
+                            "type": "tool",
+                            "callID": "q1",
+                            "tool": "question",
+                            "state": {"status": "completed", "output": "yes"},
+                        }
+                    ],
+                    "model": {"providerID": "openai", "modelID": "gpt-5.5"},
+                },
+                "params": {"directory": "/tmp/work"},
+            },
+        )
+    ]
+    assert chunks == [
+        {"type": "assistant", "content": [{"type": "text", "text": "continued"}]},
+        {"type": "result", "subtype": "success", "result": "continued"},
+    ]
 
 
 async def test_opencode_client_reports_empty_json_response(monkeypatch):

--- a/tests/test_opencode_backend.py
+++ b/tests/test_opencode_backend.py
@@ -151,6 +151,107 @@ def test_opencode_event_converter_ignores_other_sessions():
     assert converter.final_text() == ""
 
 
+def test_opencode_event_converter_ignores_user_text_parts():
+    """OpenCode event converter only emits text from assistant messages."""
+    from src.backends.opencode.events import OpenCodeEventConverter
+
+    converter = OpenCodeEventConverter(session_id="oc-session")
+
+    user_message = {
+        "type": "message.updated",
+        "properties": {
+            "sessionID": "oc-session",
+            "info": {
+                "id": "msg-user",
+                "role": "user",
+                "sessionID": "oc-session",
+            },
+        },
+    }
+    user_part = {
+        "type": "message.part.updated",
+        "properties": {
+            "sessionID": "oc-session",
+            "part": {
+                "id": "part-user",
+                "messageID": "msg-user",
+                "sessionID": "oc-session",
+                "type": "text",
+                "text": "Say exactly ok",
+            },
+        },
+    }
+    assistant_message = {
+        "type": "message.updated",
+        "properties": {
+            "sessionID": "oc-session",
+            "info": {
+                "id": "msg-assistant",
+                "role": "assistant",
+                "sessionID": "oc-session",
+            },
+        },
+    }
+    assistant_start = {
+        "type": "message.part.updated",
+        "properties": {
+            "sessionID": "oc-session",
+            "part": {
+                "id": "part-assistant",
+                "messageID": "msg-assistant",
+                "sessionID": "oc-session",
+                "type": "text",
+                "text": "",
+            },
+        },
+    }
+    assistant_delta = {
+        "type": "message.part.delta",
+        "properties": {
+            "sessionID": "oc-session",
+            "messageID": "msg-assistant",
+            "partID": "part-assistant",
+            "field": "text",
+            "delta": "ok",
+        },
+    }
+    assistant_done = {
+        "type": "message.part.updated",
+        "properties": {
+            "sessionID": "oc-session",
+            "part": {
+                "id": "part-assistant",
+                "messageID": "msg-assistant",
+                "sessionID": "oc-session",
+                "type": "text",
+                "text": "ok",
+            },
+        },
+    }
+
+    chunks = []
+    for event in [
+        user_message,
+        user_part,
+        assistant_message,
+        assistant_start,
+        assistant_delta,
+        assistant_done,
+    ]:
+        chunks.extend(converter.convert(event))
+
+    assert chunks == [
+        {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "ok"},
+            },
+        }
+    ]
+    assert converter.final_text() == "ok"
+
+
 def test_opencode_event_converter_emits_tool_use_and_result_once():
     """OpenCode event converter emits a tool_use and a completed tool_result."""
     from src.backends.opencode.events import OpenCodeEventConverter

--- a/tests/test_opencode_backend.py
+++ b/tests/test_opencode_backend.py
@@ -1,6 +1,7 @@
 """OpenCode backend tests."""
 
 import importlib
+import json
 
 
 def test_opencode_descriptor_resolves_prefixed_model(monkeypatch):
@@ -137,9 +138,125 @@ async def test_opencode_client_sends_prompt_to_existing_server(monkeypatch):
         "providerID": "anthropic",
         "modelID": "claude-sonnet-4-5",
     }
+    assert calls[1][2]["json"]["agent"] == "general"
     assert calls[1][2]["json"]["parts"] == [{"type": "text", "text": "say hi"}]
     assert getattr(session, "opencode_session_id") == "oc-session"
     assert chunks[-1]["result"] == "hello from opencode"
     assert chunks[-1]["usage"]["input_tokens"] == 7
     assert chunks[-1]["usage"]["output_tokens"] == 3
     assert backend.parse_message(chunks) == "hello from opencode"
+
+
+async def test_opencode_client_uses_configured_agent(monkeypatch):
+    """OPENCODE_AGENT overrides the default OpenCode request agent."""
+    calls = []
+
+    class FakeResponse:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def post(self, path, **kwargs):
+            calls.append((path, kwargs))
+            if path == "/session":
+                return FakeResponse({"id": "oc-session"})
+            return FakeResponse(
+                {
+                    "info": {"role": "assistant"},
+                    "parts": [{"type": "text", "text": "ok"}],
+                }
+            )
+
+    monkeypatch.setenv("OPENCODE_BASE_URL", "http://127.0.0.1:4096")
+    monkeypatch.setenv("OPENCODE_AGENT", "plan")
+    monkeypatch.setattr("src.backends.opencode.client.httpx.AsyncClient", FakeAsyncClient)
+
+    from src.backends.opencode.client import OpenCodeClient
+    from src.session_manager import Session
+
+    backend = OpenCodeClient()
+    session = Session(session_id="gw-session")
+    client = await backend.create_client(session=session, model="openai/gpt-5.1-codex")
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "hi", session)]
+
+    assert calls[1][1]["json"]["agent"] == "plan"
+    assert chunks[-1]["result"] == "ok"
+
+
+async def test_opencode_client_reports_empty_json_response(monkeypatch):
+    """Empty OpenCode response bodies produce actionable backend errors."""
+
+    class EmptyResponse:
+        status_code = 200
+        text = ""
+        headers = {"content-type": "application/json", "content-length": "0"}
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            raise json.JSONDecodeError("Expecting value", "", 0)
+
+    class FakeResponse:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def post(self, path, **kwargs):
+            if path == "/session":
+                return FakeResponse({"id": "oc-session"})
+            return EmptyResponse()
+
+    monkeypatch.setenv("OPENCODE_BASE_URL", "http://127.0.0.1:4096")
+    monkeypatch.setattr("src.backends.opencode.client.httpx.AsyncClient", FakeAsyncClient)
+
+    from src.backends.opencode.client import OpenCodeClient
+    from src.session_manager import Session
+
+    backend = OpenCodeClient()
+    session = Session(session_id="gw-session")
+    client = await backend.create_client(session=session, model="openai/gpt-5.1-codex")
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "hi", session)]
+
+    assert chunks == [
+        {
+            "type": "error",
+            "is_error": True,
+            "error_message": (
+                "OpenCode returned an empty or non-JSON response "
+                "(status=200, content-type=application/json, body='')"
+            ),
+        }
+    ]

--- a/tests/test_opencode_backend.py
+++ b/tests/test_opencode_backend.py
@@ -34,3 +34,112 @@ def test_opencode_descriptor_rejects_unprefixed_model(monkeypatch):
 
     assert opencode_pkg.OPENCODE_DESCRIPTOR.resolve_fn("anthropic/claude-sonnet-4-5") is None
     assert opencode_pkg.OPENCODE_DESCRIPTOR.resolve_fn("opencode/missing_provider_model") is None
+
+
+def test_opencode_auth_provider_validates_managed_binary(monkeypatch):
+    """Managed mode is valid when the opencode binary is available."""
+    monkeypatch.delenv("OPENCODE_BASE_URL", raising=False)
+    monkeypatch.setattr("src.backends.opencode.auth.shutil.which", lambda name: "/bin/opencode")
+
+    from src.backends.opencode.auth import OpenCodeAuthProvider
+
+    status = OpenCodeAuthProvider().validate()
+
+    assert status["valid"] is True
+    assert status["errors"] == []
+    assert status["config"]["mode"] == "managed"
+
+
+def test_auth_manager_returns_opencode_provider():
+    """auth_manager can instantiate OpenCode auth before live backend registration."""
+    from src.auth import auth_manager
+
+    provider = auth_manager.get_provider("opencode")
+
+    assert provider.name == "opencode"
+
+
+async def test_opencode_client_sends_prompt_to_existing_server(monkeypatch):
+    """OpenCode client creates a session and sends prompt bodies over HTTP."""
+    calls = []
+
+    class FakeResponse:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def get(self, path):
+            calls.append(("GET", path, {}))
+            return FakeResponse({"healthy": True, "version": "test"})
+
+        async def post(self, path, **kwargs):
+            calls.append(("POST", path, kwargs))
+            if path == "/session":
+                return FakeResponse({"id": "oc-session"})
+            return FakeResponse(
+                {
+                    "info": {
+                        "role": "assistant",
+                        "tokens": {
+                            "input": 7,
+                            "output": 3,
+                            "reasoning": 0,
+                            "cache": {"read": 0, "write": 0},
+                        },
+                    },
+                    "parts": [{"type": "text", "text": "hello from opencode"}],
+                }
+            )
+
+    monkeypatch.setenv("OPENCODE_BASE_URL", "http://127.0.0.1:4096")
+    monkeypatch.setattr("src.backends.opencode.client.httpx.AsyncClient", FakeAsyncClient)
+
+    from src.backends.opencode.client import OpenCodeClient
+    from src.session_manager import Session
+
+    backend = OpenCodeClient()
+    session = Session(session_id="gw-session")
+    client = await backend.create_client(
+        session=session,
+        model="anthropic/claude-sonnet-4-5",
+        system_prompt="request instructions",
+        _custom_base="base prompt",
+        cwd="/tmp/work",
+    )
+    chunks = [
+        chunk async for chunk in backend.run_completion_with_client(client, "say hi", session)
+    ]
+
+    assert calls[0] == (
+        "POST",
+        "/session",
+        {"json": {"title": "gw-session"}, "params": {"directory": "/tmp/work"}},
+    )
+    assert calls[1][0] == "POST"
+    assert calls[1][1] == "/session/oc-session/message"
+    assert calls[1][2]["json"]["system"] == "base prompt\n\nrequest instructions"
+    assert calls[1][2]["json"]["model"] == {
+        "providerID": "anthropic",
+        "modelID": "claude-sonnet-4-5",
+    }
+    assert calls[1][2]["json"]["parts"] == [{"type": "text", "text": "say hi"}]
+    assert getattr(session, "opencode_session_id") == "oc-session"
+    assert chunks[-1]["result"] == "hello from opencode"
+    assert chunks[-1]["usage"]["input_tokens"] == 7
+    assert chunks[-1]["usage"]["output_tokens"] == 3
+    assert backend.parse_message(chunks) == "hello from opencode"

--- a/tests/test_opencode_backend.py
+++ b/tests/test_opencode_backend.py
@@ -151,6 +151,186 @@ def test_opencode_event_converter_ignores_other_sessions():
     assert converter.final_text() == ""
 
 
+def test_opencode_event_converter_emits_tool_use_and_result_once():
+    """OpenCode event converter emits a tool_use and a completed tool_result."""
+    from src.backends.opencode.events import OpenCodeEventConverter
+
+    converter = OpenCodeEventConverter(session_id="oc-session")
+
+    running_chunks = converter.convert(
+        {
+            "type": "message.part.updated",
+            "properties": {
+                "sessionID": "oc-session",
+                "part": {
+                    "id": "part-tool",
+                    "type": "tool",
+                    "callID": "call-1",
+                    "tool": "bash",
+                    "state": {"status": "running", "input": {"command": "pwd"}},
+                },
+            },
+        }
+    )
+    completed_chunks = converter.convert(
+        {
+            "type": "message.part.updated",
+            "properties": {
+                "sessionID": "oc-session",
+                "part": {
+                    "id": "part-tool",
+                    "type": "tool",
+                    "callID": "call-1",
+                    "tool": "bash",
+                    "state": {
+                        "status": "completed",
+                        "input": {"command": "pwd"},
+                        "output": "/tmp/work\n",
+                    },
+                },
+            },
+        }
+    )
+
+    assert running_chunks == [
+        {
+            "type": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "call-1",
+                    "name": "bash",
+                    "input": {"command": "pwd"},
+                }
+            ],
+        }
+    ]
+    assert completed_chunks == [
+        {
+            "type": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "call-1",
+                    "content": "/tmp/work\n",
+                    "is_error": False,
+                }
+            ],
+        }
+    ]
+
+
+def test_opencode_event_converter_emits_error_tool_result():
+    """OpenCode event converter emits error tool results from failed tool updates."""
+    from src.backends.opencode.events import OpenCodeEventConverter
+
+    converter = OpenCodeEventConverter(session_id="oc-session")
+
+    chunks = converter.convert(
+        {
+            "type": "message.part.updated",
+            "properties": {
+                "sessionID": "oc-session",
+                "part": {
+                    "type": "tool",
+                    "callID": "call-1",
+                    "tool": "bash",
+                    "state": {
+                        "status": "error",
+                        "input": {"command": "exit 1"},
+                        "error": "failed",
+                    },
+                },
+            },
+        }
+    )
+
+    assert chunks == [
+        {
+            "type": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "call-1",
+                    "name": "bash",
+                    "input": {"command": "exit 1"},
+                }
+            ],
+        },
+        {
+            "type": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "call-1",
+                    "content": "failed",
+                    "is_error": True,
+                }
+            ],
+        },
+    ]
+
+
+def test_opencode_event_converter_accumulates_step_finish_usage():
+    """OpenCode event converter accumulates usage from step-finish parts."""
+    from src.backends.opencode.events import OpenCodeEventConverter
+
+    converter = OpenCodeEventConverter(session_id="oc-session")
+
+    chunks = converter.convert(
+        {
+            "type": "message.part.updated",
+            "properties": {
+                "sessionID": "oc-session",
+                "part": {
+                    "type": "step-finish",
+                    "tokens": {
+                        "input": 11,
+                        "output": 5,
+                        "reasoning": 2,
+                        "cache": {"read": 3, "write": 7},
+                    },
+                },
+            },
+        }
+    )
+
+    assert chunks == []
+    assert converter.usage == {
+        "input_tokens": 21,
+        "output_tokens": 5,
+        "total_tokens": 28,
+    }
+    assert converter.saw_activity is True
+
+
+def test_opencode_event_converter_finishes_only_after_activity():
+    """OpenCode event converter requires session activity before idle finishes."""
+    from src.backends.opencode.events import OpenCodeEventConverter
+
+    converter = OpenCodeEventConverter(session_id="oc-session")
+    idle_event = {"type": "session.idle", "properties": {"sessionID": "oc-session"}}
+
+    assert converter.finished(idle_event) is False
+
+    converter.convert(
+        {
+            "type": "message.part.delta",
+            "properties": {
+                "sessionID": "oc-session",
+                "partID": "part-text",
+                "field": "text",
+                "delta": "ok",
+            },
+        }
+    )
+
+    assert converter.finished(
+        {"type": "session.idle", "properties": {"sessionID": "other-session"}}
+    ) is False
+    assert converter.finished(idle_event) is True
+
+
 async def test_opencode_client_sends_prompt_to_existing_server(monkeypatch):
     """OpenCode client creates a session and sends prompt bodies over HTTP."""
     calls = []

--- a/tests/test_opencode_backend.py
+++ b/tests/test_opencode_backend.py
@@ -26,6 +26,23 @@ def test_opencode_client_exposes_runtime_metadata(monkeypatch):
     }
 
 
+def test_opencode_runtime_metadata_treats_explicit_base_url_as_external(monkeypatch):
+    """Direct base_url construction is external mode even without OPENCODE_BASE_URL."""
+    monkeypatch.delenv("OPENCODE_BASE_URL", raising=False)
+    monkeypatch.setenv("OPENCODE_MODELS", "openai/gpt-5.5")
+
+    import src.backends.opencode.client as client_module
+    import src.backends.opencode.constants as constants_module
+
+    importlib.reload(constants_module)
+    client_module = importlib.reload(client_module)
+
+    client = client_module.OpenCodeClient(base_url="http://127.0.0.1:4096")
+
+    assert client.runtime_metadata()["mode"] == "external"
+    assert client.runtime_metadata()["managed_process"] is False
+
+
 def test_opencode_descriptor_resolves_prefixed_model(monkeypatch):
     """OpenCode descriptor resolves opencode/<provider>/<model> IDs."""
     monkeypatch.setenv("OPENCODE_MODELS", "anthropic/claude-sonnet-4-5")

--- a/tests/test_opencode_backend.py
+++ b/tests/test_opencode_backend.py
@@ -402,8 +402,56 @@ def test_opencode_event_converter_emits_error_tool_result():
     ]
 
 
-def test_opencode_event_converter_emits_question_tool_use():
-    """Question tool updates are exposed as Responses-compatible tool_use chunks."""
+def test_opencode_event_converter_emits_question_request_tool_use():
+    """Question requests are exposed as Responses-compatible tool_use chunks."""
+    from src.backends.opencode.events import OpenCodeEventConverter
+
+    converter = OpenCodeEventConverter(session_id="oc-session")
+    chunks = converter.convert(
+        {
+            "type": "question.asked",
+            "properties": {
+                "id": "que_1",
+                "sessionID": "oc-session",
+                "questions": [
+                    {
+                        "question": "Continue?",
+                        "options": [{"label": "Yes"}, {"label": "No"}],
+                    },
+                ],
+                "tool": {"messageID": "msg_1", "callID": "call_1"},
+            },
+        }
+    )
+
+    assert chunks == [
+        {
+            "type": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "que_1",
+                    "name": "question",
+                    "input": {
+                        "questions": [
+                            {
+                                "question": "Continue?",
+                                "options": [{"label": "Yes"}, {"label": "No"}],
+                            }
+                        ],
+                    },
+                    "metadata": {
+                        "opencode_question_request_id": "que_1",
+                        "opencode_tool_call_id": "call_1",
+                    },
+                }
+            ],
+        }
+    ]
+
+
+def test_opencode_event_converter_suppresses_question_tool_part_updates():
+    """Question tool part updates should not be exposed before question.asked."""
     from src.backends.opencode.events import OpenCodeEventConverter
 
     converter = OpenCodeEventConverter(session_id="oc-session")
@@ -415,12 +463,16 @@ def test_opencode_event_converter_emits_question_tool_use():
                     "sessionID": "oc-session",
                     "type": "tool",
                     "tool": "question",
-                    "callID": "q1",
+                    "callID": "call_1",
                     "state": {
                         "status": "running",
                         "input": {
-                            "question": "Continue?",
-                            "options": [{"label": "Yes"}, {"label": "No"}],
+                            "questions": [
+                                {
+                                    "question": "Continue?",
+                                    "options": [{"label": "Yes"}, {"label": "No"}],
+                                }
+                            ]
                         },
                     },
                 }
@@ -428,22 +480,8 @@ def test_opencode_event_converter_emits_question_tool_use():
         }
     )
 
-    assert chunks == [
-        {
-            "type": "assistant",
-            "content": [
-                {
-                    "type": "tool_use",
-                    "id": "q1",
-                    "name": "question",
-                    "input": {
-                        "question": "Continue?",
-                        "options": [{"label": "Yes"}, {"label": "No"}],
-                    },
-                }
-            ],
-        }
-    ]
+    assert chunks == []
+    assert converter.saw_activity is True
 
 
 def test_opencode_event_converter_accumulates_step_finish_usage():
@@ -645,19 +683,49 @@ async def test_opencode_client_uses_configured_agent(monkeypatch):
     assert chunks[-1]["result"] == "ok"
 
 
-async def test_opencode_client_resumes_question_with_tool_output(monkeypatch):
-    """OpenCode question continuation sends a completed question tool part."""
+async def test_opencode_client_resumes_question_with_reply_endpoint(monkeypatch):
+    """OpenCode question continuation replies to the pending question request."""
     calls = []
+    events = [
+        {
+            "type": "message.part.delta",
+            "properties": {
+                "sessionID": "oc-session",
+                "messageID": "msg-2",
+                "partID": "part-text",
+                "field": "text",
+                "delta": "continued",
+            },
+        },
+        {"type": "session.idle", "properties": {"sessionID": "oc-session"}},
+    ]
 
     class FakeResponse:
+        def __init__(self, payload=True):
+            self._payload = payload
+
         def raise_for_status(self):
             return None
 
         def json(self):
-            return {
-                "info": {"role": "assistant"},
-                "parts": [{"type": "text", "text": "continued"}],
-            }
+            return self._payload
+
+    class FakeStreamResponse:
+        def raise_for_status(self):
+            return None
+
+        async def aiter_lines(self):
+            for event in events:
+                yield f"event: {event['type']}"
+                yield "data: " + json.dumps(event)
+                yield ""
+
+    class FakeStreamContext:
+        async def __aenter__(self):
+            return FakeStreamResponse()
+
+        async def __aexit__(self, *args):
+            return None
 
     class FakeAsyncClient:
         def __init__(self, **kwargs):
@@ -669,8 +737,12 @@ async def test_opencode_client_resumes_question_with_tool_output(monkeypatch):
         async def __aexit__(self, *args):
             return None
 
+        def stream(self, method, path, **kwargs):
+            calls.append(("STREAM", method, path, kwargs))
+            return FakeStreamContext()
+
         async def post(self, path, **kwargs):
-            calls.append((path, kwargs))
+            calls.append(("POST", path, kwargs))
             return FakeResponse()
 
     monkeypatch.setenv("OPENCODE_BASE_URL", "http://127.0.0.1:4096")
@@ -691,7 +763,7 @@ async def test_opencode_client_resumes_question_with_tool_output(monkeypatch):
         chunk
         async for chunk in backend.resume_question_with_client(
             client,
-            "q1",
+            "que_1",
             "yes",
             Session(session_id="gw-session"),
         )
@@ -699,25 +771,30 @@ async def test_opencode_client_resumes_question_with_tool_output(monkeypatch):
 
     assert calls == [
         (
-            "/session/oc-session/message",
+            "STREAM",
+            "GET",
+            "/event",
+            {"params": {"directory": "/tmp/work"}},
+        ),
+        (
+            "POST",
+            "/question/que_1/reply",
             {
                 "json": {
-                    "agent": "plan",
-                    "parts": [
-                        {
-                            "type": "tool",
-                            "callID": "q1",
-                            "tool": "question",
-                            "state": {"status": "completed", "output": "yes"},
-                        }
-                    ],
-                    "model": {"providerID": "openai", "modelID": "gpt-5.5"},
+                    "answers": [["yes"]],
                 },
                 "params": {"directory": "/tmp/work"},
             },
         )
     ]
     assert chunks == [
+        {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "continued"},
+            },
+        },
         {"type": "assistant", "content": [{"type": "text", "text": "continued"}]},
         {"type": "result", "subtype": "success", "result": "continued"},
     ]

--- a/tests/test_opencode_backend.py
+++ b/tests/test_opencode_backend.py
@@ -1,0 +1,36 @@
+"""OpenCode backend tests."""
+
+import importlib
+
+
+def test_opencode_descriptor_resolves_prefixed_model(monkeypatch):
+    """OpenCode descriptor resolves opencode/<provider>/<model> IDs."""
+    monkeypatch.setenv("OPENCODE_MODELS", "anthropic/claude-sonnet-4-5")
+
+    import src.backends.opencode as opencode_pkg
+
+    opencode_pkg = importlib.reload(opencode_pkg)
+
+    resolved = opencode_pkg.OPENCODE_DESCRIPTOR.resolve_fn(
+        "opencode/anthropic/claude-sonnet-4-5"
+    )
+
+    assert resolved is not None
+    assert resolved.public_model == "opencode/anthropic/claude-sonnet-4-5"
+    assert resolved.backend == "opencode"
+    assert resolved.provider_model == "anthropic/claude-sonnet-4-5"
+    assert opencode_pkg.OPENCODE_DESCRIPTOR.models == [
+        "opencode/anthropic/claude-sonnet-4-5"
+    ]
+
+
+def test_opencode_descriptor_rejects_unprefixed_model(monkeypatch):
+    """OpenCode descriptor does not claim bare provider/model IDs."""
+    monkeypatch.setenv("OPENCODE_MODELS", "anthropic/claude-sonnet-4-5")
+
+    import src.backends.opencode as opencode_pkg
+
+    opencode_pkg = importlib.reload(opencode_pkg)
+
+    assert opencode_pkg.OPENCODE_DESCRIPTOR.resolve_fn("anthropic/claude-sonnet-4-5") is None
+    assert opencode_pkg.OPENCODE_DESCRIPTOR.resolve_fn("opencode/missing_provider_model") is None

--- a/tests/test_opencode_backend.py
+++ b/tests/test_opencode_backend.py
@@ -260,3 +260,584 @@ async def test_opencode_client_reports_empty_json_response(monkeypatch):
             ),
         }
     ]
+
+
+async def test_opencode_client_streams_text_deltas_from_event_sse(monkeypatch):
+    """Streaming mode uses prompt_async and converts OpenCode text deltas."""
+    calls = []
+
+    events = [
+        {
+            "type": "message.part.delta",
+            "properties": {
+                "sessionID": "oc-session",
+                "messageID": "msg-1",
+                "partID": "part-1",
+                "field": "text",
+                "delta": "hel",
+            },
+        },
+        {
+            "type": "message.part.delta",
+            "properties": {
+                "sessionID": "oc-session",
+                "messageID": "msg-1",
+                "partID": "part-1",
+                "field": "text",
+                "delta": "lo",
+            },
+        },
+        {"type": "session.idle", "properties": {"sessionID": "oc-session"}},
+    ]
+
+    class FakeResponse:
+        def __init__(self, payload=None):
+            self._payload = payload or {}
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    class FakeStreamResponse:
+        def raise_for_status(self):
+            return None
+
+        async def aiter_lines(self):
+            for event in events:
+                yield f"event: {event['type']}"
+                yield "data: " + json.dumps(event)
+                yield ""
+
+    class FakeStreamContext:
+        async def __aenter__(self):
+            return FakeStreamResponse()
+
+        async def __aexit__(self, *args):
+            return None
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        def stream(self, method, path, **kwargs):
+            calls.append(("STREAM", method, path, kwargs))
+            return FakeStreamContext()
+
+        async def post(self, path, **kwargs):
+            calls.append(("POST", path, kwargs))
+            if path == "/session":
+                return FakeResponse({"id": "oc-session"})
+            return FakeResponse()
+
+    monkeypatch.setenv("OPENCODE_BASE_URL", "http://127.0.0.1:4096")
+    monkeypatch.setattr("src.backends.opencode.client.httpx.AsyncClient", FakeAsyncClient)
+
+    from src.backends.opencode.client import OpenCodeClient
+    from src.session_manager import Session
+
+    backend = OpenCodeClient()
+    session = Session(session_id="gw-session")
+    client = await backend.create_client(session=session, model="openai/gpt-5.1-codex")
+    client.stream_events = True
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "hi", session)]
+
+    assert calls[1] == (
+        "STREAM",
+        "GET",
+        "/event",
+        {"params": None},
+    )
+    assert calls[2][0] == "POST"
+    assert calls[2][1] == "/session/oc-session/prompt_async"
+    assert [chunk["event"]["delta"]["text"] for chunk in chunks[:2]] == ["hel", "lo"]
+    assert chunks[-1] == {"type": "result", "subtype": "success", "result": "hello"}
+
+
+async def test_opencode_client_streams_tool_use_and_result_from_event_sse(monkeypatch):
+    """Streaming mode converts OpenCode tool updates to gateway tool chunks."""
+    events = [
+        {
+            "type": "message.part.updated",
+            "properties": {
+                "sessionID": "oc-session",
+                "part": {
+                    "id": "part-tool",
+                    "type": "tool",
+                    "callID": "call-1",
+                    "tool": "bash",
+                    "state": {
+                        "status": "running",
+                        "input": {"command": "pwd"},
+                        "title": "pwd",
+                    },
+                },
+            },
+        },
+        {
+            "type": "message.part.updated",
+            "properties": {
+                "sessionID": "oc-session",
+                "part": {
+                    "id": "part-tool",
+                    "type": "tool",
+                    "callID": "call-1",
+                    "tool": "bash",
+                    "state": {
+                        "status": "completed",
+                        "input": {"command": "pwd"},
+                        "output": "/tmp/work\n",
+                        "title": "pwd",
+                        "metadata": {},
+                    },
+                },
+            },
+        },
+        {
+            "type": "message.part.updated",
+            "properties": {
+                "sessionID": "oc-session",
+                "part": {
+                    "id": "part-text",
+                    "type": "text",
+                    "text": "done",
+                },
+            },
+        },
+        {"type": "session.idle", "properties": {"sessionID": "oc-session"}},
+    ]
+
+    class FakeResponse:
+        def __init__(self, payload=None):
+            self._payload = payload or {}
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    class FakeStreamResponse:
+        def raise_for_status(self):
+            return None
+
+        async def aiter_lines(self):
+            for event in events:
+                yield "data: " + json.dumps(event)
+                yield ""
+
+    class FakeStreamContext:
+        async def __aenter__(self):
+            return FakeStreamResponse()
+
+        async def __aexit__(self, *args):
+            return None
+
+    class FakeAsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def stream(self, method, path, **kwargs):
+            return FakeStreamContext()
+
+        async def post(self, path, **kwargs):
+            if path == "/session":
+                return FakeResponse({"id": "oc-session"})
+            return FakeResponse()
+
+    monkeypatch.setenv("OPENCODE_BASE_URL", "http://127.0.0.1:4096")
+    monkeypatch.setattr("src.backends.opencode.client.httpx.AsyncClient", FakeAsyncClient)
+
+    from src.backends.opencode.client import OpenCodeClient
+    from src.session_manager import Session
+
+    backend = OpenCodeClient()
+    session = Session(session_id="gw-session")
+    client = await backend.create_client(session=session, model="openai/gpt-5.1-codex")
+    client.stream_events = True
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "hi", session)]
+
+    assert {
+        "type": "tool_use",
+        "id": "call-1",
+        "name": "bash",
+        "input": {"command": "pwd"},
+    } in [block for chunk in chunks for block in chunk.get("content", [])]
+    assert {
+        "type": "tool_result",
+        "tool_use_id": "call-1",
+        "content": "/tmp/work\n",
+        "is_error": False,
+    } in [block for chunk in chunks for block in chunk.get("content", [])]
+    assert chunks[-1]["result"] == "done"
+
+
+async def test_opencode_streaming_aggregates_step_finish_usage(monkeypatch):
+    """Streaming mode aggregates per-step OpenCode token usage."""
+    events = [
+        {
+            "type": "message.part.delta",
+            "properties": {
+                "sessionID": "oc-session",
+                "partID": "part-text",
+                "field": "text",
+                "delta": "ok",
+            },
+        },
+        {
+            "type": "message.part.updated",
+            "properties": {
+                "sessionID": "oc-session",
+                "part": {
+                    "id": "part-step-1",
+                    "type": "step-finish",
+                    "tokens": {
+                        "input": 11,
+                        "output": 5,
+                        "reasoning": 2,
+                        "cache": {"read": 3, "write": 7},
+                    },
+                },
+            },
+        },
+        {
+            "type": "message.part.updated",
+            "properties": {
+                "sessionID": "oc-session",
+                "part": {
+                    "id": "part-step-2",
+                    "type": "step-finish",
+                    "tokens": {
+                        "input": 13,
+                        "output": 7,
+                        "reasoning": 1,
+                        "cache": {"read": 0, "write": 4},
+                    },
+                },
+            },
+        },
+        {"type": "session.idle", "properties": {"sessionID": "oc-session"}},
+    ]
+
+    class FakeResponse:
+        def __init__(self, payload=None):
+            self._payload = payload or {}
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    class FakeStreamResponse:
+        def raise_for_status(self):
+            return None
+
+        async def aiter_lines(self):
+            for event in events:
+                yield "data: " + json.dumps(event)
+                yield ""
+
+    class FakeStreamContext:
+        async def __aenter__(self):
+            return FakeStreamResponse()
+
+        async def __aexit__(self, *args):
+            return None
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        def stream(self, method, path, **kwargs):
+            return FakeStreamContext()
+
+        async def post(self, path, **kwargs):
+            if path == "/session":
+                return FakeResponse({"id": "oc-session"})
+            return FakeResponse()
+
+    monkeypatch.setenv("OPENCODE_BASE_URL", "http://127.0.0.1:4096")
+    monkeypatch.setattr("src.backends.opencode.client.httpx.AsyncClient", FakeAsyncClient)
+
+    from src.backends.opencode.client import OpenCodeClient
+    from src.session_manager import Session
+
+    backend = OpenCodeClient()
+    session = Session(session_id="gw-session")
+    client = await backend.create_client(session=session, model="openai/gpt-5.1-codex")
+    client.stream_events = True
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "hi", session)]
+
+    assert chunks[-1]["usage"] == {
+        "input_tokens": 38,
+        "output_tokens": 12,
+    }
+
+
+async def test_opencode_streaming_ignores_initial_idle_until_activity(monkeypatch):
+    """An idle snapshot before any session activity must not end the stream."""
+    events = [
+        {"type": "session.idle", "properties": {"sessionID": "oc-session"}},
+        {
+            "type": "message.part.delta",
+            "properties": {
+                "sessionID": "oc-session",
+                "partID": "part-text",
+                "field": "text",
+                "delta": "after-idle",
+            },
+        },
+        {"type": "session.idle", "properties": {"sessionID": "oc-session"}},
+    ]
+
+    class FakeResponse:
+        def __init__(self, payload=None):
+            self._payload = payload or {}
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    class FakeStreamResponse:
+        def raise_for_status(self):
+            return None
+
+        async def aiter_lines(self):
+            for event in events:
+                yield "data: " + json.dumps(event)
+                yield ""
+
+    class FakeStreamContext:
+        async def __aenter__(self):
+            return FakeStreamResponse()
+
+        async def __aexit__(self, *args):
+            return None
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        def stream(self, method, path, **kwargs):
+            return FakeStreamContext()
+
+        async def post(self, path, **kwargs):
+            if path == "/session":
+                return FakeResponse({"id": "oc-session"})
+            return FakeResponse()
+
+    monkeypatch.setenv("OPENCODE_BASE_URL", "http://127.0.0.1:4096")
+    monkeypatch.setattr("src.backends.opencode.client.httpx.AsyncClient", FakeAsyncClient)
+
+    from src.backends.opencode.client import OpenCodeClient
+    from src.session_manager import Session
+
+    backend = OpenCodeClient()
+    session = Session(session_id="gw-session")
+    client = await backend.create_client(session=session, model="openai/gpt-5.1-codex")
+    client.stream_events = True
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "hi", session)]
+
+    assert chunks[-1]["result"] == "after-idle"
+
+
+async def test_opencode_streaming_event_client_disables_read_timeout(monkeypatch):
+    """The /event stream client disables read timeout while keeping connect timeout."""
+    client_kwargs = []
+
+    class FakeResponse:
+        def __init__(self, payload=None):
+            self._payload = payload or {}
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    class FakeStreamResponse:
+        def raise_for_status(self):
+            return None
+
+        async def aiter_lines(self):
+            yield 'data: {"type":"session.idle","properties":{"sessionID":"oc-session"}}'
+            yield ""
+
+    class FakeStreamContext:
+        async def __aenter__(self):
+            return FakeStreamResponse()
+
+        async def __aexit__(self, *args):
+            return None
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs):
+            client_kwargs.append(kwargs)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        def stream(self, method, path, **kwargs):
+            return FakeStreamContext()
+
+        async def post(self, path, **kwargs):
+            if path == "/session":
+                return FakeResponse({"id": "oc-session"})
+            return FakeResponse()
+
+    monkeypatch.setenv("OPENCODE_BASE_URL", "http://127.0.0.1:4096")
+    monkeypatch.setattr("src.backends.opencode.client.httpx.AsyncClient", FakeAsyncClient)
+
+    from src.backends.opencode.client import OpenCodeClient
+    from src.session_manager import Session
+
+    backend = OpenCodeClient()
+    session = Session(session_id="gw-session")
+    client = await backend.create_client(session=session, model="openai/gpt-5.1-codex")
+    client.stream_events = True
+
+    _ = [chunk async for chunk in backend.run_completion_with_client(client, "hi", session)]
+
+    event_timeout = client_kwargs[1]["timeout"]
+    assert event_timeout.connect == backend.timeout
+    assert event_timeout.read is None
+
+
+async def test_opencode_streaming_waits_for_non_empty_tool_input(monkeypatch):
+    """Do not emit tool_use on pending empty input when a later update has input."""
+    events = [
+        {
+            "type": "message.part.updated",
+            "properties": {
+                "sessionID": "oc-session",
+                "part": {
+                    "id": "part-tool",
+                    "type": "tool",
+                    "callID": "call-1",
+                    "tool": "bash",
+                    "state": {"status": "pending", "input": {}},
+                },
+            },
+        },
+        {
+            "type": "message.part.updated",
+            "properties": {
+                "sessionID": "oc-session",
+                "part": {
+                    "id": "part-tool",
+                    "type": "tool",
+                    "callID": "call-1",
+                    "tool": "bash",
+                    "state": {"status": "running", "input": {"command": "pwd"}},
+                },
+            },
+        },
+        {"type": "session.idle", "properties": {"sessionID": "oc-session"}},
+    ]
+
+    class FakeResponse:
+        def __init__(self, payload=None):
+            self._payload = payload or {}
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    class FakeStreamResponse:
+        def raise_for_status(self):
+            return None
+
+        async def aiter_lines(self):
+            for event in events:
+                yield "data: " + json.dumps(event)
+                yield ""
+
+    class FakeStreamContext:
+        async def __aenter__(self):
+            return FakeStreamResponse()
+
+        async def __aexit__(self, *args):
+            return None
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        def stream(self, method, path, **kwargs):
+            return FakeStreamContext()
+
+        async def post(self, path, **kwargs):
+            if path == "/session":
+                return FakeResponse({"id": "oc-session"})
+            return FakeResponse()
+
+    monkeypatch.setenv("OPENCODE_BASE_URL", "http://127.0.0.1:4096")
+    monkeypatch.setattr("src.backends.opencode.client.httpx.AsyncClient", FakeAsyncClient)
+
+    from src.backends.opencode.client import OpenCodeClient
+    from src.session_manager import Session
+
+    backend = OpenCodeClient()
+    session = Session(session_id="gw-session")
+    client = await backend.create_client(session=session, model="openai/gpt-5.1-codex")
+    client.stream_events = True
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "hi", session)]
+    tool_uses = [
+        block
+        for chunk in chunks
+        for block in chunk.get("content", [])
+        if block.get("type") == "tool_use"
+    ]
+
+    assert tool_uses == [
+        {
+            "type": "tool_use",
+            "id": "call-1",
+            "name": "bash",
+            "input": {"command": "pwd"},
+        }
+    ]

--- a/tests/test_opencode_backend.py
+++ b/tests/test_opencode_backend.py
@@ -99,6 +99,58 @@ def test_auth_manager_returns_opencode_provider():
     assert provider.name == "opencode"
 
 
+def test_opencode_event_converter_emits_text_delta_and_final_text():
+    """OpenCode event converter emits gateway text deltas and accumulates final text."""
+    from src.backends.opencode.events import OpenCodeEventConverter
+
+    converter = OpenCodeEventConverter(session_id="oc-session")
+
+    chunks = converter.convert(
+        {
+            "type": "message.part.delta",
+            "properties": {
+                "sessionID": "oc-session",
+                "partID": "p1",
+                "field": "text",
+                "delta": "hello",
+            },
+        }
+    )
+
+    assert chunks == [
+        {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "hello"},
+            },
+        }
+    ]
+    assert converter.final_text() == "hello"
+
+
+def test_opencode_event_converter_ignores_other_sessions():
+    """OpenCode event converter ignores events for unrelated sessions."""
+    from src.backends.opencode.events import OpenCodeEventConverter
+
+    converter = OpenCodeEventConverter(session_id="oc-session")
+
+    chunks = converter.convert(
+        {
+            "type": "message.part.delta",
+            "properties": {
+                "sessionID": "other-session",
+                "partID": "p1",
+                "field": "text",
+                "delta": "wrong",
+            },
+        }
+    )
+
+    assert chunks == []
+    assert converter.final_text() == ""
+
+
 async def test_opencode_client_sends_prompt_to_existing_server(monkeypatch):
     """OpenCode client creates a session and sends prompt bodies over HTTP."""
     calls = []

--- a/tests/test_opencode_backend.py
+++ b/tests/test_opencode_backend.py
@@ -313,14 +313,6 @@ def test_opencode_event_converter_emits_question_tool_use():
             ],
         }
     ]
-    assert converter.pending_question == {
-        "call_id": "q1",
-        "name": "question",
-        "arguments": {
-            "question": "Continue?",
-            "options": [{"label": "Yes"}, {"label": "No"}],
-        },
-    }
 
 
 def test_opencode_event_converter_accumulates_step_finish_usage():

--- a/tests/test_opencode_backend.py
+++ b/tests/test_opencode_backend.py
@@ -4,6 +4,28 @@ import importlib
 import json
 
 
+def test_opencode_client_exposes_runtime_metadata(monkeypatch):
+    """OpenCode client reports operational metadata for diagnostics."""
+    monkeypatch.setenv("OPENCODE_BASE_URL", "http://127.0.0.1:4096")
+    monkeypatch.setenv("OPENCODE_MODELS", "openai/gpt-5.5")
+
+    import src.backends.opencode.client as client_module
+    import src.backends.opencode.constants as constants_module
+
+    importlib.reload(constants_module)
+    client_module = importlib.reload(client_module)
+
+    client = client_module.OpenCodeClient()
+
+    assert client.runtime_metadata() == {
+        "mode": "external",
+        "base_url": "http://127.0.0.1:4096",
+        "agent": "general",
+        "models": ["opencode/openai/gpt-5.5"],
+        "managed_process": False,
+    }
+
+
 def test_opencode_descriptor_resolves_prefixed_model(monkeypatch):
     """OpenCode descriptor resolves opencode/<provider>/<model> IDs."""
     monkeypatch.setenv("OPENCODE_MODELS", "anthropic/claude-sonnet-4-5")

--- a/tests/test_opencode_backend.py
+++ b/tests/test_opencode_backend.py
@@ -73,6 +73,27 @@ def test_opencode_managed_config_allows_question_permission_override(monkeypatch
     assert config["permission"]["question"] == "allow"
 
 
+def test_opencode_managed_config_can_include_wrapper_mcp(monkeypatch):
+    """Managed OpenCode config can copy wrapper MCP servers when enabled."""
+    monkeypatch.delenv("OPENCODE_CONFIG_CONTENT", raising=False)
+    monkeypatch.delenv("OPENCODE_QUESTION_PERMISSION", raising=False)
+    monkeypatch.setenv("OPENCODE_USE_WRAPPER_MCP_CONFIG", "true")
+    monkeypatch.setenv("OPENCODE_DEFAULT_MODEL", "openai/gpt-5.5")
+    monkeypatch.setattr(
+        "src.mcp_config.get_validated_mcp_config",
+        lambda: {"demo": {"type": "stdio", "command": "uvx", "args": ["demo"]}},
+    )
+
+    from src.backends.opencode.client import OpenCodeClient
+
+    client = OpenCodeClient(base_url="http://127.0.0.1:4096")
+    config = json.loads(client._managed_config_content())
+
+    assert config["model"] == "openai/gpt-5.5"
+    assert config["permission"]["question"] == "ask"
+    assert config["mcp"]["demo"] == {"type": "local", "command": ["uvx", "demo"]}
+
+
 def test_opencode_descriptor_resolves_prefixed_model(monkeypatch):
     """OpenCode descriptor resolves opencode/<provider>/<model> IDs."""
     monkeypatch.setenv("OPENCODE_MODELS", "anthropic/claude-sonnet-4-5")

--- a/tests/test_opencode_backend.py
+++ b/tests/test_opencode_backend.py
@@ -43,6 +43,36 @@ def test_opencode_runtime_metadata_treats_explicit_base_url_as_external(monkeypa
     assert client.runtime_metadata()["managed_process"] is False
 
 
+def test_opencode_managed_config_enables_question_tool_by_default(monkeypatch):
+    """Managed OpenCode config exposes the question tool by default."""
+    monkeypatch.delenv("OPENCODE_CONFIG_CONTENT", raising=False)
+    monkeypatch.delenv("OPENCODE_QUESTION_PERMISSION", raising=False)
+    monkeypatch.delenv("OPENCODE_DEFAULT_MODEL", raising=False)
+
+    from src.backends.opencode.client import OpenCodeClient
+
+    client = OpenCodeClient(base_url="http://127.0.0.1:4096")
+
+    config = json.loads(client._managed_config_content())
+
+    assert config["permission"]["question"] == "ask"
+    assert config["share"] == "disabled"
+
+
+def test_opencode_managed_config_allows_question_permission_override(monkeypatch):
+    """Operators can override the managed OpenCode question permission."""
+    monkeypatch.delenv("OPENCODE_CONFIG_CONTENT", raising=False)
+    monkeypatch.setenv("OPENCODE_QUESTION_PERMISSION", "allow")
+
+    from src.backends.opencode.client import OpenCodeClient
+
+    client = OpenCodeClient(base_url="http://127.0.0.1:4096")
+
+    config = json.loads(client._managed_config_content())
+
+    assert config["permission"]["question"] == "allow"
+
+
 def test_opencode_descriptor_resolves_prefixed_model(monkeypatch):
     """OpenCode descriptor resolves opencode/<provider>/<model> IDs."""
     monkeypatch.setenv("OPENCODE_MODELS", "anthropic/claude-sonnet-4-5")

--- a/tests/test_streaming_utils_unit.py
+++ b/tests/test_streaming_utils_unit.py
@@ -180,6 +180,65 @@ async def test_stream_response_chunks_success_suppresses_thinking_and_formats_to
 
 
 @pytest.mark.asyncio
+async def test_stream_response_chunks_suppresses_ask_user_question_response_result():
+    async def ask_user_question_continuation_source():
+        yield {
+            "type": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_ask_1",
+                    "content": "User responded: 그냥 테스트",
+                    "is_error": True,
+                }
+            ],
+        }
+        yield {
+            "type": "assistant",
+            "content": [{"type": "text", "text": "잘 작동하네요."}],
+        }
+        yield {
+            "type": "result",
+            "subtype": "success",
+            "result": "잘 작동하네요.",
+        }
+
+    chunks_buffer = []
+    stream_result = {}
+
+    lines = [
+        line
+        async for line in stream_response_chunks(
+            chunk_source=ask_user_question_continuation_source(),
+            model="claude-test",
+            response_id="resp-stream-ask",
+            output_item_id="msg-stream-ask",
+            chunks_buffer=chunks_buffer,
+            logger=logging.getLogger("test-stream-ask-user-question"),
+            prompt_text="",
+            metadata={},
+            stream_result=stream_result,
+            request_context={
+                "continuation": True,
+                "function_call_output_call_id": "toolu_ask_1",
+            },
+        )
+    ]
+
+    parsed = [_parse_response_sse(line) for line in lines]
+    event_types = [event_type for event_type, _payload in parsed]
+
+    assert "response.tool_result" not in event_types
+    assert [
+        payload["delta"]
+        for event_type, payload in parsed
+        if event_type == "response.output_text.delta"
+    ] == ["잘 작동하네요."]
+    assert parsed[-1][0] == "response.completed"
+    assert stream_result["success"] is True
+
+
+@pytest.mark.asyncio
 async def test_stream_response_chunks_formats_legacy_assistant_messages():
     async def legacy_assistant_source():
         yield {

--- a/tests/test_workspace_manager.py
+++ b/tests/test_workspace_manager.py
@@ -117,6 +117,25 @@ class TestResolve:
         manager.resolve("dave", sync_template=True)
         assert (workspace / ".claude" / "settings.json").read_text() == '{"key": "value"}'
 
+    def test_sync_template_removes_deleted_claude_template_files(
+        self, manager, tmp_base, tmp_template
+    ):
+        skill_dir = tmp_template / ".claude" / "skills" / "old-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: old-skill\ndescription: Old skill\n---\nOld"
+        )
+
+        workspace = manager.resolve("frank", sync_template=True)
+        copied_skill = workspace / ".claude" / "skills" / "old-skill" / "SKILL.md"
+        assert copied_skill.is_file()
+
+        (skill_dir / "SKILL.md").unlink()
+        skill_dir.rmdir()
+        manager.resolve("frank", sync_template=True)
+
+        assert not copied_skill.exists()
+
     def test_no_template_source_skips_sync(self, manager_no_template, tmp_base):
         workspace = manager_no_template.resolve("eve", sync_template=True)
         assert not (workspace / ".claude").exists()


### PR DESCRIPTION
## 변경 사항

- OpenCode `permission.asked` 이벤트를 `requires_action` 흐름으로 연결하고, 사용자 응답을 `/permission/{id}/reply`로 재개하도록 구현했습니다.
- OpenCode 이미지 입력을 지원하되, `cwd/.claude_images` 아래의 `img_<16hex>.<ext>` 파일만 신뢰하도록 제한했습니다.
- 사용자 프롬프트에 임의 `<attached_image path="..." />` 마커가 들어와도 외부 파일을 읽지 않도록 차단했습니다.
- 권한 응답 파싱이 알 수 없는 입력을 허용하지 않고 기본 `reject`로 fail-closed 되도록 수정했습니다.
- OpenCode 세션 종료 시 서버 세션 삭제를 호출하고, 삭제 실패는 warning 로그로 남기도록 변경했습니다.
- permission/question pending tool call 저장과 resume kind 검증을 명시화했습니다.

## 배경

OpenCode 백엔드 확장 과정에서 이미지 마커와 권한 재개 로직이 사용자 입력을 과신할 수 있는 지점이 있었습니다. 특히 사용자 프롬프트가 첨부 이미지 마커 형식을 직접 포함하면 서버가 로컬 파일을 읽어 전송할 수 있었고, 권한 응답 파싱은 매칭 실패 시 허용으로 떨어지는 문제가 있었습니다.

이번 변경은 OpenCode 기능을 유지하면서 파일 접근과 권한 결정을 보수적으로 제한하는 쪽으로 정리했습니다.

## 영향

- OpenCode 사용자는 이미지 입력, permission 요청, 세션 cleanup 흐름을 사용할 수 있습니다.
- 신뢰되지 않은 이미지 마커는 파일 첨부로 처리되지 않고 텍스트로 남으며 warning 로그가 기록됩니다.
- 알 수 없는 permission 응답은 승인되지 않고 `reject`로 처리됩니다.
- 기존 Claude 경로의 이미지 검증은 유지하고, OpenCode 백엔드에 대해서만 image handler 의존을 완화했습니다.

## 검증

- `uv run ruff check src/backends/opencode/client.py src/backends/opencode/events.py src/routes/responses.py src/routes/deps.py tests/test_opencode_backend.py tests/test_main_api_unit.py tests/test_image_endpoints.py`
- `uv run ruff format --check src/backends/opencode/client.py src/backends/opencode/events.py src/routes/responses.py src/routes/deps.py tests/test_opencode_backend.py tests/test_main_api_unit.py tests/test_image_endpoints.py`
- `git diff --check`
- `uv run pytest -q` → `1201 passed, 3 skipped, 4 deselected`