### PR TITLE
feat(opencode): re-enable external mode + restructure docs into per-backend folders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,19 +54,43 @@ DEFAULT_MODEL=sonnet
 # BACKENDS=claude,opencode
 
 # OpenCode Backend Configuration
-# The gateway starts `opencode serve` automatically.
+#
+# Two operating modes:
+#   managed (default)  Gateway spawns `opencode serve` as a subprocess and
+#                      feeds it OPENCODE_CONFIG_CONTENT + the wrapper MCP_CONFIG
+#                      (when OPENCODE_USE_WRAPPER_MCP_CONFIG=true).
+#   external           Set OPENCODE_BASE_URL to point at an externally-managed
+#                      `opencode serve`. Use this when OpenCode must run on a
+#                      trusted host with broader filesystem access while the
+#                      gateway itself is sandboxed. In external mode the
+#                      OPENCODE_CONFIG_CONTENT, OPENCODE_USE_WRAPPER_MCP_CONFIG,
+#                      and OPENCODE_BIN/HOST/PORT/START_TIMEOUT_MS variables
+#                      are no-ops; the external server owns its own config.
+# OPENCODE_BASE_URL=http://opencode-host:7891
+
+# Managed-mode subprocess controls (ignored in external mode)
 # OPENCODE_BIN=opencode
 # OPENCODE_HOST=127.0.0.1
 # OPENCODE_PORT=0
 # OPENCODE_START_TIMEOUT_MS=5000
+
+# Request-time options (apply in both modes)
 # OPENCODE_AGENT=general
 # OPENCODE_DEFAULT_MODEL=openai/gpt-5.5
 # Managed mode exposes OpenCode's question tool by default.
 # Set to deny to hide it, or allow to enable without permission prompts.
 # OPENCODE_QUESTION_PERMISSION=ask
+
+# Basic-auth credentials for the OpenCode server (apply in both modes)
+# OPENCODE_SERVER_USERNAME=opencode
+# OPENCODE_SERVER_PASSWORD=
+
+# Managed-mode config injection (ignored in external mode)
+# OPENCODE_CONFIG_CONTENT=
 # Include validated wrapper MCP_CONFIG in managed OpenCode config.
-# External OpenCode servers must be configured separately.
 # OPENCODE_USE_WRAPPER_MCP_CONFIG=false
+
+# Public model allowlist returned by /v1/models (gateway-side, both modes)
 # OPENCODE_MODELS=openai/gpt-5.5,openai/gpt-5.5-fast,openai/gpt-5.4,openai/gpt-5.4-mini,opencode/gpt-5-nano
 
 # Optional live OpenCode smoke test settings

