### PR TITLE
[codex] add codex backend mvp

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,12 +48,14 @@ CORS_ORIGINS=["*"]
 DEFAULT_MODEL=sonnet
 
 # Backend Configuration
-# Default is Claude only. Enable OpenCode by adding it to BACKENDS.
+# Default is Claude only. Enable OpenCode or Codex by adding it to BACKENDS.
 # Backend is selected by model ID:
 #   sonnet/opus/haiku               -> Claude
 #   opencode/<provider>/<model>     -> OpenCode
+#   codex/<model>                   -> Codex
 # BACKENDS=claude
 # BACKENDS=claude,opencode
+# BACKENDS=claude,codex
 
 # OpenCode Backend Configuration
 #
@@ -99,6 +101,14 @@ DEFAULT_MODEL=sonnet
 # OPENCODE_SMOKE_ENABLED=0
 # OPENCODE_SMOKE_MODEL=openai/gpt-5.5
 # OPENCODE_SMOKE_CWD=/path/to/workspace
+
+# Codex Backend Configuration
+# Requires the local Codex CLI app-server harness.
+# CODEX_BIN=codex
+# CODEX_MODELS=gpt-5.5
+# CODEX_APPROVAL_POLICY=never
+# CODEX_SANDBOX=workspace-write
+# CODEX_CONFIG_OVERRIDES=
 
 # SDK Configuration
 # Maximum conversation turns per request

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Docker](https://img.shields.io/badge/Docker-ready-2496ED?logo=docker&logoColor=white)](https://github.com/JinY0ung-Shin/oh-my-gateway)
 [![MIT License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
-OpenAI-compatible gateway for coding agent backends. It exposes Claude Agent SDK and OpenCode through one `/v1/responses` API with streaming, multi-turn `previous_response_id` chaining, MCP integration, workspace isolation, and an admin dashboard.
+OpenAI-compatible gateway for coding agent backends. It exposes Claude Agent SDK, OpenCode, and Codex through one `/v1/responses` API with streaming, multi-turn `previous_response_id` chaining, MCP integration, workspace isolation, and an admin dashboard.
 
 > Previously published as **Claude Code Gateway**. The repository was renamed because the gateway now fronts multiple agent backends, not just Claude. The Docker Compose service is now `gateway`; update commands such as `docker compose logs claude-wrapper` to use `gateway`.
 
@@ -33,7 +33,7 @@ curl http://localhost:8000/v1/responses \
 ## What It Provides
 
 - **Responses API**: `/v1/responses` with non-streaming and SSE streaming responses.
-- **Multiple backends**: Claude (`sonnet`, `opus`, `haiku`) and OpenCode (`opencode/<provider>/<model>`).
+- **Multiple backends**: Claude (`sonnet`, `opus`, `haiku`), OpenCode (`opencode/<provider>/<model>`), and Codex (`codex/<model>`).
 - **Session continuity**: `previous_response_id` and server-side session tracking.
 - **Workspace isolation**: temporary sessions by default, or per-user directories with `USER_WORKSPACES_DIR`.
 - **MCP support**: shared gateway `MCP_CONFIG`, with optional OpenCode managed-mode config generation.
@@ -49,6 +49,7 @@ curl http://localhost:8000/v1/responses \
 | OpenCode managed mode | [docs/opencode/managed.md](docs/opencode/managed.md) |
 | OpenCode external mode | [docs/opencode/external.md](docs/opencode/external.md) |
 | OpenCode + LiteLLM recipes | [docs/opencode/litellm.md](docs/opencode/litellm.md) |
+| Codex backend setup and SDK status | [docs/codex/](docs/codex/) |
 | Streaming event reference | [docs/streaming-events.md](docs/streaming-events.md) |
 | System prompt presets | [docs/](docs/) |
 
@@ -67,6 +68,15 @@ Enable OpenCode alongside Claude:
 BACKENDS=claude,opencode
 OPENCODE_MODELS=openai/gpt-5.5
 ```
+
+Enable Codex alongside Claude:
+
+```bash
+BACKENDS=claude,codex
+CODEX_MODELS=gpt-5.5
+```
+
+Codex uses the local `codex app-server` harness through JSON-RPC, not the OpenAI Responses API. The official Python SDK exists but is experimental and may not be installable from PyPI; see [docs/codex/](docs/codex/) for the current integration notes.
 
 OpenCode has two modes:
 
@@ -99,7 +109,7 @@ Most settings are environment variables. Start with `.env.example`.
 |----------|---------|
 | `ANTHROPIC_AUTH_TOKEN` | Claude API key auth |
 | `CLAUDE_AUTH_METHOD` | Force `api_key` or `cli` auth |
-| `BACKENDS` | Backend allowlist, for example `claude,opencode` |
+| `BACKENDS` | Backend allowlist, for example `claude,opencode,codex` |
 | `DEFAULT_MODEL` | Default model for requests without `model` |
 | `DEFAULT_MAX_TURNS` | Maximum agent turns per request |
 | `MAX_TIMEOUT` | Backend timeout in milliseconds |
@@ -113,6 +123,11 @@ Most settings are environment variables. Start with `.env.example`.
 | `ASK_USER_TIMEOUT_SECONDS` | AskUserQuestion wait time before denying the tool call |
 | `OPENCODE_BASE_URL` | Enables OpenCode external mode |
 | `OPENCODE_MODELS` | Gateway allowlist for OpenCode models |
+| `CODEX_BIN` | Codex CLI binary name/path; default `codex` |
+| `CODEX_MODELS` | Gateway allowlist for Codex models; default `gpt-5.5` |
+| `CODEX_APPROVAL_POLICY` | Codex approval policy; default `never` |
+| `CODEX_SANDBOX` | Codex thread sandbox mode; default `workspace-write` |
+| `CODEX_CONFIG_OVERRIDES` | Comma-separated `codex --config key=value` overrides |
 | `API_KEY` | Optional public API bearer token |
 | `ADMIN_API_KEY` | Required admin dashboard key |
 | `USAGE_LOG_DB_URL` | Optional SQLAlchemy URL for usage logging |
@@ -183,7 +198,7 @@ When `USAGE_LOG_DB_URL` is configured, usage analytics are available under `/adm
 
 Effective `/v1/responses` request fields:
 
-- `model`: `sonnet`, `opus`, `haiku`, or `opencode/<provider>/<model>`.
+- `model`: `sonnet`, `opus`, `haiku`, `opencode/<provider>/<model>`, or `codex/<model>`.
 - `input`: string, message array, `input_text` or `input_image` parts, or `function_call_output`.
 - `instructions`: system/developer prompt for a new session only.
 - `previous_response_id`: continue the latest turn of an existing session.
@@ -204,7 +219,7 @@ Notable deviations from OpenAI Responses API behavior:
 
 You must use your own upstream credentials. This project does not pool credentials, resell access, or bypass upstream authentication.
 
-Oh My Gateway is an independent open-source project and is not affiliated with or endorsed by Anthropic or the OpenCode authors.
+Oh My Gateway is an independent open-source project and is not affiliated with or endorsed by Anthropic, OpenAI, or the OpenCode authors.
 
 ## License
 

--- a/docs/codex/README.md
+++ b/docs/codex/README.md
@@ -1,0 +1,60 @@
+# Codex Backend
+
+The Codex backend is an opt-in gateway backend for the local Codex harness.
+It uses `codex app-server --listen stdio://` and drives the app-server JSON-RPC
+protocol directly.
+
+## Enable
+
+```bash
+BACKENDS=claude,codex
+CODEX_MODELS=gpt-5.5
+DEFAULT_MODEL=codex/gpt-5.5
+```
+
+Requests use `codex/<model>`:
+
+```bash
+curl http://localhost:8000/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{"model": "codex/gpt-5.5", "input": "Summarize this repository"}'
+```
+
+## Runtime Requirements
+
+- Codex CLI must be installed and available on `PATH`, or set `CODEX_BIN`.
+- Codex auth is owned by the Codex CLI/app-server. Use your existing ChatGPT
+  Codex login or Codex-supported API-key setup.
+- Each gateway session maps to one Codex app-server thread. The gateway stores
+  the Codex thread id on the server-side session for subsequent turns.
+
+## Python SDK Status
+
+OpenAI documents a Python SDK package named `openai-codex-app-server-sdk`
+with import package `codex_app_server`. It is experimental and controls the
+same local `codex app-server` JSON-RPC protocol used here.
+
+At implementation time, the documented package and paired
+`openai-codex-cli-bin` runtime package were not resolvable from PyPI in this
+environment, while the installed Codex CLI 0.128.0 app-server responded to
+`initialize` and `model/list`. For that reason, the MVP keeps a small in-tree
+JSON-RPC client instead of adding an unavailable package dependency.
+
+## Configuration
+
+| Variable | Purpose |
+|----------|---------|
+| `CODEX_BIN` | Codex CLI binary name/path. Default: `codex` |
+| `CODEX_MODELS` | Comma-separated model allowlist exposed as `codex/<model>`. Default: `gpt-5.5` |
+| `CODEX_APPROVAL_POLICY` | `approvalPolicy` sent to Codex threads and turns. Default: `never` |
+| `CODEX_SANDBOX` | Thread-level Codex sandbox mode. Default: `workspace-write` |
+| `CODEX_CONFIG_OVERRIDES` | Comma-separated `codex --config key=value` overrides |
+
+## MVP Limits
+
+- Text prompts and text responses are supported.
+- OpenAI Responses API function-call continuations are not mapped to Codex
+  approval flows yet. Codex app-server approval requests are cancelled until
+  the gateway has an explicit approval UI.
+- Image input is not exposed through the gateway Codex backend yet, even though
+  Codex app-server models may support images.

--- a/docs/codex/README.md
+++ b/docs/codex/README.md
@@ -27,6 +27,9 @@ curl http://localhost:8000/v1/responses \
   Codex login or Codex-supported API-key setup.
 - Each gateway session maps to one Codex app-server thread. The gateway stores
   the Codex thread id on the server-side session for subsequent turns.
+- The gateway keeps one Codex app-server subprocess per backend instance and
+  serializes Codex turns through that shared process. This avoids per-session
+  process startup cost while keeping the MVP transport simple.
 
 ## Python SDK Status
 
@@ -53,6 +56,8 @@ JSON-RPC client instead of adding an unavailable package dependency.
 ## MVP Limits
 
 - Text prompts and text responses are supported.
+- Codex turns are serialized through one shared app-server process; concurrent
+  Codex request multiplexing is not implemented yet.
 - OpenAI Responses API function-call continuations are not mapped to Codex
   approval flows yet. Codex app-server approval requests are cancelled until
   the gateway has an explicit approval UI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "oh-my-gateway"
 version = "2.2.0"
-description = "OpenAI-compatible gateway for Claude Agent SDK and OpenCode"
+description = "OpenAI-compatible gateway for Claude Agent SDK, OpenCode, and Codex"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10"

--- a/src/auth.py
+++ b/src/auth.py
@@ -65,6 +65,12 @@ def _get_opencode_auth_provider_class():
     return OpenCodeAuthProvider
 
 
+def _get_codex_auth_provider_class():
+    from src.backends.codex.auth import CodexAuthProvider
+
+    return CodexAuthProvider
+
+
 # ============================================================================
 # ClaudeCodeAuthManager — backward-compatible gateway auth manager
 # ============================================================================
@@ -115,6 +121,8 @@ class ClaudeCodeAuthManager:
             return self._claude_provider
         if backend == "opencode":
             return _get_opencode_auth_provider_class()()
+        if backend == "codex":
+            return _get_codex_auth_provider_class()()
         raise ValueError(f"Unknown backend: {backend!r}")
 
     # ------------------------------------------------------------------
@@ -275,4 +283,6 @@ def __getattr__(name):
         return _get_claude_auth_provider_class()
     if name == "OpenCodeAuthProvider":
         return _get_opencode_auth_provider_class()
+    if name == "CodexAuthProvider":
+        return _get_codex_auth_provider_class()
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/backends/__init__.py
+++ b/src/backends/__init__.py
@@ -41,6 +41,8 @@ def discover_backends(registry_cls=None) -> None:
             from src.backends import claude as backend_pkg
         elif name == "opencode":
             from src.backends import opencode as backend_pkg
+        elif name == "codex":
+            from src.backends import codex as backend_pkg
         else:
             logger.warning("Unknown backend in BACKENDS=%r; skipping", name)
             continue

--- a/src/backends/codex/__init__.py
+++ b/src/backends/codex/__init__.py
@@ -1,0 +1,63 @@
+"""Codex backend subpackage."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from src.backends.base import BackendDescriptor, BackendRegistry, ResolvedModel
+from src.backends.codex.constants import configured_public_models
+
+logger = logging.getLogger(__name__)
+
+
+def _codex_resolve(model: str) -> Optional[ResolvedModel]:
+    """Resolve codex/<model> into the Codex backend."""
+    prefix = "codex/"
+    if not model.startswith(prefix):
+        return None
+    provider_model = model[len(prefix) :]
+    if not provider_model:
+        return None
+    return ResolvedModel(
+        public_model=model,
+        backend="codex",
+        provider_model=provider_model,
+    )
+
+
+CODEX_DESCRIPTOR = BackendDescriptor(
+    name="codex",
+    owned_by="openai",
+    models=configured_public_models(),
+    resolve_fn=_codex_resolve,
+)
+
+
+def __getattr__(name):
+    if name == "CodexClient":
+        from src.backends.codex.client import CodexClient
+
+        return CodexClient
+    if name == "CodexAuthProvider":
+        from src.backends.codex.auth import CodexAuthProvider
+
+        return CodexAuthProvider
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def register(registry_cls=None) -> None:
+    """Register Codex descriptor and live client when available."""
+    if registry_cls is None:
+        registry_cls = BackendRegistry
+
+    registry_cls.register_descriptor(CODEX_DESCRIPTOR)
+
+    try:
+        from src.backends.codex.client import CodexClient
+
+        client = CodexClient()
+        registry_cls.register("codex", client)
+        logger.info("Registered backend: codex")
+    except Exception as exc:
+        logger.error("Codex backend client creation failed: %s", exc)

--- a/src/backends/codex/auth.py
+++ b/src/backends/codex/auth.py
@@ -1,0 +1,53 @@
+"""Codex backend authentication and availability provider."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from typing import Any, Dict, List
+
+from src.auth import BackendAuthProvider
+from src.backends.codex.constants import codex_bin
+
+
+class CodexAuthProvider(BackendAuthProvider):
+    """Codex app-server availability checks."""
+
+    @property
+    def name(self) -> str:
+        return "codex"
+
+    def validate(self) -> Dict[str, Any]:
+        binary_name = codex_bin()
+        binary = shutil.which(binary_name)
+        if binary:
+            return {
+                "valid": True,
+                "errors": [],
+                "config": {"mode": "app-server", "binary": binary},
+            }
+        return {
+            "valid": False,
+            "errors": ["codex binary not found on PATH"],
+            "config": {"mode": "app-server", "binary": binary_name},
+        }
+
+    def build_env(self) -> Dict[str, str]:
+        env: Dict[str, str] = {}
+        for key in (
+            "CODEX_BIN",
+            "CODEX_HOME",
+            "CODEX_MODELS",
+            "CODEX_APPROVAL_POLICY",
+            "CODEX_SANDBOX",
+            "CODEX_CONFIG_OVERRIDES",
+            "OPENAI_API_KEY",
+            "CODEX_API_KEY",
+        ):
+            value = os.getenv(key)
+            if value:
+                env[key] = value
+        return env
+
+    def get_isolation_vars(self) -> List[str]:
+        return ["ANTHROPIC_AUTH_TOKEN"]

--- a/src/backends/codex/client.py
+++ b/src/backends/codex/client.py
@@ -69,6 +69,9 @@ class CodexJsonRpcClient:
             args.extend(["--config", override])
         args.extend(["app-server", "--listen", "stdio://"])
 
+        # Inherit the gateway environment so Codex CLI auth/runtime settings
+        # such as OPENAI_API_KEY and CODEX_HOME remain available. Request
+        # metadata is allowlisted separately and overlaid below.
         proc_env = os.environ.copy()
         proc_env.update(self.env)
         self._proc = subprocess.Popen(  # noqa: S603 - binary is operator-configured
@@ -84,6 +87,9 @@ class CodexJsonRpcClient:
         )
         self._start_stderr_drain_thread()
         self._initialize()
+
+    def is_running(self) -> bool:
+        return self._proc is not None and self._proc.poll() is None
 
     def close(self) -> None:
         if self._proc is None:
@@ -251,9 +257,12 @@ class CodexSessionClient:
     model: Optional[str]
     cwd: Optional[str]
     stream_events: bool = False
+    env: Optional[Dict[str, str]] = None
+    owns_rpc: bool = False
 
     async def disconnect(self) -> None:
-        await asyncio.to_thread(self.rpc.close)
+        if self.owns_rpc:
+            await asyncio.to_thread(self.rpc.close)
 
 
 class CodexClient:
@@ -261,6 +270,9 @@ class CodexClient:
 
     def __init__(self, timeout: Optional[int] = None) -> None:
         self.timeout = (timeout if timeout is not None else DEFAULT_TIMEOUT_MS) / 1000
+        self._rpc: Optional[CodexJsonRpcClient] = None
+        self._rpc_env: Dict[str, str] = {}
+        self._rpc_lock = asyncio.Lock()
 
     @property
     def name(self) -> str:
@@ -278,7 +290,17 @@ class CodexClient:
             "models": self.supported_models(),
             "approval_policy": approval_policy(),
             "sandbox": sandbox_mode(),
+            "shared_process": self._rpc_is_usable(self._rpc),
         }
+
+    def close(self) -> None:
+        rpc = self._rpc
+        self._rpc = None
+        self._rpc_env = {}
+        if rpc is not None:
+            rpc.close()
+
+    shutdown = close
 
     async def verify(self) -> bool:
         rpc = CodexJsonRpcClient(
@@ -312,39 +334,80 @@ class CodexClient:
     ) -> CodexSessionClient:
         _ = (allowed_tools, disallowed_tools, permission_mode, mcp_servers, task_budget)
         env = self._metadata_env(extra_env)
-        rpc = CodexJsonRpcClient(
-            binary=codex_bin(),
+        async with self._rpc_lock:
+            try:
+                rpc = await self._ensure_rpc_locked(env)
+
+                params = self._thread_params(
+                    model=model,
+                    cwd=cwd,
+                    system_prompt=self._combine_system_prompt(_custom_base, system_prompt),
+                )
+                thread_id = getattr(session, "codex_thread_id", None)
+                if thread_id:
+                    await asyncio.to_thread(rpc.thread_resume, thread_id, params)
+                else:
+                    result = await asyncio.to_thread(
+                        rpc.thread_start,
+                        {**params, "serviceName": "oh-my-gateway"},
+                    )
+                    thread = result.get("thread")
+                    if not isinstance(thread, dict) or not thread.get("id"):
+                        raise CodexAppServerError("thread/start response missing thread.id")
+                    thread_id = str(thread["id"])
+                    setattr(session, "codex_thread_id", thread_id)
+            except Exception:
+                await self._close_rpc_locked()
+                raise
+
+        return CodexSessionClient(
+            rpc=rpc,
+            thread_id=thread_id,
+            model=model,
             cwd=cwd,
             env=env,
-            config_overrides=configured_config_overrides(),
-            read_timeout=self.timeout,
+            owns_rpc=False,
         )
-        try:
-            await asyncio.to_thread(rpc.start)
 
-            params = self._thread_params(
-                model=model,
-                cwd=cwd,
-                system_prompt=self._combine_system_prompt(_custom_base, system_prompt),
+    async def _ensure_rpc_locked(self, env: Dict[str, str]) -> CodexJsonRpcClient:
+        if self._rpc is not None and env != self._rpc_env:
+            await self._close_rpc_locked()
+
+        if not self._rpc_is_usable(self._rpc):
+            if self._rpc is not None:
+                await self._close_rpc_locked()
+            rpc = CodexJsonRpcClient(
+                binary=codex_bin(),
+                cwd=None,
+                env=env,
+                config_overrides=configured_config_overrides(),
+                read_timeout=self.timeout,
             )
-            thread_id = getattr(session, "codex_thread_id", None)
-            if thread_id:
-                await asyncio.to_thread(rpc.thread_resume, thread_id, params)
-            else:
-                result = await asyncio.to_thread(
-                    rpc.thread_start,
-                    {**params, "serviceName": "oh-my-gateway"},
-                )
-                thread = result.get("thread")
-                if not isinstance(thread, dict) or not thread.get("id"):
-                    raise CodexAppServerError("thread/start response missing thread.id")
-                thread_id = str(thread["id"])
-                setattr(session, "codex_thread_id", thread_id)
-        except Exception:
-            await asyncio.to_thread(rpc.close)
-            raise
+            try:
+                await asyncio.to_thread(rpc.start)
+            except Exception:
+                await asyncio.to_thread(rpc.close)
+                raise
+            self._rpc = rpc
+            self._rpc_env = dict(env)
 
-        return CodexSessionClient(rpc=rpc, thread_id=thread_id, model=model, cwd=cwd)
+        assert self._rpc is not None
+        return self._rpc
+
+    async def _close_rpc_locked(self) -> None:
+        rpc = self._rpc
+        self._rpc = None
+        self._rpc_env = {}
+        if rpc is not None:
+            await asyncio.to_thread(rpc.close)
+
+    def _rpc_is_usable(self, rpc: Optional[CodexJsonRpcClient]) -> bool:
+        if rpc is None:
+            return False
+        is_running = getattr(rpc, "is_running", None)
+        if callable(is_running):
+            return bool(is_running())
+        return not bool(getattr(rpc, "closed", False))
 
     def _metadata_env(self, extra_env: Optional[Dict[str, str]]) -> Dict[str, str]:
         if not extra_env:
@@ -396,35 +459,38 @@ class CodexClient:
         session: Any,
     ) -> AsyncGenerator[Dict[str, Any], None]:
         _ = session
-        try:
-            turn = await asyncio.to_thread(
-                client.rpc.turn_start,
-                client.thread_id,
-                [{"type": "text", "text": prompt}],
-                self._turn_params(client),
-            )
-            turn_obj = turn.get("turn")
-            if not isinstance(turn_obj, dict) or not turn_obj.get("id"):
-                yield {
-                    "type": "error",
-                    "is_error": True,
-                    "error_message": "turn/start response missing turn.id",
-                }
-                return
-            turn_id = str(turn_obj["id"])
-            notification_iter = self._notification_iterator(client.rpc, turn_id)
-            while True:
-                has_value, chunk = await asyncio.to_thread(
-                    self._next_chunk,
-                    notification_iter,
+        async with self._rpc_lock:
+            try:
+                rpc = await self._ensure_rpc_locked(client.env or {})
+                turn = await asyncio.to_thread(
+                    rpc.turn_start,
+                    client.thread_id,
+                    [{"type": "text", "text": prompt}],
+                    self._turn_params(client),
                 )
-                if not has_value:
-                    break
-                if chunk is not None:
-                    yield chunk
-        except Exception as exc:
-            logger.error("Codex app-server turn failed: %s", exc, exc_info=True)
-            yield {"type": "error", "is_error": True, "error_message": str(exc)}
+                turn_obj = turn.get("turn")
+                if not isinstance(turn_obj, dict) or not turn_obj.get("id"):
+                    yield {
+                        "type": "error",
+                        "is_error": True,
+                        "error_message": "turn/start response missing turn.id",
+                    }
+                    return
+                turn_id = str(turn_obj["id"])
+                notification_iter = self._notification_iterator(rpc, turn_id)
+                while True:
+                    has_value, chunk = await asyncio.to_thread(
+                        self._next_chunk,
+                        notification_iter,
+                    )
+                    if not has_value:
+                        break
+                    if chunk is not None:
+                        yield chunk
+            except Exception as exc:
+                await self._close_rpc_locked()
+                logger.error("Codex app-server turn failed: %s", exc, exc_info=True)
+                yield {"type": "error", "is_error": True, "error_message": str(exc)}
 
     @staticmethod
     def _next_chunk(iterator: Iterator[Dict[str, Any]]) -> tuple[bool, Optional[Dict[str, Any]]]:

--- a/src/backends/codex/client.py
+++ b/src/backends/codex/client.py
@@ -1,0 +1,604 @@
+"""Codex app-server backend client.
+
+The official Python SDK currently wraps the same ``codex app-server``
+JSON-RPC protocol.  The package is experimental and may not be available from
+PyPI, so this backend keeps a small protocol client in-tree for the MVP.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import select
+import subprocess
+import threading
+import uuid
+from collections import deque
+from dataclasses import dataclass
+from typing import Any, AsyncGenerator, Dict, Iterable, Iterator, List, Optional
+
+from src.backends.codex.auth import CodexAuthProvider
+from src.backends.codex.constants import (
+    CODEX_MODELS,
+    approval_policy,
+    codex_bin,
+    configured_config_overrides,
+    sandbox_mode,
+)
+from src.constants import DEFAULT_TIMEOUT_MS
+from src.message_adapter import MessageAdapter
+
+logger = logging.getLogger(__name__)
+
+
+class CodexAppServerError(RuntimeError):
+    """Raised when the Codex app-server JSON-RPC transport fails."""
+
+
+class CodexJsonRpcClient:
+    """Minimal JSON-RPC client for ``codex app-server --listen stdio://``."""
+
+    def __init__(
+        self,
+        *,
+        binary: Optional[str] = None,
+        cwd: Optional[str] = None,
+        env: Optional[Dict[str, str]] = None,
+        config_overrides: Optional[Iterable[str]] = None,
+        read_timeout: Optional[float] = None,
+    ) -> None:
+        self.binary = binary or codex_bin()
+        self.cwd = cwd
+        self.env = env or {}
+        self.config_overrides = list(config_overrides or [])
+        self.read_timeout = read_timeout
+        self._proc: Optional[subprocess.Popen[str]] = None
+        self._lock = threading.Lock()
+        self._pending_notifications: deque[dict[str, Any]] = deque()
+        self._stderr_lines: deque[str] = deque(maxlen=400)
+        self._stderr_thread: Optional[threading.Thread] = None
+
+    def start(self) -> None:
+        if self._proc is not None:
+            return
+        args = [self.binary]
+        for override in self.config_overrides:
+            args.extend(["--config", override])
+        args.extend(["app-server", "--listen", "stdio://"])
+
+        proc_env = os.environ.copy()
+        proc_env.update(self.env)
+        self._proc = subprocess.Popen(  # noqa: S603 - binary is operator-configured
+            args,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            cwd=self.cwd,
+            env=proc_env,
+            bufsize=1,
+        )
+        self._start_stderr_drain_thread()
+        self._initialize()
+
+    def close(self) -> None:
+        if self._proc is None:
+            return
+        proc = self._proc
+        self._proc = None
+        if proc.stdin:
+            with contextlib.suppress(Exception):
+                proc.stdin.close()
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=2)
+        if self._stderr_thread and self._stderr_thread.is_alive():
+            self._stderr_thread.join(timeout=0.5)
+
+    def _initialize(self) -> None:
+        self.request(
+            "initialize",
+            {
+                "clientInfo": {
+                    "name": "oh_my_gateway",
+                    "title": "Oh My Gateway",
+                    "version": "0",
+                },
+                "capabilities": {"experimentalApi": True},
+            },
+        )
+        self.notify("initialized", {})
+
+    def request(self, method: str, params: Optional[Dict[str, Any]] = None) -> Any:
+        request_id = str(uuid.uuid4())
+        self._write_message({"id": request_id, "method": method, "params": params or {}})
+        while True:
+            msg = self._read_message()
+            if "method" in msg and "id" in msg:
+                self._write_message({"id": msg["id"], "result": self._handle_server_request(msg)})
+                continue
+            if "method" in msg and "id" not in msg:
+                self._pending_notifications.append(msg)
+                continue
+            if msg.get("id") != request_id:
+                continue
+            if "error" in msg:
+                error = msg["error"]
+                if isinstance(error, dict):
+                    raise CodexAppServerError(str(error.get("message", "Codex app-server error")))
+                raise CodexAppServerError("Codex app-server error")
+            return msg.get("result")
+
+    def notify(self, method: str, params: Optional[Dict[str, Any]] = None) -> None:
+        self._write_message({"method": method, "params": params or {}})
+
+    def next_notification(self) -> dict[str, Any]:
+        if self._pending_notifications:
+            return self._pending_notifications.popleft()
+        while True:
+            msg = self._read_message()
+            if "method" in msg and "id" in msg:
+                self._write_message({"id": msg["id"], "result": self._handle_server_request(msg)})
+                continue
+            if "method" in msg and "id" not in msg:
+                return msg
+
+    def thread_start(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        result = self.request("thread/start", params)
+        if not isinstance(result, dict):
+            raise CodexAppServerError("thread/start response must be an object")
+        return result
+
+    def thread_resume(self, thread_id: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        result = self.request("thread/resume", {"threadId": thread_id, **params})
+        if not isinstance(result, dict):
+            raise CodexAppServerError("thread/resume response must be an object")
+        return result
+
+    def turn_start(
+        self,
+        thread_id: str,
+        input_items: list[Dict[str, Any]],
+        params: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        result = self.request(
+            "turn/start",
+            {"threadId": thread_id, "input": input_items, **params},
+        )
+        if not isinstance(result, dict):
+            raise CodexAppServerError("turn/start response must be an object")
+        return result
+
+    def model_list(self) -> Dict[str, Any]:
+        result = self.request("model/list", {"includeHidden": False})
+        if not isinstance(result, dict):
+            raise CodexAppServerError("model/list response must be an object")
+        return result
+
+    def _handle_server_request(self, msg: dict[str, Any]) -> dict[str, Any]:
+        method = msg.get("method")
+        if method in {
+            "item/commandExecution/requestApproval",
+            "item/fileChange/requestApproval",
+        }:
+            return {"decision": "cancel"}
+        if method == "item/permissions/requestApproval":
+            return {"permissions": {}, "scope": "turn"}
+        return {}
+
+    def _write_message(self, payload: Dict[str, Any]) -> None:
+        if self._proc is None or self._proc.stdin is None:
+            raise CodexAppServerError("Codex app-server is not running")
+        with self._lock:
+            self._proc.stdin.write(json.dumps(payload) + "\n")
+            self._proc.stdin.flush()
+
+    def _read_message(self) -> Dict[str, Any]:
+        if self._proc is None or self._proc.stdout is None:
+            raise CodexAppServerError("Codex app-server is not running")
+        stdout = self._proc.stdout
+        if self.read_timeout is not None:
+            readable, _, _ = select.select([stdout], [], [], self.read_timeout)
+            if not readable:
+                raise CodexAppServerError(
+                    "Timed out waiting for Codex app-server message "
+                    f"after {self.read_timeout:.3g}s. stderr_tail={self._stderr_tail()[:2000]}"
+                )
+        line = stdout.readline()
+        if not line:
+            raise CodexAppServerError(
+                f"Codex app-server closed stdout. stderr_tail={self._stderr_tail()[:2000]}"
+            )
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise CodexAppServerError(f"Invalid Codex JSON-RPC line: {line!r}") from exc
+        if not isinstance(message, dict):
+            raise CodexAppServerError(f"Invalid Codex JSON-RPC payload: {message!r}")
+        return message
+
+    def _start_stderr_drain_thread(self) -> None:
+        if self._proc is None or self._proc.stderr is None:
+            return
+
+        def _drain() -> None:
+            if self._proc is None or self._proc.stderr is None:
+                return
+            for line in self._proc.stderr:
+                self._stderr_lines.append(line.rstrip("\n"))
+
+        self._stderr_thread = threading.Thread(target=_drain, daemon=True)
+        self._stderr_thread.start()
+
+    def _stderr_tail(self, limit: int = 40) -> str:
+        return "\n".join(list(self._stderr_lines)[-limit:])
+
+
+@dataclass
+class CodexSessionClient:
+    """Handle for one gateway session mapped to one Codex thread."""
+
+    rpc: CodexJsonRpcClient
+    thread_id: str
+    model: Optional[str]
+    cwd: Optional[str]
+    stream_events: bool = False
+
+    async def disconnect(self) -> None:
+        await asyncio.to_thread(self.rpc.close)
+
+
+class CodexClient:
+    """BackendClient implementation for local Codex app-server."""
+
+    def __init__(self, timeout: Optional[int] = None) -> None:
+        self.timeout = (timeout if timeout is not None else DEFAULT_TIMEOUT_MS) / 1000
+
+    @property
+    def name(self) -> str:
+        return "codex"
+
+    def supported_models(self) -> List[str]:
+        return list(CODEX_MODELS)
+
+    def get_auth_provider(self) -> CodexAuthProvider:
+        return CodexAuthProvider()
+
+    def runtime_metadata(self) -> Dict[str, Any]:
+        return {
+            "mode": "app-server",
+            "models": self.supported_models(),
+            "approval_policy": approval_policy(),
+            "sandbox": sandbox_mode(),
+        }
+
+    async def verify(self) -> bool:
+        rpc = CodexJsonRpcClient(
+            config_overrides=configured_config_overrides(),
+            read_timeout=self.timeout,
+        )
+        try:
+            await asyncio.to_thread(rpc.start)
+            payload = await asyncio.to_thread(rpc.model_list)
+            return isinstance(payload.get("data"), list)
+        except Exception as exc:
+            logger.error("Codex backend verification failed: %s", exc)
+            return False
+        finally:
+            await asyncio.to_thread(rpc.close)
+
+    async def create_client(
+        self,
+        *,
+        session: Any,
+        model: Optional[str] = None,
+        system_prompt: Optional[str] = None,
+        allowed_tools: Optional[List[str]] = None,
+        disallowed_tools: Optional[List[str]] = None,
+        permission_mode: Optional[str] = None,
+        mcp_servers: Optional[Dict[str, Any]] = None,
+        task_budget: Optional[int] = None,
+        cwd: Optional[str] = None,
+        extra_env: Optional[Dict[str, str]] = None,
+        _custom_base: Any = None,
+    ) -> CodexSessionClient:
+        _ = (allowed_tools, disallowed_tools, permission_mode, mcp_servers, task_budget)
+        env = self._metadata_env(extra_env)
+        rpc = CodexJsonRpcClient(
+            binary=codex_bin(),
+            cwd=cwd,
+            env=env,
+            config_overrides=configured_config_overrides(),
+            read_timeout=self.timeout,
+        )
+        try:
+            await asyncio.to_thread(rpc.start)
+
+            params = self._thread_params(
+                model=model,
+                cwd=cwd,
+                system_prompt=self._combine_system_prompt(_custom_base, system_prompt),
+            )
+            thread_id = getattr(session, "codex_thread_id", None)
+            if thread_id:
+                await asyncio.to_thread(rpc.thread_resume, thread_id, params)
+            else:
+                result = await asyncio.to_thread(
+                    rpc.thread_start,
+                    {**params, "serviceName": "oh-my-gateway"},
+                )
+                thread = result.get("thread")
+                if not isinstance(thread, dict) or not thread.get("id"):
+                    raise CodexAppServerError("thread/start response missing thread.id")
+                thread_id = str(thread["id"])
+                setattr(session, "codex_thread_id", thread_id)
+        except Exception:
+            await asyncio.to_thread(rpc.close)
+            raise
+
+        return CodexSessionClient(rpc=rpc, thread_id=thread_id, model=model, cwd=cwd)
+
+    def _metadata_env(self, extra_env: Optional[Dict[str, str]]) -> Dict[str, str]:
+        if not extra_env:
+            return {}
+        from src.constants import METADATA_ENV_ALLOWLIST
+
+        return {k: v for k, v in extra_env.items() if k in METADATA_ENV_ALLOWLIST}
+
+    def _combine_system_prompt(
+        self,
+        custom_base: Optional[str],
+        system_prompt: Optional[str],
+    ) -> Optional[str]:
+        if custom_base and system_prompt:
+            return f"{custom_base}\n\n{system_prompt}"
+        return custom_base or system_prompt
+
+    def _thread_params(
+        self,
+        *,
+        model: Optional[str],
+        cwd: Optional[str],
+        system_prompt: Optional[str],
+    ) -> Dict[str, Any]:
+        params: Dict[str, Any] = {
+            "approvalPolicy": approval_policy(),
+            "sandbox": sandbox_mode(),
+        }
+        if model:
+            params["model"] = model
+        if cwd:
+            params["cwd"] = cwd
+        if system_prompt:
+            params["developerInstructions"] = system_prompt
+        return params
+
+    def _turn_params(self, client: CodexSessionClient) -> Dict[str, Any]:
+        params: Dict[str, Any] = {"approvalPolicy": approval_policy()}
+        if client.model:
+            params["model"] = client.model
+        if client.cwd:
+            params["cwd"] = client.cwd
+        return params
+
+    async def run_completion_with_client(
+        self,
+        client: CodexSessionClient,
+        prompt: str,
+        session: Any,
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        _ = session
+        try:
+            turn = await asyncio.to_thread(
+                client.rpc.turn_start,
+                client.thread_id,
+                [{"type": "text", "text": prompt}],
+                self._turn_params(client),
+            )
+            turn_obj = turn.get("turn")
+            if not isinstance(turn_obj, dict) or not turn_obj.get("id"):
+                yield {
+                    "type": "error",
+                    "is_error": True,
+                    "error_message": "turn/start response missing turn.id",
+                }
+                return
+            turn_id = str(turn_obj["id"])
+            notification_iter = self._notification_iterator(client.rpc, turn_id)
+            while True:
+                has_value, chunk = await asyncio.to_thread(
+                    self._next_chunk,
+                    notification_iter,
+                )
+                if not has_value:
+                    break
+                if chunk is not None:
+                    yield chunk
+        except Exception as exc:
+            logger.error("Codex app-server turn failed: %s", exc, exc_info=True)
+            yield {"type": "error", "is_error": True, "error_message": str(exc)}
+
+    @staticmethod
+    def _next_chunk(iterator: Iterator[Dict[str, Any]]) -> tuple[bool, Optional[Dict[str, Any]]]:
+        try:
+            return True, next(iterator)
+        except StopIteration:
+            return False, None
+
+    def _notification_iterator(
+        self,
+        rpc: CodexJsonRpcClient,
+        turn_id: str,
+    ) -> Iterator[Dict[str, Any]]:
+        items: list[dict[str, Any]] = []
+        usage_box: dict[str, Optional[dict[str, int]]] = {"usage": None}
+        while True:
+            notification = rpc.next_notification()
+            yield from self._chunks_from_notification(
+                turn_id=turn_id,
+                notification=notification,
+                items=items,
+                usage_box=usage_box,
+            )
+            if (
+                notification.get("method") == "turn/completed"
+                and (notification.get("params") or {}).get("turn", {}).get("id") == turn_id
+            ):
+                break
+
+    def _chunks_from_notifications(
+        self,
+        *,
+        turn_id: str,
+        notifications: Iterable[Dict[str, Any]],
+    ) -> Iterator[Dict[str, Any]]:
+        items: list[dict[str, Any]] = []
+        usage_box: dict[str, Optional[dict[str, int]]] = {"usage": None}
+        for notification in notifications:
+            yield from self._chunks_from_notification(
+                turn_id=turn_id,
+                notification=notification,
+                items=items,
+                usage_box=usage_box,
+            )
+
+    def _chunks_from_notification(
+        self,
+        *,
+        turn_id: str,
+        notification: Dict[str, Any],
+        items: list[dict[str, Any]],
+        usage_box: dict[str, Optional[dict[str, int]]],
+    ) -> Iterator[Dict[str, Any]]:
+        method = notification.get("method")
+        params = notification.get("params") if isinstance(notification, dict) else None
+        if not isinstance(params, dict):
+            return
+
+        notification_turn_id = params.get("turnId")
+        turn = params.get("turn")
+        if isinstance(turn, dict):
+            notification_turn_id = turn.get("id")
+
+        if notification_turn_id != turn_id:
+            return
+
+        if method == "item/agentMessage/delta":
+            delta = params.get("delta")
+            if isinstance(delta, str) and delta:
+                yield {
+                    "type": "stream_event",
+                    "event": {
+                        "type": "content_block_delta",
+                        "delta": {"type": "text_delta", "text": delta},
+                    },
+                }
+            return
+
+        if method == "item/completed":
+            item = params.get("item")
+            if isinstance(item, dict):
+                items.append(item)
+            return
+
+        if method == "thread/tokenUsage/updated":
+            usage_box["usage"] = self._extract_usage(params.get("tokenUsage"))
+            return
+
+        if method != "turn/completed":
+            return
+
+        if isinstance(turn, dict) and turn.get("status") == "failed":
+            yield {
+                "type": "error",
+                "is_error": True,
+                "error_message": self._turn_error_message(turn),
+            }
+            return
+
+        final_text = self._final_response_from_items(items)
+        if not final_text:
+            return
+
+        assistant: Dict[str, Any] = {
+            "type": "assistant",
+            "content": [{"type": "text", "text": final_text}],
+        }
+        result: Dict[str, Any] = {
+            "type": "result",
+            "subtype": "success",
+            "result": final_text,
+        }
+        usage = usage_box.get("usage")
+        if usage:
+            assistant["usage"] = usage
+            result["usage"] = usage
+        yield assistant
+        yield result
+
+    def _extract_usage(self, token_usage: Any) -> Optional[dict[str, int]]:
+        if not isinstance(token_usage, dict):
+            return None
+        last = token_usage.get("last")
+        if not isinstance(last, dict):
+            return None
+        input_tokens = int(last.get("inputTokens") or 0) + int(last.get("cachedInputTokens") or 0)
+        output_tokens = int(last.get("outputTokens") or 0)
+        return {"input_tokens": input_tokens, "output_tokens": output_tokens}
+
+    def _turn_error_message(self, turn: dict[str, Any]) -> str:
+        error = turn.get("error")
+        if isinstance(error, dict) and error.get("message"):
+            return str(error["message"])
+        return "Codex turn failed"
+
+    def _final_response_from_items(self, items: list[dict[str, Any]]) -> Optional[str]:
+        last_unknown_phase: Optional[str] = None
+        for item in reversed(items):
+            if item.get("type") != "agentMessage":
+                continue
+            text = item.get("text")
+            if not isinstance(text, str):
+                continue
+            if item.get("phase") == "final_answer":
+                return text
+            if item.get("phase") is None and last_unknown_phase is None:
+                last_unknown_phase = text
+        return last_unknown_phase
+
+    def parse_message(self, messages: List[Dict[str, Any]]) -> Optional[str]:
+        for message in reversed(messages):
+            if message.get("subtype") == "success" and isinstance(message.get("result"), str):
+                result = message["result"]
+                if result.strip():
+                    return result
+        parts = []
+        for message in messages:
+            if message.get("type") == "assistant" and isinstance(message.get("content"), list):
+                text = MessageAdapter.format_blocks(message["content"])
+                if text:
+                    parts.append(text)
+        return "\n".join(parts) if parts else None
+
+    def estimate_token_usage(
+        self,
+        prompt: str,
+        completion: str,
+        model: Optional[str] = None,
+    ) -> Dict[str, int]:
+        _ = model
+        prompt_tokens = max(1, len(prompt) // 4)
+        completion_tokens = max(1, len(completion) // 4)
+        return {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        }

--- a/src/backends/codex/constants.py
+++ b/src/backends/codex/constants.py
@@ -1,0 +1,52 @@
+"""Codex backend constants and environment parsing."""
+
+from __future__ import annotations
+
+import os
+
+
+def _parse_csv(value: str) -> list[str]:
+    """Parse comma-separated environment values, preserving order."""
+    items: list[str] = []
+    for raw_item in value.split(","):
+        item = raw_item.strip()
+        if item and item not in items:
+            items.append(item)
+    return items
+
+
+def configured_provider_models() -> list[str]:
+    """Return Codex model IDs configured for model listing."""
+    return _parse_csv(os.getenv("CODEX_MODELS", "gpt-5.5"))
+
+
+def configured_public_models() -> list[str]:
+    """Return public wrapper model IDs for configured Codex models."""
+    return [f"codex/{model}" for model in configured_provider_models()]
+
+
+def configured_config_overrides() -> list[str]:
+    """Return Codex CLI ``--config`` overrides from CODEX_CONFIG_OVERRIDES."""
+    return _parse_csv(os.getenv("CODEX_CONFIG_OVERRIDES", ""))
+
+
+def codex_bin() -> str:
+    return os.getenv("CODEX_BIN", "codex")
+
+
+def approval_policy() -> str:
+    return os.getenv("CODEX_APPROVAL_POLICY", "never").strip() or "never"
+
+
+def sandbox_mode() -> str:
+    raw = os.getenv("CODEX_SANDBOX", "workspace-write").strip() or "workspace-write"
+    legacy_aliases = {
+        "readOnly": "read-only",
+        "workspaceWrite": "workspace-write",
+        "dangerFullAccess": "danger-full-access",
+    }
+    return legacy_aliases.get(raw, raw)
+
+
+CODEX_PROVIDER_MODELS = configured_provider_models()
+CODEX_MODELS = configured_public_models()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,8 +28,10 @@ def register_all_descriptors():
     need descriptors before registering fake backends.
     """
     from src.backends.claude import CLAUDE_DESCRIPTOR
+    from src.backends.codex import CODEX_DESCRIPTOR
 
     BackendRegistry.register_descriptor(CLAUDE_DESCRIPTOR)
+    BackendRegistry.register_descriptor(CODEX_DESCRIPTOR)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_backends_init_unit.py
+++ b/tests/test_backends_init_unit.py
@@ -106,6 +106,23 @@ class TestDiscoverBackends:
 
         assert calls == [("claude", "registry"), ("opencode", "registry")]
 
+    def test_discover_backends_registers_codex_from_backends_env(self, monkeypatch):
+        """BACKENDS=codex dispatches to the Codex backend package."""
+        import src.backends.codex as codex_pkg
+
+        calls = []
+
+        monkeypatch.setenv("BACKENDS", "codex")
+        monkeypatch.setattr(
+            codex_pkg, "register", lambda registry_cls=None: calls.append(registry_cls)
+        )
+
+        from src.backends import discover_backends
+
+        discover_backends(registry_cls="registry")
+
+        assert calls == ["registry"]
+
     def test_discover_backends_defaults_to_claude_only(self, monkeypatch):
         """Unset BACKENDS preserves current Claude-only startup behavior."""
         import src.backends.claude as claude_pkg
@@ -114,7 +131,9 @@ class TestDiscoverBackends:
         calls = []
 
         monkeypatch.delenv("BACKENDS", raising=False)
-        monkeypatch.setattr(claude_pkg, "register", lambda registry_cls=None: calls.append("claude"))
+        monkeypatch.setattr(
+            claude_pkg, "register", lambda registry_cls=None: calls.append("claude")
+        )
         monkeypatch.setattr(
             opencode_pkg, "register", lambda registry_cls=None: calls.append("opencode")
         )
@@ -134,7 +153,9 @@ class TestDiscoverBackends:
         calls = []
 
         monkeypatch.setenv("BACKENDS", "unknown,opencode")
-        monkeypatch.setattr(claude_pkg, "register", lambda registry_cls=None: calls.append("claude"))
+        monkeypatch.setattr(
+            claude_pkg, "register", lambda registry_cls=None: calls.append("claude")
+        )
         monkeypatch.setattr(
             opencode_pkg, "register", lambda registry_cls=None: calls.append("opencode")
         )

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -1,0 +1,385 @@
+"""Codex backend tests."""
+
+import asyncio
+import importlib
+import subprocess
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+
+def test_codex_descriptor_resolves_prefixed_models(monkeypatch):
+    """Codex descriptor resolves codex/<model> IDs without claiming bare models."""
+    monkeypatch.setenv("CODEX_MODELS", "gpt-5.5,gpt-5.3-codex")
+
+    import src.backends.codex as codex_pkg
+
+    codex_pkg = importlib.reload(codex_pkg)
+
+    resolved = codex_pkg.CODEX_DESCRIPTOR.resolve_fn("codex/gpt-5.5")
+
+    assert resolved is not None
+    assert resolved.public_model == "codex/gpt-5.5"
+    assert resolved.backend == "codex"
+    assert resolved.provider_model == "gpt-5.5"
+    assert codex_pkg.CODEX_DESCRIPTOR.models == ["codex/gpt-5.5", "codex/gpt-5.3-codex"]
+    assert codex_pkg.CODEX_DESCRIPTOR.resolve_fn("gpt-5.5") is None
+    assert codex_pkg.CODEX_DESCRIPTOR.resolve_fn("codex/") is None
+
+
+def test_codex_auth_provider_validates_binary(monkeypatch):
+    """Codex auth is valid when the local codex binary is available."""
+    monkeypatch.setattr("src.backends.codex.auth.shutil.which", lambda name: "/bin/codex")
+    monkeypatch.setenv("CODEX_BIN", "codex")
+
+    from src.backends.codex.auth import CodexAuthProvider
+
+    status = CodexAuthProvider().validate()
+
+    assert status["valid"] is True
+    assert status["errors"] == []
+    assert status["config"] == {"mode": "app-server", "binary": "/bin/codex"}
+
+
+def test_codex_auth_provider_reports_missing_binary(monkeypatch):
+    """Auth diagnostics report when Codex CLI is unavailable."""
+    monkeypatch.setattr("src.backends.codex.auth.shutil.which", lambda name: None)
+    monkeypatch.setenv("CODEX_BIN", "codex-missing")
+
+    from src.backends.codex.auth import CodexAuthProvider
+
+    status = CodexAuthProvider().validate()
+
+    assert status["valid"] is False
+    assert status["errors"] == ["codex binary not found on PATH"]
+    assert status["config"] == {"mode": "app-server", "binary": "codex-missing"}
+
+
+def test_codex_auth_env_includes_codex_settings(monkeypatch):
+    """Backend env diagnostics expose Codex-specific runtime settings."""
+    monkeypatch.setenv("CODEX_BIN", "/opt/codex")
+    monkeypatch.setenv("CODEX_HOME", "/tmp/codex-home")
+    monkeypatch.setenv("CODEX_APPROVAL_POLICY", "never")
+    monkeypatch.setenv("CODEX_SANDBOX", "workspaceWrite")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    from src.backends.codex.auth import CodexAuthProvider
+
+    env = CodexAuthProvider().build_env()
+
+    assert env["CODEX_BIN"] == "/opt/codex"
+    assert env["CODEX_HOME"] == "/tmp/codex-home"
+    assert env["CODEX_APPROVAL_POLICY"] == "never"
+    assert env["CODEX_SANDBOX"] == "workspaceWrite"
+    assert env["OPENAI_API_KEY"] == "sk-test"
+
+
+def test_codex_sandbox_mode_uses_cli_enum_and_normalizes_legacy_aliases(monkeypatch):
+    """Codex sandbox values sent to app-server match the current CLI schema."""
+    from src.backends.codex.constants import sandbox_mode
+
+    monkeypatch.delenv("CODEX_SANDBOX", raising=False)
+    assert sandbox_mode() == "workspace-write"
+
+    monkeypatch.setenv("CODEX_SANDBOX", "workspaceWrite")
+    assert sandbox_mode() == "workspace-write"
+
+    monkeypatch.setenv("CODEX_SANDBOX", "readOnly")
+    assert sandbox_mode() == "read-only"
+
+    monkeypatch.setenv("CODEX_SANDBOX", "dangerFullAccess")
+    assert sandbox_mode() == "danger-full-access"
+
+
+class FakeRpc:
+    def __init__(self):
+        self.closed = False
+        self.thread_start_calls = []
+        self.thread_resume_calls = []
+        self.turn_start_calls = []
+        self.notifications = []
+
+    def start(self):
+        pass
+
+    def close(self):
+        self.closed = True
+
+    def thread_start(self, params):
+        self.thread_start_calls.append(params)
+        return {"thread": {"id": "thr_codex"}}
+
+    def thread_resume(self, thread_id, params):
+        self.thread_resume_calls.append((thread_id, params))
+        return {"thread": {"id": thread_id}}
+
+    def turn_start(self, thread_id, input_items, params):
+        self.turn_start_calls.append((thread_id, input_items, params))
+        return {"turn": {"id": "turn_1", "status": "inProgress"}}
+
+    def next_notification(self):
+        if not self.notifications:
+            raise AssertionError("test exhausted notifications")
+        return self.notifications.pop(0)
+
+
+@pytest.mark.asyncio
+async def test_codex_client_starts_thread_and_converts_completed_turn(monkeypatch, tmp_path):
+    """Codex client converts app-server final agent messages into gateway chunks."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = [
+        {
+            "method": "item/agentMessage/delta",
+            "params": {
+                "threadId": "thr_codex",
+                "turnId": "turn_1",
+                "itemId": "item_1",
+                "delta": "Hello",
+            },
+        },
+        {
+            "method": "item/completed",
+            "params": {
+                "threadId": "thr_codex",
+                "turnId": "turn_1",
+                "item": {
+                    "type": "agentMessage",
+                    "id": "item_1",
+                    "phase": "final_answer",
+                    "text": "Hello from Codex",
+                },
+            },
+        },
+        {
+            "method": "thread/tokenUsage/updated",
+            "params": {
+                "threadId": "thr_codex",
+                "turnId": "turn_1",
+                "tokenUsage": {
+                    "last": {
+                        "inputTokens": 3,
+                        "cachedInputTokens": 0,
+                        "outputTokens": 4,
+                        "reasoningOutputTokens": 1,
+                        "totalTokens": 8,
+                    },
+                    "total": {
+                        "inputTokens": 3,
+                        "cachedInputTokens": 0,
+                        "outputTokens": 4,
+                        "reasoningOutputTokens": 1,
+                        "totalTokens": 8,
+                    },
+                },
+            },
+        },
+        {
+            "method": "turn/completed",
+            "params": {
+                "threadId": "thr_codex",
+                "turn": {"id": "turn_1", "status": "completed", "items": []},
+            },
+        },
+    ]
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session")
+    client = await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        system_prompt="extra instructions",
+        cwd=str(tmp_path),
+    )
+    chunks = [
+        chunk async for chunk in backend.run_completion_with_client(client, "say hello", session)
+    ]
+
+    assert fake_rpc.thread_start_calls == [
+        {
+            "model": "gpt-5.5",
+            "cwd": str(tmp_path),
+            "approvalPolicy": "never",
+            "sandbox": "workspace-write",
+            "developerInstructions": "extra instructions",
+            "serviceName": "oh-my-gateway",
+        }
+    ]
+    assert fake_rpc.turn_start_calls == [
+        (
+            "thr_codex",
+            [{"type": "text", "text": "say hello"}],
+            {"model": "gpt-5.5", "cwd": str(tmp_path), "approvalPolicy": "never"},
+        )
+    ]
+    assert chunks[0] == {
+        "type": "stream_event",
+        "event": {
+            "type": "content_block_delta",
+            "delta": {"type": "text_delta", "text": "Hello"},
+        },
+    }
+    assert chunks[-2]["content"] == [{"type": "text", "text": "Hello from Codex"}]
+    assert chunks[-2]["usage"] == {"input_tokens": 3, "output_tokens": 4}
+    assert chunks[-1]["type"] == "result"
+    assert chunks[-1]["result"] == "Hello from Codex"
+    assert backend.parse_message(chunks) == "Hello from Codex"
+    assert getattr(session, "codex_thread_id") == "thr_codex"
+
+    await client.disconnect()
+    assert fake_rpc.closed is True
+
+
+@pytest.mark.asyncio
+async def test_codex_client_reuses_session_thread(monkeypatch):
+    """Existing gateway sessions resume the stored Codex thread id."""
+    fake_rpc = FakeRpc()
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", codex_thread_id="thr_existing")
+
+    client = await backend.create_client(session=session, model="gpt-5.5")
+
+    assert client.thread_id == "thr_existing"
+    assert fake_rpc.thread_start_calls == []
+    assert fake_rpc.thread_resume_calls == [
+        (
+            "thr_existing",
+            {"model": "gpt-5.5", "approvalPolicy": "never", "sandbox": "workspace-write"},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_codex_client_closes_rpc_when_thread_start_fails(monkeypatch):
+    """Partially-created Codex subprocesses are closed when thread setup fails."""
+
+    class FailingThreadStartRpc(FakeRpc):
+        def thread_start(self, params):
+            self.thread_start_calls.append(params)
+            raise RuntimeError("thread start failed")
+
+    fake_rpc = FailingThreadStartRpc()
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session")
+
+    with pytest.raises(RuntimeError, match="thread start failed"):
+        await backend.create_client(session=session, model="gpt-5.5")
+
+    assert fake_rpc.closed is True
+
+
+@pytest.mark.asyncio
+async def test_codex_client_filters_metadata_env(monkeypatch):
+    """Only allowlisted metadata keys are passed to the Codex subprocess env."""
+    fake_rpc = FakeRpc()
+    created_kwargs = {}
+
+    def fake_factory(**kwargs):
+        created_kwargs.update(kwargs)
+        return fake_rpc
+
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", fake_factory)
+    monkeypatch.setattr("src.constants.METADATA_ENV_ALLOWLIST", frozenset({"SAFE_ENV"}))
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session")
+
+    await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        extra_env={"SAFE_ENV": "1", "DROP_ENV": "2"},
+    )
+
+    assert created_kwargs["env"] == {"SAFE_ENV": "1"}
+
+
+def test_codex_client_reports_failed_turn():
+    """Failed Codex turns become gateway backend error chunks."""
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    chunks = list(
+        backend._chunks_from_notifications(
+            turn_id="turn_1",
+            notifications=[
+                {
+                    "method": "turn/completed",
+                    "params": {
+                        "turn": {
+                            "id": "turn_1",
+                            "status": "failed",
+                            "error": {"message": "auth failed"},
+                        }
+                    },
+                }
+            ],
+        )
+    )
+
+    assert chunks == [{"type": "error", "is_error": True, "error_message": "auth failed"}]
+
+
+def test_codex_json_rpc_client_times_out_waiting_for_message():
+    """JSON-RPC reads fail fast instead of blocking forever on silent app-server."""
+    from src.backends.codex.client import CodexAppServerError, CodexJsonRpcClient
+
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(5)"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+    )
+    rpc = CodexJsonRpcClient(read_timeout=0.01)
+    rpc._proc = proc
+    try:
+        with pytest.raises(CodexAppServerError, match="Timed out waiting"):
+            rpc._read_message()
+    finally:
+        rpc.close()
+
+
+def test_codex_json_rpc_client_does_not_auto_accept_approval_requests():
+    """Approval requests are cancelled until the gateway has an explicit approval flow."""
+    from src.backends.codex.client import CodexJsonRpcClient
+
+    rpc = CodexJsonRpcClient()
+
+    assert rpc._handle_server_request(
+        {"method": "item/commandExecution/requestApproval"}
+    ) == {"decision": "cancel"}
+    assert rpc._handle_server_request({"method": "item/fileChange/requestApproval"}) == {
+        "decision": "cancel"
+    }
+    assert rpc._handle_server_request({"method": "item/permissions/requestApproval"}) == {
+        "permissions": {},
+        "scope": "turn",
+    }
+
+
+@pytest.mark.asyncio
+async def test_codex_session_disconnect_is_async(monkeypatch):
+    """Session cleanup can await Codex session disconnect."""
+    fake_rpc = FakeRpc()
+
+    from src.backends.codex.client import CodexSessionClient
+
+    client = CodexSessionClient(rpc=fake_rpc, thread_id="thr", model=None, cwd=None)
+
+    await asyncio.wait_for(client.disconnect(), timeout=1)
+
+    assert fake_rpc.closed is True

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -230,7 +230,45 @@ async def test_codex_client_starts_thread_and_converts_completed_turn(monkeypatc
     assert getattr(session, "codex_thread_id") == "thr_codex"
 
     await client.disconnect()
+    assert fake_rpc.closed is False
+    backend.close()
     assert fake_rpc.closed is True
+
+
+@pytest.mark.asyncio
+async def test_codex_client_reuses_shared_rpc_process(monkeypatch):
+    """One Codex backend process is reused across gateway sessions."""
+    created = []
+
+    def fake_factory(**kwargs):
+        rpc = FakeRpc()
+        created.append((rpc, kwargs))
+        return rpc
+
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", fake_factory)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session_one = SimpleNamespace(session_id="gw-session-1")
+    session_two = SimpleNamespace(session_id="gw-session-2")
+
+    client_one = await backend.create_client(session=session_one, model="gpt-5.5")
+    client_two = await backend.create_client(session=session_two, model="gpt-5.5")
+
+    assert client_one.thread_id == "thr_codex"
+    assert client_two.thread_id == "thr_codex"
+    assert len(created) == 1
+    rpc, kwargs = created[0]
+    assert kwargs["cwd"] is None
+    assert len(rpc.thread_start_calls) == 2
+
+    await client_one.disconnect()
+    await client_two.disconnect()
+    assert rpc.closed is False
+
+    backend.close()
+    assert rpc.closed is True
 
 
 @pytest.mark.asyncio
@@ -277,6 +315,43 @@ async def test_codex_client_closes_rpc_when_thread_start_fails(monkeypatch):
         await backend.create_client(session=session, model="gpt-5.5")
 
     assert fake_rpc.closed is True
+
+
+@pytest.mark.asyncio
+async def test_codex_client_restarts_shared_rpc_after_turn_error(monkeypatch):
+    """Transport failures close the shared app-server so the next request restarts it."""
+
+    class FailingTurnRpc(FakeRpc):
+        def turn_start(self, thread_id, input_items, params):
+            self.turn_start_calls.append((thread_id, input_items, params))
+            raise RuntimeError("transport failed")
+
+    created = []
+
+    def fake_factory(**kwargs):
+        rpc = FailingTurnRpc() if not created else FakeRpc()
+        created.append(rpc)
+        return rpc
+
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", fake_factory)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session")
+    client = await backend.create_client(session=session, model="gpt-5.5")
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "hi", session)]
+
+    assert chunks == [
+        {"type": "error", "is_error": True, "error_message": "transport failed"}
+    ]
+    assert created[0].closed is True
+
+    await backend.create_client(session=SimpleNamespace(session_id="gw-session-2"), model="gpt-5.5")
+
+    assert len(created) == 2
+    assert created[1].closed is False
 
 
 @pytest.mark.asyncio
@@ -373,7 +448,7 @@ def test_codex_json_rpc_client_does_not_auto_accept_approval_requests():
 
 @pytest.mark.asyncio
 async def test_codex_session_disconnect_is_async(monkeypatch):
-    """Session cleanup can await Codex session disconnect."""
+    """Session cleanup can await Codex handles without closing shared backend RPC."""
     fake_rpc = FakeRpc()
 
     from src.backends.codex.client import CodexSessionClient
@@ -382,4 +457,4 @@ async def test_codex_session_disconnect_is_async(monkeypatch):
 
     await asyncio.wait_for(client.disconnect(), timeout=1)
 
-    assert fake_rpc.closed is True
+    assert fake_rpc.closed is False

--- a/tests/test_main_api_unit.py
+++ b/tests/test_main_api_unit.py
@@ -203,6 +203,56 @@ def test_responses_dispatches_to_opencode_backend_without_mcp():
     assert calls["prompt"] == "hi"
 
 
+def test_responses_dispatches_to_codex_backend_without_mcp():
+    """Responses requests for codex/... models dispatch to Codex backend."""
+    calls = {}
+
+    def resolve(model):
+        if model == "codex/gpt-5.5":
+            return ResolvedModel(model, "codex", "gpt-5.5")
+        return None
+
+    async def create_client(**kwargs):
+        calls["create_client"] = kwargs
+        return object()
+
+    async def run_completion_with_client(client, prompt, session):
+        calls["prompt"] = prompt
+        yield {"content": [{"type": "text", "text": "Codex response"}]}
+        yield {"type": "result", "subtype": "success", "result": "Codex response"}
+
+    backend = MagicMock()
+    backend.name = "codex"
+    backend.create_client = create_client
+    backend.run_completion_with_client = run_completion_with_client
+    backend.parse_message.return_value = "Codex response"
+    backend.estimate_token_usage.return_value = {
+        "prompt_tokens": 2,
+        "completion_tokens": 4,
+        "total_tokens": 6,
+    }
+    BackendRegistry.register_descriptor(
+        BackendDescriptor(
+            name="codex",
+            owned_by="openai",
+            models=["codex/gpt-5.5"],
+            resolve_fn=resolve,
+        )
+    )
+    BackendRegistry.register("codex", backend)
+
+    with client_context() as (client, _mock_cli):
+        response = client.post(
+            "/v1/responses",
+            json={"model": "codex/gpt-5.5", "input": "hi"},
+        )
+
+    assert response.status_code == 200
+    assert calls["create_client"]["model"] == "gpt-5.5"
+    assert calls["create_client"]["mcp_servers"] is None
+    assert calls["prompt"] == "hi"
+
+
 def test_responses_streaming_enables_opencode_event_streaming():
     """Streaming OpenCode responses ask the OpenCode client to use /event."""
     calls = {}


### PR DESCRIPTION
## Summary

Adds an opt-in Codex backend that dispatches `codex/<model>` requests to the local `codex app-server --listen stdio://` JSON-RPC harness.

## What Changed

- Registers Codex through `BACKENDS=...,codex` with `codex/<model>` model resolution.
- Adds a Codex app-server JSON-RPC client, auth/availability provider, session-to-thread mapping, streaming delta conversion, token usage extraction, and text result parsing.
- Uses the current Codex CLI sandbox enum (`workspace-write`) while accepting legacy camelCase aliases.
- Reuses one Codex app-server subprocess per backend instance and serializes Codex turns through that shared process.
- Adds timeout handling, subprocess cleanup, and lazy restart after transport failures.
- Cancels Codex approval requests until the gateway has an explicit approval UI.
- Documents Codex setup, env vars, SDK status, shared-process behavior, and MVP limits.

## Root Cause / Context

The project already had multi-backend dispatch for Claude and OpenCode. Codex needed a separate local harness integration because the documented Python SDK package is experimental and was not available in this environment, while the installed Codex CLI app-server protocol was usable directly.

## Validation

- `git diff --check`
- `.venv/bin/ruff check src/backends/codex tests/test_codex_backend.py`
- `.venv/bin/pytest tests/test_codex_backend.py -q` (`15 passed`)
- `.venv/bin/pytest tests/test_codex_backend.py tests/test_backends_init_unit.py::TestDiscoverBackends::test_discover_backends_registers_codex_from_backends_env tests/test_main_api_unit.py::test_responses_dispatches_to_codex_backend_without_mcp -q` (`17 passed`)
- Real Codex app-server smoke: shared process was active and two thread starts succeeded
- `.venv/bin/pytest -q` (`1334 passed, 3 skipped, 4 deselected`)