--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
-# Claude Code Gateway
+# Oh My Gateway
 
 [![Python 3.10+](https://img.shields.io/badge/Python-3.10%2B-3776AB?logo=python&logoColor=white)](https://python.org)
 [![FastAPI](https://img.shields.io/badge/FastAPI-009688?logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com)
-[![Docker](https://img.shields.io/badge/Docker-ready-2496ED?logo=docker&logoColor=white)](https://github.com/JinY0ung-Shin/claude-code-gateway)
+[![Docker](https://img.shields.io/badge/Docker-ready-2496ED?logo=docker&logoColor=white)](https://github.com/JinY0ung-Shin/oh-my-gateway)
 [![MIT License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
-FastAPI gateway that exposes the Claude Agent SDK through the Responses API. Use Claude Code with `previous_response_id` chaining for multi-turn conversations.
+FastAPI gateway that exposes coding agent backends (Claude Agent SDK, OpenCode) through a single OpenAI Responses-compatible API. Supports `previous_response_id` chaining for multi-turn conversations, MCP server integration, per-user workspace isolation, and a built-in admin dashboard.
+
+> Previously published as **Claude Code Gateway**. The repository was renamed because the gateway now fronts multiple agent backends, not just Claude.
 
 ## Quick Start
 
 ```bash
-git clone https://github.com/JinY0ung-Shin/claude-code-gateway
-cd claude-code-gateway
+git clone https://github.com/JinY0ung-Shin/oh-my-gateway
+cd oh-my-gateway
 uv sync
 
 export ANTHROPIC_AUTH_TOKEN=your-api-key
@@ -28,9 +30,10 @@ curl http://localhost:8000/v1/responses \
 ## Features
 
 - **Responses API** — `/v1/responses` with `previous_response_id` chaining
+- **Multiple Backends** — Claude (Agent SDK) and OpenCode in one gateway, selected by model id (`sonnet`, `opus`, `haiku`, or `opencode/<provider>/<model>`)
 - **Session Management** — Multi-turn conversations via `session_id`
 - **Auth Support** — API key or CLI auth
-- **MCP Server Integration** — Connect external tool servers at startup
+- **MCP Server Integration** — Connect external tool servers at startup; shared between Claude and OpenCode
 - **Subagent Control** — Block specific subagent types per deployment
 - **Adaptive Thinking** — Configurable thinking modes and budget
 - **Token-Level Streaming** — Real-time token delivery via SDK partial messages
@@ -42,8 +45,8 @@ curl http://localhost:8000/v1/responses \
 **Prerequisites:** Python 3.10+ and [uv](https://docs.astral.sh/uv/)
 
 ```bash
-git clone https://github.com/JinY0ung-Shin/claude-code-gateway
-cd claude-code-gateway
+git clone https://github.com/JinY0ung-Shin/oh-my-gateway
+cd oh-my-gateway
 uv sync
 cp .env.example .env
 ```
@@ -73,8 +76,9 @@ Key environment variables (see `.env.example` for full list):
 | `MAX_TIMEOUT` | `600000` | Request timeout (ms) |
 | `DEFAULT_MAX_TURNS` | `10` | Max agent turns per request |
 | `BACKENDS` | `claude` | Backend allowlist, for example `claude,opencode` |
+| `OPENCODE_BASE_URL` | _(unset)_ | When set, switches OpenCode to external mode (skip subprocess, point at this URL) |
 | `OPENCODE_MODELS` | _(unset)_ | Comma-separated OpenCode `provider/model` IDs exposed as `opencode/...` |
-| `OPENCODE_USE_WRAPPER_MCP_CONFIG` | `false` | Copy validated wrapper `MCP_CONFIG` into OpenCode config |
+| `OPENCODE_USE_WRAPPER_MCP_CONFIG` | `false` | Copy validated wrapper `MCP_CONFIG` into OpenCode config (managed mode only) |
 | `DISALLOWED_SUBAGENT_TYPES` | `statusline-setup` | Comma-separated subagent types to block |
 | `CLAUDE_SANDBOX_ENABLED` | unset | Bash sandbox: unset = project settings, `true` = force on, `false` = force off |
 | `MCP_CONFIG` | — | MCP server config (JSON string or file path) |
@@ -90,13 +94,35 @@ export BACKENDS=claude,opencode
 export OPENCODE_MODELS=openai/gpt-5.5
 ```
 
+OpenCode runs in one of two modes:
+
+#### Managed mode (default)
+
 The gateway starts `opencode serve` automatically and requires the `opencode` binary on `PATH`. The Docker image installs OpenCode during build. OpenCode's `question` tool is exposed by default with `OPENCODE_QUESTION_PERMISSION=ask`; set it to `deny` to hide the tool.
 
 Set `OPENCODE_USE_WRAPPER_MCP_CONFIG=true` to copy the validated wrapper `MCP_CONFIG` into the generated OpenCode config. The wrapper converts `stdio` servers to OpenCode `local` MCP entries and `http`, `sse`, or `streamable-http` servers to OpenCode `remote` entries.
 
 When `OPENCODE_CONFIG_CONTENT` is set, the wrapper parses it as JSON, preserves explicit values, fills missing safe defaults, and then serializes the generated config passed to `opencode serve`.
 
-Additional OpenCode options such as `OPENCODE_BIN`, `OPENCODE_HOST`, `OPENCODE_PORT`, `OPENCODE_AGENT`, `OPENCODE_DEFAULT_MODEL`, `OPENCODE_QUESTION_PERMISSION`, `OPENCODE_USE_WRAPPER_MCP_CONFIG`, and server authentication variables are documented in `.env.example`.
+#### External mode
+
+Set `OPENCODE_BASE_URL` to point at an externally-managed `opencode serve` instance. Use this when OpenCode must run on a trusted host with broader filesystem access while the gateway itself is sandboxed (or when several gateway replicas share a single OpenCode server).
+
+```bash
+export OPENCODE_BASE_URL=http://opencode-host:7891
+export OPENCODE_SERVER_USERNAME=opencode
+export OPENCODE_SERVER_PASSWORD=...
+```
+
+In external mode the gateway does **not** start a subprocess and does **not** generate a config. The external server owns its own MCP and provider definitions, so the following variables become **no-ops**:
+
+- `OPENCODE_CONFIG_CONTENT`
+- `OPENCODE_USE_WRAPPER_MCP_CONFIG`
+- `OPENCODE_BIN`, `OPENCODE_HOST`, `OPENCODE_PORT`, `OPENCODE_START_TIMEOUT_MS`
+
+Request-time options (`OPENCODE_AGENT`, `OPENCODE_DEFAULT_MODEL`, `OPENCODE_QUESTION_PERMISSION`, `OPENCODE_MODELS`) and basic-auth credentials still apply. Verify the active mode with `GET /admin/api/backends` — the `opencode.config.mode` field reports `managed` or `external`.
+
+Additional OpenCode options such as `OPENCODE_BIN`, `OPENCODE_HOST`, `OPENCODE_PORT`, `OPENCODE_AGENT`, `OPENCODE_DEFAULT_MODEL`, `OPENCODE_QUESTION_PERMISSION`, `OPENCODE_USE_WRAPPER_MCP_CONFIG`, and server authentication variables are documented in `.env.example`. See **[docs/opencode-litellm.md](docs/opencode-litellm.md)** for a full LiteLLM + OpenCode setup walkthrough including MCP server configuration.
 
 ### Bash Sandbox
 
@@ -222,7 +248,7 @@ The gateway includes a built-in admin dashboard at `/admin` (requires `ADMIN_API
 |--------|----------|-------------|
 | `GET` | `/admin/api/summary` | Dashboard summary (models, sessions, backends) |
 | `GET` | `/admin/api/server-info` | Server version and runtime info |
-| `GET` | `/admin/api/backends` | Backend health, auth status, model availability |
+| `GET` | `/admin/api/backends` | Backend health, auth status, model availability (reports `mode: managed` or `mode: external` for OpenCode) |
 | `GET` | `/admin/api/mcp-servers` | MCP server config and tool patterns |
 | `GET` | `/admin/api/tools` | Tool registry per backend and MCP patterns |
 | `GET` | `/admin/api/sandbox` | Sandbox and permission mode config |
@@ -304,44 +330,52 @@ The `/v1/responses` endpoint intentionally deviates from the OpenAI Responses AP
 ## Docker
 
 ```bash
-docker build -t claude-code-gateway .
+docker build -t oh-my-gateway .
 
 # With a private PyPI mirror
 docker build \
   --build-arg PIP_INDEX_URL=https://pypi.example.com/simple \
-  -t claude-code-gateway .
+  -t oh-my-gateway .
 
 # Pin or override the OpenCode version
 docker build \
   --build-arg OPENCODE_VERSION=1.14.29 \
-  -t claude-code-gateway .
+  -t oh-my-gateway .
 
 # With API key auth
 docker run -d -p 8000:8000 \
   -e ANTHROPIC_AUTH_TOKEN=your-key \
-  claude-code-gateway
+  oh-my-gateway
 
 # With CLI auth
 docker run -d -p 8000:8000 \
   -v ~/.claude:/root/.claude \
-  claude-code-gateway
+  oh-my-gateway
 
 # With workspace
 docker run -d -p 8000:8000 \
   -e ANTHROPIC_AUTH_TOKEN=your-key \
   -v /path/to/project:/workspace \
   -e CLAUDE_CWD=/workspace \
-  claude-code-gateway
+  oh-my-gateway
 
-# With OpenCode enabled
+# With OpenCode in managed mode (gateway spawns `opencode serve`)
 docker run -d -p 8000:8000 \
   -e BACKENDS=claude,opencode \
   -e OPENCODE_MODELS=openai/gpt-5.5 \
   -e OPENAI_API_KEY=your-key \
-  claude-code-gateway
+  oh-my-gateway
+
+# With OpenCode in external mode (gateway is sandboxed; OpenCode runs on a trusted host)
+docker run -d -p 8000:8000 \
+  -e BACKENDS=claude,opencode \
+  -e OPENCODE_BASE_URL=http://opencode-host:7891 \
+  -e OPENCODE_SERVER_PASSWORD=... \
+  -e OPENCODE_MODELS=openai/gpt-5.5 \
+  oh-my-gateway
 ```
 
-Or with docker-compose: set `BACKENDS=claude,opencode`, `OPENCODE_MODELS`, and provider keys in `.env`, then run `docker compose up -d`. The image includes OpenCode and the gateway starts it automatically.
+Or with docker-compose: set `BACKENDS=claude,opencode`, `OPENCODE_MODELS`, and provider keys (or `OPENCODE_BASE_URL` for external mode) in `.env`, then run `docker compose up -d`. The image includes OpenCode and the gateway starts it automatically when running in managed mode.
 
 ## Development
 
@@ -357,13 +391,13 @@ uv run ruff check --fix . && uv run ruff format .   # Lint & format
 
 You must use your own Claude access (API key or CLI auth) to use this gateway.
 
-This project is a gateway layer on top of the official Claude Agent SDK. It does not pool credentials, resell access, or bypass Anthropic authentication.
+This project is a gateway layer on top of the official Claude Agent SDK and OpenCode. It does not pool credentials, resell access, or bypass upstream authentication.
 
-- [Usage Policy](https://www.anthropic.com/legal/aup)
-- [Consumer Terms](https://www.anthropic.com/legal/consumer-terms)
-- [Commercial Terms](https://www.anthropic.com/legal/commercial-terms)
+- [Anthropic Usage Policy](https://www.anthropic.com/legal/aup)
+- [Anthropic Consumer Terms](https://www.anthropic.com/legal/consumer-terms)
+- [Anthropic Commercial Terms](https://www.anthropic.com/legal/commercial-terms)
 
-This is an independent open-source project, not affiliated with or endorsed by Anthropic.
+This is an independent open-source project, not affiliated with or endorsed by Anthropic or the OpenCode authors.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ curl http://localhost:8000/v1/responses \
 | OpenCode backend overview + when to use which mode | [docs/opencode/](docs/opencode/) |
 | OpenCode managed mode (gateway spawns `opencode serve`) | [docs/opencode/managed.md](docs/opencode/managed.md) |
 | OpenCode external mode (point at an existing `opencode serve`) | [docs/opencode/external.md](docs/opencode/external.md) |
+| OpenCode + LiteLLM recipes (reasoning content, multi-provider routing) | [docs/opencode/litellm.md](docs/opencode/litellm.md) |
 | SSE streaming event reference | [docs/streaming-events.md](docs/streaming-events.md) |
 | System prompt presets | [docs/](docs/) — `claude-code-system-prompt-reference.md`, `compact-system-prompt.md`, `minimal-system-prompt.md` |
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ curl http://localhost:8000/v1/responses \
   -d '{"model": "sonnet", "input": "Hello"}'
 ```
 
+## Documentation
+
+| Topic | Doc |
+|-------|-----|
+| Claude Code backend (auth, workspaces, sandbox, thinking, MCP, subagents) | [docs/claude-code/](docs/claude-code/) |
+| OpenCode backend overview + when to use which mode | [docs/opencode/](docs/opencode/) |
+| OpenCode managed mode (gateway spawns `opencode serve`) | [docs/opencode/managed.md](docs/opencode/managed.md) |
+| OpenCode external mode (point at an existing `opencode serve`) | [docs/opencode/external.md](docs/opencode/external.md) |
+| SSE streaming event reference | [docs/streaming-events.md](docs/streaming-events.md) |
+| System prompt presets | [docs/](docs/) — `claude-code-system-prompt-reference.md`, `compact-system-prompt.md`, `minimal-system-prompt.md` |
+
 ## Features
 
 - **Responses API** — `/v1/responses` with `previous_response_id` chaining
@@ -122,7 +133,7 @@ In external mode the gateway does **not** start a subprocess and does **not** ge
 
 Request-time options (`OPENCODE_AGENT`, `OPENCODE_DEFAULT_MODEL`, `OPENCODE_QUESTION_PERMISSION`, `OPENCODE_MODELS`) and basic-auth credentials still apply. Verify the active mode with `GET /admin/api/backends` — the `opencode.config.mode` field reports `managed` or `external`.
 
-Additional OpenCode options such as `OPENCODE_BIN`, `OPENCODE_HOST`, `OPENCODE_PORT`, `OPENCODE_AGENT`, `OPENCODE_DEFAULT_MODEL`, `OPENCODE_QUESTION_PERMISSION`, `OPENCODE_USE_WRAPPER_MCP_CONFIG`, and server authentication variables are documented in `.env.example`. See **[docs/opencode-litellm.md](docs/opencode-litellm.md)** for a full LiteLLM + OpenCode setup walkthrough including MCP server configuration.
+Full setup walkthroughs (LiteLLM provider, MCP servers, docker-compose, troubleshooting) live under **[docs/opencode/](docs/opencode/)** — see [managed.md](docs/opencode/managed.md) and [external.md](docs/opencode/external.md). The Claude backend has its own detailed guide at **[docs/claude-code/](docs/claude-code/)**.
 
 ### Bash Sandbox
 

--- a/docs/claude-code/README.md
+++ b/docs/claude-code/README.md
@@ -1,0 +1,282 @@
+# Claude Code Backend
+
+The Claude Code backend wraps Anthropic's [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk-python) and exposes it through the gateway's `/v1/responses` endpoint. This is the **default** backend — sessions for `sonnet`, `opus`, or `haiku` model ids route here automatically.
+
+## Quick Start
+
+```bash
+export ANTHROPIC_AUTH_TOKEN=sk-ant-...
+uv run uvicorn src.main:app --reload --port 8000
+```
+
+```bash
+curl http://localhost:8000/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{"model": "sonnet", "input": "Hello"}'
+```
+
+Multi-turn:
+
+```bash
+# First turn
+RESP=$(curl -s http://localhost:8000/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{"model":"sonnet","input":"My name is Alice"}')
+RESP_ID=$(echo "$RESP" | jq -r .id)
+
+# Continue
+curl http://localhost:8000/v1/responses \
+  -H "Content-Type: application/json" \
+  -d "{\"model\":\"sonnet\",\"input\":\"What is my name?\",\"previous_response_id\":\"$RESP_ID\"}"
+```
+
+## Authentication
+
+| Method | Setup | When to use |
+|--------|-------|-------------|
+| **API key** | `export ANTHROPIC_AUTH_TOKEN=sk-ant-...` | Production, CI, headless |
+| **CLI auth** | `claude auth login` then mount `~/.claude` | Local dev, sharing your subscription |
+
+Override which is used (auto-detection by default):
+
+```bash
+CLAUDE_AUTH_METHOD=api_key   # or cli
+```
+
+For corporate proxies or alternate Anthropic endpoints:
+
+```bash
+ANTHROPIC_BASE_URL=https://your-proxy.example.com
+ANTHROPIC_DEFAULT_OPUS_MODEL=claude-opus-4-7
+ANTHROPIC_DEFAULT_SONNET_MODEL=claude-sonnet-4-6
+ANTHROPIC_DEFAULT_HAIKU_MODEL=claude-haiku-4-5-20251001
+```
+
+Verify:
+
+```bash
+curl http://localhost:8000/v1/auth/status
+```
+
+## Working Directory
+
+Claude operates inside a working directory. Configure it once globally, or per-user.
+
+### Single global workspace
+
+```bash
+CLAUDE_CWD=./working_dir
+```
+
+If unset, the gateway creates a fresh temp directory per session and cleans it up on expiry.
+
+### Per-user workspace isolation
+
+Each `/v1/responses` request can include a `user` field. The gateway routes that user's requests to a permanent directory under `USER_WORKSPACES_DIR`:
+
+```bash
+USER_WORKSPACES_DIR=/data/workspaces
+```
+
+```bash
+curl http://localhost:8000/v1/responses \
+  -d '{"model":"sonnet","input":"Create a Python script","user":"alice"}'
+```
+
+- `user` specified → workspace at `/data/workspaces/alice/`, survives restarts
+- `user` omitted → temp workspace per session, cleaned on TTL expiry
+- New sessions copy `.claude/` config from `CLAUDE_CWD` into the user workspace
+- User identifiers must match `^[a-zA-Z0-9][a-zA-Z0-9._-]{0,62}$`
+
+`USER_WORKSPACES_DIR` falls back to `CLAUDE_CWD` when unset; if both are unset, temp dirs are used.
+
+## Thinking Mode
+
+Claude can show internal reasoning ("thinking") before producing a final answer. Three modes:
+
+| Mode | Behavior |
+|------|----------|
+| `adaptive` (default) | SDK decides per-request whether to allocate budget |
+| `enabled` | Always thinking with fixed `THINKING_BUDGET_TOKENS` |
+| `disabled` | No thinking blocks emitted |
+
+```bash
+THINKING_MODE=adaptive
+THINKING_BUDGET_TOKENS=10000   # only used in 'enabled' mode
+```
+
+The gateway forwards thinking blocks via streaming events as a separate part type (see [streaming-events.md](../streaming-events.md)). Most clients render them as a collapsed "thought" UI.
+
+## Bash Sandbox (OS-level isolation)
+
+The Claude Agent SDK's `SandboxSettings` can isolate Bash tool execution using macOS Seatbelt or Linux bubblewrap.
+
+```bash
+CLAUDE_SANDBOX_ENABLED=true              # tri-state: unset / true / false
+CLAUDE_SANDBOX_AUTO_ALLOW_BASH=true      # auto-approve bash when sandboxed
+CLAUDE_SANDBOX_EXCLUDED_COMMANDS=        # comma-separated bypass list
+CLAUDE_SANDBOX_ALLOW_UNSANDBOXED=false   # let model request unsandboxed via dangerouslyDisableSandbox
+CLAUDE_SANDBOX_NETWORK_ALLOW_LOCAL=false # allow local-port binds inside sandbox
+CLAUDE_SANDBOX_WEAKER_NESTED=false       # for unprivileged Linux containers
+```
+
+Tri-state semantics:
+
+- **unset** — gateway does not configure sandbox; respects `.claude/settings.json`
+- **`true`** — forces sandbox on with strict defaults
+- **`false`** — forces sandbox off, overriding project settings
+
+> Sandbox isolates Bash commands only. File tool access (Read/Edit/Write) is governed by SDK permission rules, not the sandbox. Linux/macOS only — not Windows.
+
+## Custom System Prompt
+
+By default the gateway uses the bundled `claude_code` preset. To override:
+
+```bash
+SYSTEM_PROMPT_FILE=docs/claude-code-system-prompt-reference.md
+```
+
+The file may contain `{{PLACEHOLDER}}` tokens; some are auto-resolved per request:
+
+| Placeholder | Resolved from |
+|-------------|---------------|
+| `{{WORKING_DIRECTORY}}` | per-request workspace cwd |
+| `{{MEMORY_PATH}}` | `<cwd>/.memory` (auto-created) |
+| `{{PLATFORM}}` | `sys.platform` |
+| `{{SHELL}}` | `$SHELL` |
+| `{{OS_VERSION}}` | `platform.platform()` |
+| `{{PROMPT_LANGUAGE}}` | `PROMPT_LANGUAGE` env var |
+
+You can also manage prompts at runtime via the admin UI (`/admin`).
+
+Three reference prompts ship with the repo:
+
+- `docs/claude-code-system-prompt-reference.md` — the full Claude Code prompt
+- `docs/compact-system-prompt.md` — leaner variant for less verbose models
+- `docs/minimal-system-prompt.md` — bare-bones for narrow agent tasks
+
+## Subagent Control
+
+Claude exposes built-in subagent types (`general-purpose`, `Explore`, `Plan`, `statusline-setup`). To block specific ones per deployment:
+
+```bash
+DISALLOWED_SUBAGENT_TYPES=statusline-setup,general-purpose
+```
+
+When the model invokes a blocked subagent, the SDK returns an error to the model and the parent agent continues.
+
+Streaming visibility for subagent output:
+
+```bash
+SUBAGENT_STREAM_TEXT=false           # default: only final summary, not interim deltas
+SUBAGENT_STREAM_TOOL_BLOCKS=true     # default: forward tool_use/tool_result blocks
+SUBAGENT_STREAM_PROGRESS=true        # default: forward task_started/progress events
+```
+
+## MCP Server Integration
+
+The gateway forwards configured MCP servers to Claude. Configure once with the wrapper's shared `MCP_CONFIG`:
+
+```bash
+MCP_CONFIG=/path/to/mcp-config.json
+# or inline JSON
+MCP_CONFIG='{"mcpServers":{"fs":{"type":"stdio","command":"npx","args":["-y","@modelcontextprotocol/server-filesystem","/workspace"]}}}'
+```
+
+Supported transports: `stdio`, `sse`, `http`, `streamable-http`. The same config can also be forwarded to OpenCode via `OPENCODE_USE_WRAPPER_MCP_CONFIG=true` — see [opencode/managed.md](../opencode/managed.md#mcp-servers).
+
+Verify what the gateway loaded:
+
+```bash
+curl http://localhost:8000/v1/mcp/servers
+```
+
+## Task Budget
+
+Cap the total tokens a single agent run can spend on tool use:
+
+```bash
+TASK_BUDGET=100000
+```
+
+Per-request `task_budget` in the API body overrides the global default. The model paces tool use and wraps up before exceeding the limit.
+
+## Sessions and Multi-turn
+
+The gateway tracks sessions internally so `previous_response_id` chains work across multiple turns:
+
+```bash
+SESSION_MAX_AGE_MINUTES=60
+SESSION_CLEANUP_INTERVAL_MINUTES=5
+```
+
+Quirks worth knowing:
+
+- `instructions` + `previous_response_id` together → **400** (system prompt cannot change mid-session)
+- Stale `previous_response_id` → **409** with the latest valid id in the body, e.g.:
+  ```
+  Stale previous_response_id: only the latest response (resp_<uuid>_<turn>) can be continued
+  ```
+  Clients should retry with that id.
+- Mixing backends (Claude → OpenCode) within one session → **400**
+
+## Streaming
+
+Set `"stream": true` for SSE delivery:
+
+```bash
+curl -N http://localhost:8000/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{"model":"sonnet","input":"Hello","stream":true}'
+```
+
+For full event reference (tool calls, subagent events, thinking blocks, etc.) see [streaming-events.md](../streaming-events.md).
+
+## Examples
+
+End-to-end examples live in `examples/`:
+
+- `examples/curl_example.sh` — basic + streaming + chaining
+- `examples/openai_sdk.py` — using the OpenAI Python SDK against the gateway
+- `examples/streaming.py` — streaming SSE in Python
+- `examples/session_continuity.py` — multi-turn with `previous_response_id`
+
+## Configuration Reference
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ANTHROPIC_AUTH_TOKEN` | — | API key auth |
+| `ANTHROPIC_BASE_URL` | `https://api.anthropic.com` | Override Anthropic endpoint |
+| `CLAUDE_AUTH_METHOD` | auto | `cli` or `api_key` |
+| `DEFAULT_MODEL` | `sonnet` | Used when request omits `model` |
+| `CLAUDE_CWD` | temp dir | Global working directory |
+| `USER_WORKSPACES_DIR` | `CLAUDE_CWD` | Per-user workspace base |
+| `THINKING_MODE` | `adaptive` | `adaptive` / `enabled` / `disabled` |
+| `THINKING_BUDGET_TOKENS` | `10000` | Budget for `enabled` mode |
+| `TASK_BUDGET` | unset | Global tool-use token budget |
+| `DEFAULT_MAX_TURNS` | `10` | Max agent turns per request |
+| `TOKEN_STREAMING` | `true` | Per-token vs per-message streaming |
+| `MAX_TIMEOUT` | `600000` | Request timeout (ms) |
+| `CLAUDE_SANDBOX_ENABLED` | unset | Tri-state Bash sandbox |
+| `SYSTEM_PROMPT_FILE` | unset | Custom system prompt path |
+| `DISALLOWED_SUBAGENT_TYPES` | `statusline-setup` | Blocked subagent types |
+| `MCP_CONFIG` | — | MCP server config (shared with OpenCode optionally) |
+
+See `.env.example` for the full list.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|--------------|
+| `401` from Anthropic | `ANTHROPIC_AUTH_TOKEN` missing or invalid; check `/v1/auth/status` |
+| `409 Stale previous_response_id` | Concurrent writer advanced the session; retry with the id from the error body |
+| Sandbox errors on Linux | bubblewrap not installed, or unprivileged container without `CLAUDE_SANDBOX_WEAKER_NESTED=true` |
+| MCP tools missing | check `/v1/mcp/servers` and gateway logs for `[mcp]` load errors |
+| Model produces empty answer | look for blocked subagent or task budget exhaustion in admin logs |
+
+Useful checks:
+
+- `GET /admin/api/backends` — backend health, auth method, model availability
+- `GET /admin/api/mcp-servers` — MCP server load status per backend
+- `GET /admin/api/logs` — request log with filtering
+- `GET /admin/api/config` — redacted runtime env (verify variables made it in)

--- a/docs/opencode/README.md
+++ b/docs/opencode/README.md
@@ -1,0 +1,156 @@
+# OpenCode Backend
+
+[OpenCode](https://opencode.ai) is a coding-agent runtime similar to Claude Code, but it can talk to any provider behind an OpenAI-compatible API (LiteLLM, vLLM, OpenAI, Anthropic, Bedrock, etc.). This gateway treats OpenCode as a second backend, sitting alongside Claude.
+
+## When to use OpenCode vs Claude
+
+| | Claude backend | OpenCode backend |
+|---|----------------|------------------|
+| **Routing** | `model: "sonnet" / "opus" / "haiku"` | `model: "opencode/<provider>/<model>"` |
+| **Auth** | Anthropic API key or `claude auth login` | Provider-specific keys (passed through OpenCode) |
+| **Provider variety** | Anthropic only | Any OpenAI-compatible endpoint |
+| **MCP tools** | Native | Native (per OpenCode); wrapper `MCP_CONFIG` can be forwarded |
+| **Reasoning models** | First-class via SDK | Works through any reasoning model on the provider side (e.g. via LiteLLM `merge_reasoning_content_in_choices: true`) |
+| **Best for** | Anthropic Claude usage | Multi-provider routing, on-prem models, vendor isolation |
+
+You can have **both backends enabled at once** — `BACKENDS=claude,opencode`. Each request is routed by its `model` id.
+
+## Two operating modes
+
+OpenCode runs in one of two modes. Pick based on **where the agent process needs to live**:
+
+|  | **Managed** (default) | **External** |
+|---|----------------------|---------------|
+| Where OpenCode runs | Subprocess inside the gateway container | Separate process / host |
+| Who owns the config | Gateway (built from `OPENCODE_CONFIG_CONTENT` + wrapper `MCP_CONFIG`) | The external server itself |
+| Filesystem access | Whatever the gateway container can see | Whatever the external host can see |
+| Setup complexity | Low | Medium |
+| Use when… | Single deployment, gateway container is the trust boundary | Gateway is sandboxed but OpenCode needs broader filesystem access; or several gateway replicas share one OpenCode |
+
+**Switch is automatic, controlled by `OPENCODE_BASE_URL`:**
+
+- Unset → managed mode
+- Set → external mode (gateway forwards to that URL)
+
+Detailed setup:
+
+- **[managed.md](managed.md)** — managed-mode setup with LiteLLM provider and MCP server walkthrough
+- **[external.md](external.md)** — external-mode setup, security model, and what's a no-op
+
+## Quick start (managed mode)
+
+```bash
+# .env
+BACKENDS=claude,opencode
+LITELLM_API_KEY=sk-1234
+OPENCODE_CONFIG_CONTENT={"provider":{"litellm":{"npm":"@ai-sdk/openai-compatible","name":"LiteLLM","options":{"baseURL":"http://litellm:4000/v1","apiKey":"{env:LITELLM_API_KEY}"},"models":{"claude-sonnet-4-5":{},"gpt-4o":{}}}}}
+OPENCODE_MODELS=litellm/claude-sonnet-4-5,litellm/gpt-4o
+OPENCODE_DEFAULT_MODEL=litellm/claude-sonnet-4-5
+```
+
+```bash
+curl http://localhost:8000/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{"model":"opencode/litellm/claude-sonnet-4-5","input":"Hello"}'
+```
+
+Full walkthrough: [managed.md](managed.md).
+
+## Quick start (external mode)
+
+You already have `opencode serve` running on a trusted host:
+
+```bash
+# .env
+BACKENDS=claude,opencode
+OPENCODE_BASE_URL=http://opencode-host:7891
+OPENCODE_SERVER_USERNAME=opencode
+OPENCODE_SERVER_PASSWORD=...
+OPENCODE_MODELS=litellm/claude-sonnet-4-5
+```
+
+```bash
+curl http://localhost:8000/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{"model":"opencode/litellm/claude-sonnet-4-5","input":"Hello"}'
+```
+
+Full walkthrough: [external.md](external.md).
+
+## Model id format
+
+The gateway recognises any `model` field starting with `opencode/`:
+
+```
+opencode/<provider>/<model>
+        ^^^^^^^^^^^^^^^^^^^
+        passed verbatim to OpenCode
+```
+
+`<provider>` matches a key under `provider` in OpenCode's config (managed mode: `OPENCODE_CONFIG_CONTENT`; external mode: whatever config the external server loads). `<model>` matches a key under that provider's `models` block.
+
+The gateway's **`OPENCODE_MODELS` env var is an allowlist** that controls which `opencode/<provider>/<model>` ids `/v1/models` returns and which the `/v1/responses` endpoint accepts. Anything not in the list is rejected at the wrapper layer, even if the underlying OpenCode server would happily run it.
+
+```bash
+OPENCODE_MODELS=litellm/claude-sonnet-4-5,litellm/gpt-4o,openai/gpt-5.5
+```
+
+Wire-format example (what the request body sends):
+
+```json
+{ "model": "opencode/litellm/claude-sonnet-4-5", "input": "..." }
+```
+
+## Settings that apply in both modes
+
+These work regardless of mode:
+
+| Variable | Description |
+|----------|-------------|
+| `OPENCODE_MODELS` | Public allowlist exposed via `/v1/models` |
+| `OPENCODE_DEFAULT_MODEL` | Used when an `opencode/...` request omits the provider|
+| `OPENCODE_AGENT` | OpenCode agent profile (`general` by default) |
+| `OPENCODE_QUESTION_PERMISSION` | `ask` / `allow` / `deny` for OpenCode's `question` tool |
+| `OPENCODE_SERVER_USERNAME` | Basic-auth username (default `opencode`) |
+| `OPENCODE_SERVER_PASSWORD` | Basic-auth password; absent = no auth header sent |
+
+## Settings that apply in managed mode only
+
+These are silently ignored in external mode:
+
+| Variable | Description |
+|----------|-------------|
+| `OPENCODE_BIN` | Binary path (default `opencode`) |
+| `OPENCODE_HOST`, `OPENCODE_PORT` | Bind address for the spawned subprocess |
+| `OPENCODE_START_TIMEOUT_MS` | Startup wait timeout (default 5000) |
+| `OPENCODE_CONFIG_CONTENT` | Provider/MCP config injected into the subprocess |
+| `OPENCODE_USE_WRAPPER_MCP_CONFIG` | Forward wrapper `MCP_CONFIG` to OpenCode |
+
+## Switching modes
+
+To move from managed → external:
+
+1. Stand up `opencode serve` on the target host with the same config you previously fed to the gateway via `OPENCODE_CONFIG_CONTENT`.
+2. Set `OPENCODE_BASE_URL` (and basic-auth env vars if applicable) on the gateway.
+3. Restart the gateway. Verify `GET /admin/api/backends` shows `opencode.config.mode = external`.
+4. Optional: clear `OPENCODE_CONFIG_CONTENT` and `OPENCODE_USE_WRAPPER_MCP_CONFIG` from the gateway env. They're no-ops in external mode but removing them avoids confusion.
+
+External → managed is the reverse: unset `OPENCODE_BASE_URL`, restore the config envs, restart.
+
+## Verification
+
+```bash
+# Mode + base url
+curl -s http://localhost:8000/admin/api/backends | jq '.opencode.config'
+# {"mode": "managed", "binary": "/usr/local/bin/opencode"} OR
+# {"mode": "external", "base_url": "http://opencode-host:7891"}
+
+# Models actually exposed
+curl -s http://localhost:8000/v1/models | jq '.data[].id'
+
+# End-to-end smoke test
+curl -N http://localhost:8000/v1/responses \
+  -d '{"model":"opencode/litellm/claude-sonnet-4-5","input":"ping","stream":true}'
+```
+
+For mode-specific troubleshooting see [managed.md](managed.md#troubleshooting) and [external.md](external.md#troubleshooting).

--- a/docs/opencode/README.md
+++ b/docs/opencode/README.md
@@ -36,6 +36,7 @@ Detailed setup:
 
 - **[managed.md](managed.md)** — managed-mode setup with LiteLLM provider and MCP server walkthrough
 - **[external.md](external.md)** — external-mode setup, security model, and what's a no-op
+- **[litellm.md](litellm.md)** — LiteLLM-specific recipes (reasoning_content rendering, virtual keys, upstream patterns)
 
 ## Quick start (managed mode)
 

--- a/docs/opencode/external.md
+++ b/docs/opencode/external.md
@@ -1,0 +1,210 @@
+# OpenCode — External Mode
+
+In external mode the gateway does **not** start `opencode serve` itself. Instead, it forwards HTTP traffic to an externally-managed OpenCode server. The external server owns its own provider config and MCP servers — the gateway is purely a proxy + router + auth layer.
+
+```
+┌─────────────────────────┐         ┌──────────────────────────┐
+│ gateway container       │         │ trusted host             │
+│ (sandboxed,             │         │ (broader fs access,      │
+│  limited fs access)     │ ──HTTP─►│  shared across replicas, │
+│                         │  basic  │  …)                      │
+│   FastAPI on 8000       │  auth   │                          │
+│                         │         │   opencode serve         │
+│                         │         │   on 7891                │
+└─────────────────────────┘         └──────────────────────────┘
+```
+
+## When to use
+
+- **Sandbox/trust split** — the gateway runs in a locked-down container, but OpenCode needs broader filesystem access (e.g. read/write across a developer workspace mounted on a host)
+- **Shared OpenCode** — multiple gateway replicas talk to one OpenCode instance
+- **Independent debugging / lifecycle** — restart OpenCode without restarting the gateway, or vice versa
+- **Existing OpenCode deployment** — you already operate `opencode serve` and just want to front it with the gateway's session/auth/responses-API surface
+
+If none of these apply, prefer [managed mode](managed.md). It has fewer moving parts.
+
+## Architectural trade-offs
+
+### What the external server owns
+
+When you go external, the external server reads its **own** config file at startup. The gateway has no way to inject config into a process it didn't spawn. Practically:
+
+| Setting | Source in external mode |
+|---------|-------------------------|
+| Providers (`provider.*`) | The external server's own config file |
+| MCP servers (`mcp.*`) | The external server's own config file |
+| Model definitions (`provider.*.models`) | The external server's own config file |
+| Auth (basic-auth realm, etc.) | However the external server / its reverse proxy is set up |
+
+So the following **gateway-side env vars become no-ops**:
+
+- `OPENCODE_CONFIG_CONTENT`
+- `OPENCODE_USE_WRAPPER_MCP_CONFIG`
+- `OPENCODE_BIN`, `OPENCODE_HOST`, `OPENCODE_PORT`, `OPENCODE_START_TIMEOUT_MS`
+
+### What still applies in external mode
+
+These flow through the gateway at request time and still take effect:
+
+- `OPENCODE_MODELS` — public allowlist (`/v1/models`, `/v1/responses` accept gate)
+- `OPENCODE_DEFAULT_MODEL` — used when request omits provider/model
+- `OPENCODE_AGENT` — agent profile passed in each prompt
+- `OPENCODE_QUESTION_PERMISSION` — passed in session creation
+- `OPENCODE_SERVER_USERNAME`, `OPENCODE_SERVER_PASSWORD` — basic-auth credentials sent with every request
+- `OPENCODE_BASE_URL` — the URL itself, obviously
+
+## Step 1 — bring up the external OpenCode server
+
+Set up `opencode serve` on the trusted host with:
+
+1. The provider config you want (LiteLLM, OpenAI, etc.) baked into its config file (e.g. `~/.config/opencode/opencode.json` or wherever your install reads from)
+2. Whatever MCP servers you want OpenCode to expose
+3. Basic auth (recommended — anyone who can reach the URL gets full agent access otherwise)
+
+Example `~/.config/opencode/opencode.json`:
+
+```json
+{
+  "provider": {
+    "litellm": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "LiteLLM",
+      "options": {
+        "baseURL": "http://litellm:4000/v1",
+        "apiKey": "{env:LITELLM_API_KEY}"
+      },
+      "models": {
+        "claude-sonnet-4-5": {},
+        "gpt-4o": {}
+      }
+    }
+  },
+  "mcp": {
+    "filesystem": {
+      "type": "local",
+      "command": ["npx", "-y", "@modelcontextprotocol/server-filesystem", "/home/agent/workspace"]
+    }
+  }
+}
+```
+
+Start it:
+
+```bash
+export LITELLM_API_KEY=sk-1234
+export OPENCODE_SERVER_USERNAME=opencode
+export OPENCODE_SERVER_PASSWORD=...
+opencode serve --hostname 0.0.0.0 --port 7891
+```
+
+> **Auth note:** the basic-auth `WWW-Authenticate` realm (`Secure Area` is the default if you see it in browser challenges) usually comes from a built-in middleware or a reverse proxy you set up. Make sure the username/password actually configured there match what you give the gateway in step 2 — mismatch is by far the most common 401 source.
+
+Verify the server is reachable from the gateway's network:
+
+```bash
+# from the gateway host (or container)
+curl -u $OPENCODE_SERVER_USERNAME:$OPENCODE_SERVER_PASSWORD \
+     http://opencode-host:7891/global/health
+# {"healthy": true}
+```
+
+## Step 2 — point the gateway at it
+
+```bash
+# .env
+BACKENDS=claude,opencode
+OPENCODE_BASE_URL=http://opencode-host:7891
+OPENCODE_SERVER_USERNAME=opencode
+OPENCODE_SERVER_PASSWORD=...   # must match the server side
+OPENCODE_MODELS=litellm/claude-sonnet-4-5,litellm/gpt-4o
+OPENCODE_DEFAULT_MODEL=litellm/claude-sonnet-4-5
+```
+
+Restart the gateway. Verify the mode:
+
+```bash
+curl -s http://localhost:8000/admin/api/backends | jq '.opencode.config'
+```
+
+```json
+{"mode": "external", "base_url": "http://opencode-host:7891"}
+```
+
+## Step 3 — call it
+
+```bash
+curl http://localhost:8000/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{"model":"opencode/litellm/claude-sonnet-4-5","input":"ping"}'
+```
+
+Streaming, multi-turn, per-user workspace isolation all work the same as managed mode and the Claude backend.
+
+## Network considerations (Docker)
+
+If the gateway runs in a container and OpenCode runs on the host, `OPENCODE_BASE_URL=http://127.0.0.1:7891` from inside the container resolves to the **container's** loopback, not the host's. Options:
+
+- **`host.docker.internal`** — `OPENCODE_BASE_URL=http://host.docker.internal:7891` (Docker Desktop and recent Linux Docker)
+- **Host network mode** — set `network_mode: host` on the gateway service in docker-compose
+- **Docker bridge gateway IP** — typically `172.17.0.1`, but inspect with `docker network inspect bridge`
+
+If both gateway and OpenCode are containerised on the same compose network, use the OpenCode service name as the hostname:
+
+```yaml
+services:
+  opencode:
+    image: your/opencode:latest
+    ports: ["7891:7891"]
+  gateway:
+    environment:
+      OPENCODE_BASE_URL: http://opencode:7891
+```
+
+## Security model
+
+External mode shifts trust boundaries. Things to think about:
+
+1. **Basic auth is mandatory in production.** The gateway can run unauthenticated against an external OpenCode (`OPENCODE_SERVER_PASSWORD` unset → no `Authorization` header sent), but anyone on the network who can reach the URL gets full agent access otherwise. Always set a password and use TLS where possible.
+2. **The external server can read whatever its host can read.** That's the point — but make sure the `OPENCODE_BASE_URL` you trust really is the OpenCode server, not e.g. an attacker on the LAN listening on the same port. If you're crossing trust zones, terminate the link with TLS and pin certs.
+3. **MCP server scope** is controlled on the external server. The gateway's `MCP_CONFIG` is **not** consulted for OpenCode in external mode. Audit the external server's own config to see what tools your agents actually have.
+4. **Per-user workspace isolation** still works on the gateway side (assigning each user a subdirectory under `USER_WORKSPACES_DIR`), but the *external server* may or may not honor those paths — if its filesystem doesn't see the same directory tree, the cwd parameter is meaningless. For real isolation, run one external OpenCode per user/tenant or mount the same workspace volumes on both sides.
+5. **Audit logs are split.** The gateway logs which user made each request and what `model` they targeted. The external OpenCode logs the actual provider call and tool use. Correlate via timestamps + the gateway's `chat_id` (passed as the OpenCode session title).
+
+## Verification checklist
+
+- [ ] `GET /admin/api/backends` shows `opencode.config.mode = "external"` and the right `base_url`
+- [ ] `curl -u user:pass <url>/global/health` returns `{"healthy": true}` from the gateway's network
+- [ ] `GET /v1/models` lists your `OPENCODE_MODELS` entries with `opencode/` prefix
+- [ ] A streamed `/v1/responses` request returns content and the LiteLLM/provider logs show the corresponding upstream call
+- [ ] Multi-turn (`previous_response_id`) preserves context across turns
+- [ ] Restarting the gateway does **not** restart OpenCode (and vice versa)
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|--------------|
+| `401 Unauthorized` even with creds | `OPENCODE_SERVER_USERNAME` / `OPENCODE_SERVER_PASSWORD` mismatch with the actual server. From inside the gateway container, run `curl -u user:pass <url>/global/health` directly to isolate. |
+| `WWW-Authenticate: Basic realm="Secure Area"` in 401 response | A basic-auth middleware (built-in or reverse-proxy like nginx/Caddy) is in front of OpenCode. Verify the user/pass that middleware was configured with — not what `opencode serve` itself accepts. |
+| `Connection refused` | Gateway can't reach `OPENCODE_BASE_URL`. Check container network — `127.0.0.1` from inside a container is **not** the host. Use `host.docker.internal` or service name. |
+| `provider not found` from OpenCode | The external server's config doesn't include that provider. Update its config file and restart it (gateway-side `OPENCODE_CONFIG_CONTENT` is a no-op here). |
+| Backend reports `mode: "managed"` after setting `OPENCODE_BASE_URL` | Env var didn't make it into the gateway container. `docker exec <container> env \| grep OPENCODE_BASE_URL` to confirm. Common cause: `.env` not picked up because of missing `env_file:` in compose. |
+| Tool calls succeed but file changes don't appear in the gateway's `USER_WORKSPACES_DIR` | The external server's filesystem differs from the gateway's. Either share volumes or accept that workspaces are external-server-local. |
+| 502 / 504 to clients | External OpenCode is slow or unhealthy. Bump `MAX_TIMEOUT` on the gateway and check the external server's logs / load. |
+
+## Configuration reference (external mode)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OPENCODE_BASE_URL` | unset | URL of the external `opencode serve`. Setting this enables external mode. |
+| `OPENCODE_SERVER_USERNAME` | `opencode` | Basic-auth username sent with every request |
+| `OPENCODE_SERVER_PASSWORD` | unset | Basic-auth password; if unset, no `Authorization` header is sent |
+| `OPENCODE_AGENT` | `general` | Agent profile passed at request time |
+| `OPENCODE_DEFAULT_MODEL` | unset | Used when the request omits provider/model |
+| `OPENCODE_QUESTION_PERMISSION` | `ask` | `ask` / `allow` / `deny` for the question tool |
+| `OPENCODE_MODELS` | unset | Public allowlist exposed via `/v1/models` |
+
+These exist but are **no-ops** in external mode:
+
+- `OPENCODE_BIN`, `OPENCODE_HOST`, `OPENCODE_PORT`, `OPENCODE_START_TIMEOUT_MS`
+- `OPENCODE_CONFIG_CONTENT`
+- `OPENCODE_USE_WRAPPER_MCP_CONFIG`

--- a/docs/opencode/litellm.md
+++ b/docs/opencode/litellm.md
@@ -1,0 +1,177 @@
+# OpenCode + LiteLLM Recipes
+
+[LiteLLM](https://docs.litellm.ai/) is a unified proxy that exposes 100+ LLM providers behind a single OpenAI-compatible endpoint. Pairing it with OpenCode means you write **one** OpenCode provider definition and reach every model LiteLLM routes to (Anthropic, OpenAI, Bedrock, on-prem vLLM/SGLang, GLM, Qwen, etc.).
+
+This page covers LiteLLM-specific concerns. For general OpenCode setup see:
+
+- **[managed.md](managed.md)** — gateway spawns `opencode serve` itself
+- **[external.md](external.md)** — gateway forwards to your own `opencode serve`
+
+## Why LiteLLM?
+
+| | Direct provider in OpenCode | LiteLLM proxy |
+|---|----------------------------|---------------|
+| One config per provider | yes — `provider.openai`, `provider.anthropic`, … | one provider entry → many upstream models |
+| Per-team API keys | provider-level | **per-virtual-key, plus rate limits & budgets** |
+| On-prem / self-hosted endpoints | one provider per endpoint | one LiteLLM, many backends |
+| Reasoning-content normalization | provider-dependent | **`merge_reasoning_content_in_choices: true` works everywhere** |
+| Logs / observability | provider-dependent | unified callbacks (Langfuse, OTEL, …) |
+
+If you only target Anthropic, you might not need LiteLLM. If you mix providers or run any self-hosted models, it's the right abstraction.
+
+## OpenCode provider definition
+
+LiteLLM speaks OpenAI Chat-Completions, so you register it in OpenCode as the `openai-compatible` provider type:
+
+```json
+{
+  "provider": {
+    "litellm": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "LiteLLM",
+      "options": {
+        "baseURL": "http://litellm:4000/v1",
+        "apiKey": "{env:LITELLM_API_KEY}"
+      },
+      "models": {
+        "claude-sonnet-4-5": {},
+        "gpt-4o": {},
+        "GLM-5.1-FP8": {},
+        "Qwen3-235B": {}
+      }
+    }
+  }
+}
+```
+
+Each key under `models` is a **LiteLLM model name** — the same string you pass as `model` directly to LiteLLM's `/chat/completions`. The gateway exposes it as `opencode/litellm/<key>` to clients.
+
+In **managed mode** put this in `OPENCODE_CONFIG_CONTENT` (single-line JSON). In **external mode** put it in the external server's own opencode config file (e.g. `~/.config/opencode/opencode.json`).
+
+## Reasoning-content rendering (`<think>` tags)
+
+When you call a reasoning model via LiteLLM, the API returns `reasoning_content` as a separate field on each chunk:
+
+```json
+{
+  "choices": [{
+    "message": {
+      "content": "Hello!",
+      "reasoning_content": "User asked for a greeting..."
+    }
+  }]
+}
+```
+
+OpenCode's `@ai-sdk/openai-compatible` provider does **not** automatically split `reasoning_content` into a distinct UI track. By default the reasoning either disappears (if the adapter ignores the field) or leaks into the visible answer (if some intermediate step concatenates fields).
+
+**Cleanest fix: let LiteLLM merge reasoning into content with `<think>` tags.**
+
+```yaml
+# litellm config.yaml
+litellm_settings:
+  merge_reasoning_content_in_choices: true
+```
+
+Or per model:
+
+```yaml
+model_list:
+  - model_name: GLM-5.1-FP8
+    litellm_params:
+      model: openai/GLM-5.1-FP8
+      api_base: http://glm-server:8000/v1
+      api_key: dummy
+      merge_reasoning_content_in_choices: true
+```
+
+After this, LiteLLM returns:
+
+```json
+{
+  "choices": [{
+    "message": {
+      "content": "<think>User asked for a greeting...</think>\nHello!"
+    }
+  }]
+}
+```
+
+OpenCode forwards the content verbatim, the gateway streams it through, and Open WebUI / any `<think>`-aware client renders it as a collapsible reasoning block. **No gateway-side changes required.**
+
+## Per-tenant or per-team isolation via virtual keys
+
+LiteLLM supports **virtual keys** — short-lived API keys with their own rate limits, budget caps, allowed models, and metadata. Pair this with the gateway's `user` field for end-to-end isolation:
+
+```bash
+# 1. Mint a virtual key on LiteLLM with a budget
+curl -X POST http://litellm:4000/key/generate \
+  -H "Authorization: Bearer sk-master" \
+  -d '{"models": ["claude-sonnet-4-5"], "max_budget": 5.0, "metadata": {"team": "research"}}'
+```
+
+The OpenCode provider config stays the same; rotate `LITELLM_API_KEY` when you rotate the virtual key. For multi-tenant setups, run **one gateway per tenant** and give each its own virtual key, rather than trying to multiplex tenants through one OpenCode session.
+
+## Common LiteLLM upstream patterns
+
+### Self-hosted vLLM / SGLang
+
+```yaml
+model_list:
+  - model_name: Qwen3-235B
+    litellm_params:
+      model: openai/Qwen3-235B   # forwards to OpenAI-compatible vLLM
+      api_base: http://vllm:8000/v1
+      api_key: dummy             # vLLM ignores it
+```
+
+OpenCode side:
+
+```json
+{"provider":{"litellm":{"...": "...", "models": {"Qwen3-235B": {}}}}}
+```
+
+### Anthropic via LiteLLM (instead of native)
+
+```yaml
+model_list:
+  - model_name: claude-sonnet-4-5
+    litellm_params:
+      model: anthropic/claude-sonnet-4-5-20250929
+      api_key: os.environ/ANTHROPIC_API_KEY
+      thinking: {"type": "enabled", "budget_tokens": 5000}
+```
+
+Why? Lets you put Anthropic, OpenAI, and on-prem models behind one auth surface (LiteLLM virtual keys) with unified logging and budgets.
+
+### Bedrock
+
+```yaml
+model_list:
+  - model_name: claude-via-bedrock
+    litellm_params:
+      model: bedrock/anthropic.claude-sonnet-4-5
+      aws_region_name: us-east-1
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|--------------|
+| `provider not found: litellm` from OpenCode | provider key missing in OpenCode config |
+| `model not found` from LiteLLM | the LiteLLM `model_name` doesn't match what OpenCode sent. Compare LiteLLM logs against OpenCode's request body. |
+| Reasoning text leaks into the answer body | `merge_reasoning_content_in_choices` not enabled on LiteLLM, or the model isn't a reasoning model and is just narrating |
+| 401 from LiteLLM (not OpenCode!) | `LITELLM_API_KEY` env var unset or wrong; `{env:LITELLM_API_KEY}` interpolation will pass an empty string |
+| LiteLLM logs show calls but model errors | upstream provider issue — call LiteLLM directly with the same payload to isolate |
+| Streaming stalls partway | LiteLLM's request timeout < the gateway's `MAX_TIMEOUT`. Bump LiteLLM's timeout. |
+
+Quick LiteLLM smoke test (bypassing gateway/OpenCode):
+
+```bash
+curl http://litellm:4000/chat/completions \
+  -H "Authorization: Bearer $LITELLM_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"ping"}]}'
+```
+
+If this works but `opencode/litellm/claude-sonnet-4-5` doesn't, the issue is in OpenCode's provider definition or the gateway's allowlist (`OPENCODE_MODELS`).

--- a/docs/opencode/managed.md
+++ b/docs/opencode/managed.md
@@ -1,0 +1,293 @@
+# OpenCode — Managed Mode
+
+In managed mode the gateway spawns `opencode serve` as a subprocess on startup, feeds it a generated config, and proxies HTTP traffic to it. This is the **default** when `BACKENDS=claude,opencode` and `OPENCODE_BASE_URL` is unset.
+
+```
+┌──────────────────────────────────────────┐
+│ gateway container                        │
+│                                          │
+│   FastAPI    ───── HTTP ─────►  opencode │
+│   (port 8000)                  serve     │
+│                                (port N)  │
+│                                          │
+│   spawns/owns  ──────────────────►       │
+│   reads stdout for "listening on" line   │
+└──────────────────────────────────────────┘
+```
+
+## When to use
+
+- Single deployment where the gateway container is the trust boundary
+- You want one source of truth for provider config and MCP servers (the gateway env)
+- You don't need OpenCode to access files outside the gateway container
+
+If you need OpenCode to run somewhere else, see [external.md](external.md).
+
+## Prerequisites
+
+- `opencode` binary on `PATH` inside the gateway process / container
+- The Docker image bundles it; for local dev: `npm i -g opencode-ai` (or whatever the official install method is)
+
+Verify the gateway sees the binary:
+
+```bash
+curl -s http://localhost:8000/admin/api/backends | jq '.opencode'
+```
+
+```json
+{
+  "valid": true,
+  "errors": [],
+  "config": {"mode": "managed", "binary": "/usr/local/bin/opencode"}
+}
+```
+
+## Step 1 — enable the backend
+
+```bash
+BACKENDS=claude,opencode
+```
+
+Without `opencode` in `BACKENDS`, the OpenCode-prefixed model ids return `404 unknown model`.
+
+## Step 2 — declare your providers
+
+OpenCode loads a config that defines providers (LLM endpoints) and which model ids to expose for each. The gateway accepts this config as a JSON string in `OPENCODE_CONFIG_CONTENT`. The string is parsed, merged with safe defaults, and serialised back into the OpenCode config file.
+
+### LiteLLM provider example
+
+LiteLLM exposes an OpenAI-compatible endpoint, so register it as an `openai-compatible` provider:
+
+```json
+{
+  "provider": {
+    "litellm": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "LiteLLM",
+      "options": {
+        "baseURL": "http://litellm:4000/v1",
+        "apiKey": "{env:LITELLM_API_KEY}"
+      },
+      "models": {
+        "claude-sonnet-4-5": {},
+        "gpt-4o": {},
+        "gpt-4o-mini": {}
+      }
+    }
+  }
+}
+```
+
+Notes:
+
+- `baseURL` is your LiteLLM `/v1` endpoint (network-reachable from the gateway container).
+- `{env:VAR}` is OpenCode's env-var interpolation; the variable must exist in the gateway process env so OpenCode (a child process) inherits it.
+- Each key under `models` is a **LiteLLM model name** — the same string you'd send as `model` directly to LiteLLM.
+
+In `.env`:
+
+```bash
+LITELLM_API_KEY=sk-1234
+OPENCODE_CONFIG_CONTENT={"provider":{"litellm":{"npm":"@ai-sdk/openai-compatible","name":"LiteLLM","options":{"baseURL":"http://litellm:4000/v1","apiKey":"{env:LITELLM_API_KEY}"},"models":{"claude-sonnet-4-5":{},"gpt-4o":{}}}}}
+```
+
+### Mixing providers
+
+`provider` is a dict — add as many entries as you want:
+
+```json
+{
+  "provider": {
+    "litellm": { "npm": "@ai-sdk/openai-compatible", "options": {"baseURL": "http://litellm:4000/v1", "apiKey": "{env:LITELLM_API_KEY}"}, "models": {"gpt-4o": {}} },
+    "openai":  { "options": {"apiKey": "{env:OPENAI_API_KEY}"}, "models": {"gpt-5.5": {}} }
+  }
+}
+```
+
+## Step 3 — allowlist models
+
+`OPENCODE_MODELS` controls what `/v1/models` returns and what the `/v1/responses` endpoint accepts. Each entry must match a `<provider>/<model-key>` pair from your config:
+
+```bash
+OPENCODE_MODELS=litellm/claude-sonnet-4-5,litellm/gpt-4o,openai/gpt-5.5
+OPENCODE_DEFAULT_MODEL=litellm/claude-sonnet-4-5
+```
+
+Anything not in the allowlist is rejected by the gateway, even if the underlying OpenCode server would happily run it.
+
+## Step 4 — call it
+
+```bash
+curl http://localhost:8000/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "opencode/litellm/claude-sonnet-4-5",
+    "input": "ping"
+  }'
+```
+
+Streaming, `previous_response_id` chaining, `user` workspace isolation work the same as for Claude.
+
+## MCP servers
+
+OpenCode has its own MCP config schema (separate from the wrapper's `MCP_CONFIG`). You can configure it two ways, and they can be mixed.
+
+### Option A — inline in `OPENCODE_CONFIG_CONTENT`
+
+OpenCode's native MCP block uses `type: "local"` (stdio) or `type: "remote"` (HTTP/SSE/streamable-HTTP):
+
+```json
+{
+  "provider": { "...": "..." },
+  "mcp": {
+    "filesystem": {
+      "type": "local",
+      "command": ["npx", "-y", "@modelcontextprotocol/server-filesystem", "/workspace"],
+      "environment": {"FOO": "bar"},
+      "enabled": true,
+      "timeout": 30
+    },
+    "internal-search": {
+      "type": "remote",
+      "url": "https://mcp.example.com/sse",
+      "headers": {"Authorization": "Bearer {env:INTERNAL_MCP_TOKEN}"},
+      "enabled": true
+    }
+  }
+}
+```
+
+`{env:VAR}` interpolation works in `headers` values and inside `environment`. Variables must exist in the gateway env for OpenCode to inherit.
+
+### Option B — reuse the wrapper's `MCP_CONFIG`
+
+If you already have `MCP_CONFIG` set up for Claude, forward it to OpenCode automatically:
+
+```bash
+OPENCODE_USE_WRAPPER_MCP_CONFIG=true
+```
+
+The converter at `src/backends/opencode/config.py:_convert_mcp_server` translates wrapper transports into OpenCode types:
+
+| Wrapper `type` | OpenCode `type` | Notes |
+|----------------|-----------------|-------|
+| `stdio` | `local` | `command` + `args` flattened into one list; `env`/`environment` copied across |
+| `http`, `sse`, `streamable-http` | `remote` | `url`, `headers`, `oauth`, `enabled`, `timeout` preserved |
+
+Wrapper `MCP_CONFIG` example that works on both backends:
+
+```json
+{
+  "mcpServers": {
+    "fs": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/workspace"]
+    },
+    "search": {
+      "type": "streamable-http",
+      "url": "https://mcp.example.com/mcp",
+      "headers": {"Authorization": "Bearer {env:SEARCH_TOKEN}"}
+    }
+  }
+}
+```
+
+### Precedence (Option A + B combined)
+
+- Servers explicitly defined in `OPENCODE_CONFIG_CONTENT.mcp` are kept as-is
+- Wrapper `MCP_CONFIG` entries are added **only** for names not already present (the merger uses `setdefault`)
+
+So `MCP_CONFIG` is the shared baseline; override per-OpenCode by adding the same name to `OPENCODE_CONFIG_CONTENT.mcp`.
+
+## Reasoning content (`<think>` rendering)
+
+If you call a reasoning model (e.g. via LiteLLM), the model's reasoning_content can either be returned as a separate field or merged into the response text. The cleanest path for Open WebUI / clients that recognise `<think>` tags is to enable LiteLLM's tag-merge mode:
+
+```yaml
+# litellm config.yaml
+litellm_settings:
+  merge_reasoning_content_in_choices: true
+```
+
+LiteLLM then prefixes reasoning into `content` as `<think>...</think>`, and the gateway/client renders it as a collapsed block. No gateway-side changes needed.
+
+## docker-compose example
+
+```yaml
+services:
+  litellm:
+    image: ghcr.io/berriai/litellm:main-stable
+    ports: ["4000:4000"]
+    volumes:
+      - ./litellm.config.yaml:/app/config.yaml
+    command: ["--config", "/app/config.yaml"]
+
+  gateway:
+    build: .
+    ports: ["8000:8000"]
+    environment:
+      ANTHROPIC_AUTH_TOKEN: ${ANTHROPIC_AUTH_TOKEN}
+      BACKENDS: claude,opencode
+      LITELLM_API_KEY: ${LITELLM_API_KEY}
+      OPENCODE_MODELS: litellm/claude-sonnet-4-5,litellm/gpt-4o
+      OPENCODE_DEFAULT_MODEL: litellm/claude-sonnet-4-5
+      OPENCODE_USE_WRAPPER_MCP_CONFIG: "true"
+      MCP_CONFIG: |
+        {"mcpServers":{"fs":{"type":"stdio","command":"npx","args":["-y","@modelcontextprotocol/server-filesystem","/workspace"]}}}
+      OPENCODE_CONFIG_CONTENT: |
+        {"provider":{"litellm":{"npm":"@ai-sdk/openai-compatible","name":"LiteLLM","options":{"baseURL":"http://litellm:4000/v1","apiKey":"{env:LITELLM_API_KEY}"},"models":{"claude-sonnet-4-5":{},"gpt-4o":{}}}}}
+    depends_on: [litellm]
+```
+
+## Verification
+
+```bash
+# Backend mode + binary path
+curl -s http://localhost:8000/admin/api/backends | jq '.opencode.config'
+
+# Models exposed
+curl -s http://localhost:8000/v1/models | jq '.data[].id'
+
+# MCP servers each backend sees
+curl -s http://localhost:8000/admin/api/mcp-servers | jq
+
+# Live smoke test
+OPENCODE_SMOKE_ENABLED=1 \
+OPENCODE_SMOKE_MODEL=litellm/claude-sonnet-4-5 \
+uv run pytest tests/integration/test_opencode_smoke.py -q
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|--------------|
+| `opencode binary not found on PATH` | Install OpenCode in the gateway image / dev environment |
+| `Timeout waiting for OpenCode server after 5000ms` | `opencode serve` failed to start; check gateway logs for stderr from the subprocess. Common: invalid `OPENCODE_CONFIG_CONTENT` JSON, port conflict |
+| `400 unknown model: opencode/litellm/foo` | `litellm/foo` missing from `OPENCODE_MODELS` |
+| `provider not found` from OpenCode | provider key not in `OPENCODE_CONFIG_CONTENT.provider`, or model key not under it |
+| MCP tools never appear | server failed to start; check gateway logs for `[opencode]` MCP load errors and verify command/url is reachable |
+| Reasoning text leaks into the answer body | enable `merge_reasoning_content_in_choices` on LiteLLM, or use a non-reasoning model |
+| 401 from OpenCode | `OPENCODE_SERVER_PASSWORD` set on gateway but not on the (auto-spawned) subprocess — managed mode shouldn't need basic auth, so simply unset both username/password env vars |
+
+Useful checks:
+
+- `GET /admin/api/backends` — backend health, mode, binary path
+- `GET /admin/api/mcp-servers` — what MCP each backend sees
+- `GET /admin/api/config` — redacted env (verify variables made it in)
+- gateway stdout — captures the OpenCode subprocess's stdout/stderr
+
+## Configuration reference (managed mode)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OPENCODE_BIN` | `opencode` | Binary on `PATH` |
+| `OPENCODE_HOST` | `127.0.0.1` | Subprocess bind host |
+| `OPENCODE_PORT` | `0` (auto) | Subprocess bind port |
+| `OPENCODE_START_TIMEOUT_MS` | `5000` | How long to wait for "listening on" line |
+| `OPENCODE_AGENT` | `general` | Agent profile id |
+| `OPENCODE_DEFAULT_MODEL` | unset | Used when request omits provider/model |
+| `OPENCODE_QUESTION_PERMISSION` | `ask` | `ask` / `allow` / `deny` for the `question` tool |
+| `OPENCODE_CONFIG_CONTENT` | `{}` | Provider + MCP config injected into the subprocess |
+| `OPENCODE_USE_WRAPPER_MCP_CONFIG` | `false` | Forward wrapper `MCP_CONFIG` to OpenCode |
+| `OPENCODE_MODELS` | unset | Public allowlist of `<provider>/<model>` ids |

--- a/src/backends/opencode/auth.py
+++ b/src/backends/opencode/auth.py
@@ -17,13 +17,12 @@ class OpenCodeAuthProvider(BackendAuthProvider):
         return "opencode"
 
     def validate(self) -> Dict[str, Any]:
-        if os.getenv("OPENCODE_BASE_URL"):
+        base_url = os.getenv("OPENCODE_BASE_URL")
+        if base_url:
             return {
-                "valid": False,
-                "errors": [
-                    "OPENCODE_BASE_URL is no longer supported; unset it to use managed OpenCode"
-                ],
-                "config": {"mode": "managed"},
+                "valid": True,
+                "errors": [],
+                "config": {"mode": "external", "base_url": base_url},
             }
 
         binary = shutil.which(os.getenv("OPENCODE_BIN", "opencode"))
@@ -48,6 +47,7 @@ class OpenCodeAuthProvider(BackendAuthProvider):
             "OPENCODE_PORT",
             "OPENCODE_START_TIMEOUT_MS",
             "OPENCODE_AGENT",
+            "OPENCODE_BASE_URL",
             "OPENCODE_SERVER_USERNAME",
             "OPENCODE_SERVER_PASSWORD",
             "OPENCODE_CONFIG_CONTENT",

--- a/src/backends/opencode/client.py
+++ b/src/backends/opencode/client.py
@@ -3,6 +3,22 @@
 Wraps the OpenCode headless HTTP server into the gateway ``BackendClient``
 protocol.  The official OpenCode SDK is TypeScript; this Python backend talks
 to the same server API directly with httpx.
+
+Two operating modes:
+
+- **managed** (default) — the gateway spawns ``opencode serve`` as a
+  subprocess and feeds it a generated config built from
+  ``OPENCODE_CONFIG_CONTENT`` and (optionally) the wrapper's ``MCP_CONFIG``.
+- **external** — when ``OPENCODE_BASE_URL`` is set, the gateway points its
+  HTTP client at that URL instead of starting a subprocess.  The external
+  server owns its own config, so wrapper-side options that affect server
+  startup (``OPENCODE_CONFIG_CONTENT``, ``OPENCODE_USE_WRAPPER_MCP_CONFIG``,
+  ``OPENCODE_BIN``, ``OPENCODE_HOST``, ``OPENCODE_PORT``,
+  ``OPENCODE_START_TIMEOUT_MS``) become no-ops.  Request-time parameters
+  (``OPENCODE_AGENT``, ``OPENCODE_DEFAULT_MODEL``,
+  ``OPENCODE_QUESTION_PERMISSION``, ``OPENCODE_MODELS``) and basic-auth
+  credentials (``OPENCODE_SERVER_USERNAME`` / ``OPENCODE_SERVER_PASSWORD``)
+  still apply.
 """
 
 from __future__ import annotations
@@ -92,11 +108,19 @@ class OpenCodeClient:
         self._server_password = os.getenv("OPENCODE_SERVER_PASSWORD")
         self._agent = os.getenv("OPENCODE_AGENT", "general").strip() or "general"
 
-        if os.getenv("OPENCODE_BASE_URL"):
-            raise RuntimeError(
-                "OPENCODE_BASE_URL is no longer supported; unset it to use managed OpenCode"
+        external_url = os.getenv("OPENCODE_BASE_URL")
+        if external_url:
+            self._mode = "external"
+            self.base_url = external_url.rstrip("/")
+            logger.info(
+                "OpenCode backend in external mode: %s "
+                "(OPENCODE_CONFIG_CONTENT and OPENCODE_USE_WRAPPER_MCP_CONFIG "
+                "are no-ops; the external server owns its config)",
+                self.base_url,
             )
-        self.base_url = self._start_managed_server()
+        else:
+            self._mode = "managed"
+            self.base_url = self._start_managed_server()
 
     @property
     def name(self) -> str:
@@ -111,7 +135,7 @@ class OpenCodeClient:
     def runtime_metadata(self) -> Dict[str, Any]:
         """Return operational details for admin diagnostics."""
         return {
-            "mode": "managed",
+            "mode": self._mode,
             "base_url": self.base_url,
             "agent": self._agent,
             "models": self.supported_models(),


### PR DESCRIPTION
## Summary

Re-enables OpenCode **external mode** (removed in #93's managed-only refactor) and adds a structured `docs/` tree with detailed per-backend usage guides.

### Code (~140 lines)

- `src/backends/opencode/auth.py` — `validate()` reports `mode=external` when `OPENCODE_BASE_URL` is set; binary check is skipped in that mode. `build_env()` forwards the new var.
- `src/backends/opencode/client.py` — `__init__` skips the managed `opencode serve` subprocess in external mode and points httpx at `OPENCODE_BASE_URL` instead. `runtime_metadata()` reports the active mode (`managed` / `external`) instead of always `managed`.

The rest of the client (sessions, SSE, question/permission resume, basic-auth) is mode-agnostic and shared.

### Why this matters

Use case: gateway runs in a sandboxed container, but OpenCode needs broader filesystem access on a trusted host. Or several gateway replicas share one OpenCode. Both were impossible after #93 without forking.

In external mode the following gateway-side variables become **no-ops** (the external server owns its own config):

- `OPENCODE_CONFIG_CONTENT`
- `OPENCODE_USE_WRAPPER_MCP_CONFIG`
- `OPENCODE_BIN`, `OPENCODE_HOST`, `OPENCODE_PORT`, `OPENCODE_START_TIMEOUT_MS`

Request-time options (`OPENCODE_AGENT`, `OPENCODE_DEFAULT_MODEL`, `OPENCODE_QUESTION_PERMISSION`, `OPENCODE_MODELS`) and basic-auth credentials still apply.

### Docs

New top-level structure (the user requested per-backend folders):

- **`docs/claude-code/README.md`** — Claude backend usage: auth, working dir, per-user workspaces, sandbox, thinking modes, system prompt customization, MCP, subagent control, full env-var reference, troubleshooting.
- **`docs/opencode/README.md`** — backend overview + when to use which mode + cross-links.
- **`docs/opencode/managed.md`** — managed-mode setup with LiteLLM provider example, MCP option-A/B with precedence rules, docker-compose example, troubleshooting.
- **`docs/opencode/external.md`** — external-mode setup, architecture diagram, network/Docker considerations, security model, verification checklist, troubleshooting.
- **`docs/opencode/litellm.md`** — LiteLLM-specific recipes: `merge_reasoning_content_in_choices` for `<think>` rendering, virtual keys, upstream patterns (vLLM, Anthropic-via-LiteLLM, Bedrock).

Top-level `README.md` rebranded **Claude Code Gateway → Oh My Gateway** (matches the repo rename), with a new Documentation table that points at the new tree.

### Testing performed

- Branch deployed end-to-end against an external `opencode serve` on the same host (Docker `network_mode: host`)
- `GET /admin/api/backends` confirmed `opencode.config.mode = "external"`
- `/v1/responses` round-trip succeeded with `model: opencode/litellm/<...>` — verified the call reached LiteLLM via its logs
- Multi-turn `previous_response_id` chaining preserved context
- `<think>` tag rendering confirmed end-to-end after enabling `merge_reasoning_content_in_choices: true` on LiteLLM (documented in `litellm.md`)

## Test plan

- [ ] CI passes (`uv run pytest tests/`, ruff check)
- [ ] `GET /admin/api/backends` reports `opencode.config.mode = managed` when `OPENCODE_BASE_URL` is unset (regression check)
- [ ] `GET /admin/api/backends` reports `opencode.config.mode = external, base_url = <url>` when set
- [x] Docker image still builds (no Dockerfile changes; only Python source changed)
- [ ] `/v1/models` returns the same set as before for both modes
- [x] Existing managed-mode users see no behavior change after upgrade

## Notes

- Closes the managed-only refactor in #93 by re-introducing external as a first-class mode.
- Supersedes the work that was on `claude/litellm-gateway-setup-6Pd8B` (that branch's `docs/opencode-litellm.md` is now incorporated as `docs/opencode/litellm.md` and trimmed to LiteLLM-specific content; general managed-mode walkthrough lives in `managed.md`). That branch can be closed.