### PR TITLE
[codex] implement codex approval continuation

### DIFF
--- a/docs/codex/README.md
+++ b/docs/codex/README.md
@@ -53,13 +53,21 @@ JSON-RPC client instead of adding an unavailable package dependency.
 | `CODEX_SANDBOX` | Thread-level Codex sandbox mode. Default: `danger-full-access` for local experimental use |
 | `CODEX_CONFIG_OVERRIDES` | Comma-separated `codex --config key=value` overrides |
 
-## MVP Limits
+## Supported Behavior
 
 - Text prompts and text responses are supported.
+- Codex app-server command, file-change, and permission approval requests are
+  exposed as Responses `requires_action` entries with the existing
+  `AskUserQuestion` function-call shape. Send a matching
+  `function_call_output` with the previous response id to continue the paused
+  Codex turn.
+- Command/file approvals accept Codex decision strings such as `accept`,
+  `acceptForSession`, `decline`, and `cancel`. Short aliases like `yes`,
+  `no`, and `always` are normalized by the gateway.
+
+## Current Limits
+
 - Codex turns are serialized through one shared app-server process; concurrent
   Codex request multiplexing is not implemented yet.
-- OpenAI Responses API function-call continuations are not mapped to Codex
-  approval flows yet. Codex app-server approval requests are cancelled until
-  the gateway has an explicit approval UI.
 - Image input is not exposed through the gateway Codex backend yet, even though
   Codex app-server models may support images.

--- a/docs/codex/README.md
+++ b/docs/codex/README.md
@@ -69,5 +69,7 @@ JSON-RPC client instead of adding an unavailable package dependency.
 
 - Codex turns are serialized through one shared app-server process; concurrent
   Codex request multiplexing is not implemented yet.
+- The shared Codex app-server is restarted when the metadata-derived allowlisted
+  environment changes between requests.
 - Image input is not exposed through the gateway Codex backend yet, even though
   Codex app-server models may support images.

--- a/docs/codex/README.md
+++ b/docs/codex/README.md
@@ -71,5 +71,7 @@ JSON-RPC client instead of adding an unavailable package dependency.
   Codex request multiplexing is not implemented yet.
 - The shared Codex app-server is restarted when the metadata-derived allowlisted
   environment changes between requests.
+- A Codex turn or approval transport error closes the shared app-server so the
+  next request starts from a fresh process.
 - Image input is not exposed through the gateway Codex backend yet, even though
   Codex app-server models may support images.

--- a/docs/superpowers/plans/2026-05-05-backend-isolated-workspaces.md
+++ b/docs/superpowers/plans/2026-05-05-backend-isolated-workspaces.md
@@ -1,0 +1,918 @@
+# Backend-Isolated Workspaces Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Claude, Codex, and OpenCode use independent per-user working directories and backend-native skill/config locations.
+
+**Architecture:** `WorkspaceManager` becomes backend-aware while preserving the existing anonymous temporary workspace behavior. `/v1/responses` resolves workspace paths with the already-resolved backend, stores that backend-specific cwd in `Session.workspace`, and keeps existing backend mismatch guards. Admin skill helpers gain an optional backend parameter so the current Claude-default API remains compatible while service logic can target `.agents/skills` and `.opencode/skills`.
+
+**Tech Stack:** Python 3.12, FastAPI, pytest, unittest.mock, pathlib/shutil filesystem helpers.
+
+---
+
+## File Map
+
+- Modify `src/workspace_manager.py`: add backend-aware path resolution, backend-specific template sync, skill mirroring, and generalized template source discovery.
+- Modify `src/routes/responses.py`: pass `resolved.backend` into workspace resolution and rehydration lookup.
+- Modify `src/admin_service.py`: map skill roots by backend and add optional backend parameters to skill helpers.
+- Modify `src/routes/admin.py`: accept an optional `backend` query parameter for skill endpoints while defaulting to Claude.
+- Modify `tests/test_workspace_manager.py`: cover backend-specific paths and template sync.
+- Modify `tests/test_responses_user.py`: assert backend is passed to workspace resolution and cwd forwarding.
+- Modify `tests/test_admin_skills.py`: cover backend-aware service helpers and route query parameters.
+
+---
+
+### Task 1: Backend-Aware Workspace Paths
+
+**Files:**
+- Modify: `src/workspace_manager.py`
+- Test: `tests/test_workspace_manager.py`
+
+- [ ] **Step 1: Write failing path tests**
+
+Add these tests inside `TestResolve` in `tests/test_workspace_manager.py`:
+
+```python
+    def test_named_user_backend_creates_backend_directory(self, manager, tmp_base):
+        workspace = manager.resolve("alice", backend="codex", sync_template=False)
+        assert workspace == tmp_base / "alice" / "codex"
+        assert workspace.is_dir()
+
+    def test_named_user_backend_directories_are_independent(self, manager, tmp_base):
+        claude = manager.resolve("alice", backend="claude", sync_template=False)
+        codex = manager.resolve("alice", backend="codex", sync_template=False)
+        assert claude == tmp_base / "alice" / "claude"
+        assert codex == tmp_base / "alice" / "codex"
+        assert claude != codex
+
+    def test_anonymous_ignores_backend_for_tmp_layout(self, manager, tmp_base):
+        workspace = manager.resolve(None, backend="opencode", sync_template=False)
+        assert workspace.parent == tmp_base
+        assert workspace.name.startswith("_tmp_")
+
+    def test_rejects_invalid_backend_name(self, manager):
+        with pytest.raises(ValueError, match="Invalid backend"):
+            manager.resolve("alice", backend="../codex", sync_template=False)
+```
+
+- [ ] **Step 2: Run path tests and verify failure**
+
+Run:
+
+```bash
+uv run pytest tests/test_workspace_manager.py::TestResolve -q
+```
+
+Expected: fails because `WorkspaceManager.resolve()` does not accept `backend`.
+
+- [ ] **Step 3: Implement backend path support**
+
+In `src/workspace_manager.py`, add a backend name pattern near `_USER_PATTERN`:
+
+```python
+_BACKEND_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,31}$")
+```
+
+Add this method to `WorkspaceManager`:
+
+```python
+    def _sanitize_backend(self, backend: Optional[str]) -> Optional[str]:
+        """Validate and return a backend directory name."""
+        if backend is None:
+            return None
+        if not backend or not _BACKEND_PATTERN.match(backend):
+            raise ValueError(
+                f"Invalid backend: {backend!r}. Must match ^[a-z][a-z0-9_-]{{0,31}}$"
+            )
+        return backend
+```
+
+Change the `resolve` signature and path selection:
+
+```python
+    def resolve(
+        self,
+        user: Optional[str] = None,
+        sync_template: bool = False,
+        backend: Optional[str] = None,
+    ) -> Path:
+        """Return the workspace path for *user*, creating it if necessary.
+
+        Named users use ``base_path/user/backend`` when *backend* is provided.
+        Anonymous workspaces remain session-scoped ``_tmp_{uuid}`` directories.
+        """
+        backend_name = self._sanitize_backend(backend)
+        if user is not None:
+            sanitized = self._sanitize(user)
+            workspace = self.base_path / sanitized
+            if backend_name:
+                workspace = workspace / backend_name
+        else:
+            workspace = self.base_path / f"_tmp_{uuid.uuid4().hex}"
+
+        workspace.mkdir(parents=True, exist_ok=True)
+
+        if sync_template:
+            self._sync_template(workspace, backend=backend_name)
+            self._sync_project_files(workspace)
+
+        return workspace
+```
+
+Temporarily update `_sync_template` to accept `backend` without changing copy behavior yet:
+
+```python
+    def _sync_template(self, workspace: Path, backend: Optional[str] = None) -> None:
+        """Copy backend template files into *workspace*."""
+        _ = backend
+        if self.template_source is None:
+            return
+        src = self.template_source / ".claude"
+        if not src.is_dir():
+            logger.debug("Template source .claude/ not found at %s, skipping sync", src)
+            return
+        dst = workspace / ".claude"
+        if dst.exists():
+            if dst.is_symlink():
+                dst.unlink()
+            else:
+                shutil.rmtree(dst)
+        shutil.copytree(src, dst)
+        logger.debug("Synced .claude/ template to %s", dst)
+```
+
+- [ ] **Step 4: Run path tests and verify pass**
+
+Run:
+
+```bash
+uv run pytest tests/test_workspace_manager.py::TestResolve -q
+```
+
+Expected: all `TestResolve` tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/workspace_manager.py tests/test_workspace_manager.py
+git commit -m "feat: resolve backend-specific workspaces"
+```
+
+---
+
+### Task 2: Backend-Specific Template Sync And Skill Mirrors
+
+**Files:**
+- Modify: `src/workspace_manager.py`
+- Test: `tests/test_workspace_manager.py`
+
+- [ ] **Step 1: Extend template fixture**
+
+Replace the `tmp_template` fixture body in `tests/test_workspace_manager.py` with:
+
+```python
+@pytest.fixture
+def tmp_template(tmp_path):
+    """Provide a temporary CLAUDE_CWD-style template directory."""
+    template = tmp_path / "template"
+
+    claude_dir = template / ".claude"
+    claude_dir.mkdir(parents=True)
+    (claude_dir / "settings.json").write_text('{"key": "value"}')
+    (claude_dir / "subdir").mkdir()
+    (claude_dir / "subdir" / "nested.txt").write_text("nested content")
+    claude_skill = claude_dir / "skills" / "shared-skill"
+    claude_skill.mkdir(parents=True)
+    (claude_skill / "SKILL.md").write_text(
+        "---\nname: shared-skill\ndescription: Claude skill\n---\nClaude"
+    )
+    (template / "CLAUDE.md").write_text("# Claude instructions\n")
+
+    agents_dir = template / ".agents"
+    agents_dir.mkdir()
+    (agents_dir / "config.json").write_text('{"agent": true}')
+    (template / "AGENTS.md").write_text("# Agent instructions\n")
+
+    opencode_dir = template / ".opencode"
+    opencode_dir.mkdir()
+    (opencode_dir / "opencode.json").write_text('{"permission": {}}')
+
+    return template
+```
+
+- [ ] **Step 2: Write failing backend template tests**
+
+Add these tests inside `TestResolve`:
+
+```python
+    def test_claude_sync_copies_only_claude_native_files(self, manager):
+        workspace = manager.resolve("alice", backend="claude", sync_template=True)
+        assert (workspace / ".claude" / "settings.json").is_file()
+        assert (workspace / "CLAUDE.md").read_text() == "# Claude instructions\n"
+        assert not (workspace / ".agents").exists()
+        assert not (workspace / ".opencode").exists()
+
+    def test_codex_sync_copies_agents_and_mirrors_claude_skills(self, manager):
+        workspace = manager.resolve("alice", backend="codex", sync_template=True)
+        assert (workspace / ".agents" / "config.json").is_file()
+        assert (workspace / "AGENTS.md").read_text() == "# Agent instructions\n"
+        mirrored = workspace / ".agents" / "skills" / "shared-skill" / "SKILL.md"
+        assert mirrored.read_text().endswith("Claude")
+        assert not (workspace / ".claude").exists()
+        assert not (workspace / ".opencode").exists()
+
+    def test_opencode_sync_copies_opencode_and_mirrors_claude_skills(self, manager):
+        workspace = manager.resolve("alice", backend="opencode", sync_template=True)
+        assert (workspace / ".opencode" / "opencode.json").is_file()
+        mirrored = workspace / ".opencode" / "skills" / "shared-skill" / "SKILL.md"
+        assert mirrored.read_text().endswith("Claude")
+        assert not (workspace / ".claude").exists()
+        assert not (workspace / ".agents").exists()
+
+    def test_codex_native_skills_win_over_claude_mirror(self, tmp_base, tmp_template):
+        native = tmp_template / ".agents" / "skills" / "shared-skill"
+        native.mkdir(parents=True)
+        (native / "SKILL.md").write_text(
+            "---\nname: shared-skill\ndescription: Codex native\n---\nCodex"
+        )
+        mgr = WorkspaceManager(base_path=tmp_base, template_source=tmp_template)
+        workspace = mgr.resolve("alice", backend="codex", sync_template=True)
+        skill = workspace / ".agents" / "skills" / "shared-skill" / "SKILL.md"
+        assert skill.read_text().endswith("Codex")
+
+    def test_opencode_claude_compatibility_wins_over_agents_duplicate(
+        self, tmp_base, tmp_template
+    ):
+        agent_skill = tmp_template / ".agents" / "skills" / "shared-skill"
+        agent_skill.mkdir(parents=True)
+        (agent_skill / "SKILL.md").write_text(
+            "---\nname: shared-skill\ndescription: Agent copy\n---\nAgent"
+        )
+        mgr = WorkspaceManager(base_path=tmp_base, template_source=tmp_template)
+        workspace = mgr.resolve("alice", backend="opencode", sync_template=True)
+        skill = workspace / ".opencode" / "skills" / "shared-skill" / "SKILL.md"
+        assert skill.read_text().endswith("Claude")
+
+    def test_template_source_without_claude_dir_can_sync_agents(self, tmp_base, tmp_path):
+        template = tmp_path / "template"
+        agents = template / ".agents"
+        agents.mkdir(parents=True)
+        (agents / "config.json").write_text('{"agent": true}')
+        mgr = WorkspaceManager(base_path=tmp_base, template_source=template)
+
+        workspace = mgr.resolve("alice", backend="codex", sync_template=True)
+
+        assert (workspace / ".agents" / "config.json").is_file()
+```
+
+- [ ] **Step 3: Run template tests and verify failure**
+
+Run:
+
+```bash
+uv run pytest tests/test_workspace_manager.py::TestResolve -q
+```
+
+Expected: backend-specific template tests fail because sync still only copies `.claude/`.
+
+- [ ] **Step 4: Implement backend template sync helpers**
+
+In `src/workspace_manager.py`, replace `_sync_template` with these helpers:
+
+```python
+    def _replace_tree(self, src: Path, dst: Path) -> None:
+        if dst.exists():
+            if dst.is_symlink():
+                dst.unlink()
+            else:
+                shutil.rmtree(dst)
+        shutil.copytree(src, dst)
+
+    def _copy_template_file(self, name: str, workspace: Path) -> None:
+        if self.template_source is None:
+            return
+        src = self.template_source / name
+        if not src.is_file():
+            return
+        dst = workspace / name
+        if dst.exists() or dst.is_symlink():
+            dst.unlink()
+        shutil.copy2(src, dst)
+
+    def _copy_template_dir(self, name: str, workspace: Path) -> bool:
+        if self.template_source is None:
+            return False
+        src = self.template_source / name
+        if not src.is_dir():
+            return False
+        self._replace_tree(src, workspace / name)
+        return True
+
+    def _mirror_skill_dirs(self, sources: tuple[Path, ...], dst: Path) -> None:
+        for src in sources:
+            if not src.is_dir():
+                continue
+            dst.mkdir(parents=True, exist_ok=True)
+            for child in sorted(src.iterdir()):
+                if not child.is_dir() or child.is_symlink():
+                    continue
+                skill_file = child / "SKILL.md"
+                if not skill_file.is_file() or skill_file.is_symlink():
+                    continue
+                target = dst / child.name
+                if target.exists():
+                    continue
+                shutil.copytree(child, target)
+```
+
+Then implement `_sync_template` as:
+
+```python
+    def _sync_template(self, workspace: Path, backend: Optional[str] = None) -> None:
+        """Copy backend-native templates into *workspace*."""
+        if self.template_source is None:
+            return
+
+        if backend == "codex":
+            self._copy_template_dir(".agents", workspace)
+            self._copy_template_file("AGENTS.md", workspace)
+            skills_dst = workspace / ".agents" / "skills"
+            if not skills_dst.exists():
+                self._mirror_skill_dirs((self.template_source / ".claude" / "skills",), skills_dst)
+            logger.debug("Synced Codex template to %s", workspace)
+            return
+
+        if backend == "opencode":
+            self._copy_template_dir(".opencode", workspace)
+            skills_dst = workspace / ".opencode" / "skills"
+            if not skills_dst.exists():
+                self._mirror_skill_dirs(
+                    (
+                        self.template_source / ".claude" / "skills",
+                        self.template_source / ".agents" / "skills",
+                    ),
+                    skills_dst,
+                )
+            logger.debug("Synced OpenCode template to %s", workspace)
+            return
+
+        self._copy_template_dir(".claude", workspace)
+        self._copy_template_file("CLAUDE.md", workspace)
+        logger.debug("Synced Claude template to %s", workspace)
+```
+
+Change `_resolve_template_source` to return `CLAUDE_CWD` when it is a directory:
+
+```python
+def _resolve_template_source() -> Optional[Path]:
+    """Determine the agent template source directory."""
+    claude_cwd = os.getenv("CLAUDE_CWD", "")
+    if claude_cwd:
+        p = Path(claude_cwd)
+        if p.is_dir():
+            return p
+    return None
+```
+
+- [ ] **Step 5: Run workspace tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_workspace_manager.py -q
+```
+
+Expected: all workspace manager tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/workspace_manager.py tests/test_workspace_manager.py
+git commit -m "feat: sync backend native agent templates"
+```
+
+---
+
+### Task 3: Route `/v1/responses` Through Backend-Specific Workspaces
+
+**Files:**
+- Modify: `src/routes/responses.py`
+- Test: `tests/test_responses_user.py`
+
+- [ ] **Step 1: Update failing expectations in response user tests**
+
+In `tests/test_responses_user.py`, update existing `mock_wm.resolve` assertions:
+
+```python
+mock_wm.resolve.assert_called_once_with("alice", sync_template=True, backend="claude")
+mock_wm.resolve.assert_called_once_with(None, sync_template=True, backend="claude")
+mock_wm.resolve.assert_called_once_with("alice", sync_template=False, backend="claude")
+```
+
+Update `test_cwd_passed_to_run_completion` to use a backend-specific path:
+
+```python
+mock_wm.resolve.return_value = Path("/tmp/ws/alice/claude")
+...
+assert create_calls[0]["cwd"] == "/tmp/ws/alice/claude"
+```
+
+Add this test to `TestUserParam`:
+
+```python
+    def test_responses_resolves_codex_workspace_with_codex_backend(
+        self, isolated_session_manager
+    ):
+        mock_wm = MagicMock()
+        mock_wm.resolve.return_value = Path("/tmp/ws/alice/codex")
+        create_calls = []
+
+        async def fake_create_client(**kwargs):
+            create_calls.append(kwargs)
+            return object()
+
+        async def fake_run_completion(client, prompt, session):
+            yield {"subtype": "success", "result": "Hello from Codex"}
+
+        with client_context_with_workspace(mock_wm) as (client, mock_cli):
+            BackendRegistry.unregister("claude")
+            BackendRegistry.register("codex", mock_cli)
+            mock_cli.create_client = fake_create_client
+            mock_cli.run_completion_with_client = fake_run_completion
+            mock_cli.parse_message = MagicMock(return_value="Hello from Codex")
+            resp = client.post(
+                "/v1/responses",
+                json={
+                    "model": "codex/openai/gpt-5.1-codex",
+                    "input": "hello",
+                    "user": "alice",
+                },
+            )
+
+        assert resp.status_code == 200
+        mock_wm.resolve.assert_called_once_with("alice", sync_template=True, backend="codex")
+        assert create_calls[0]["cwd"] == "/tmp/ws/alice/codex"
+```
+
+- [ ] **Step 2: Run response tests and verify failure**
+
+Run:
+
+```bash
+uv run pytest tests/test_responses_user.py -q
+```
+
+Expected: fails because routes do not pass `backend=...`.
+
+- [ ] **Step 3: Thread backend through workspace resolution**
+
+In `src/routes/responses.py`, change `_resolve_response_session` signature:
+
+```python
+def _resolve_response_session(body: ResponseCreateRequest, backend: str):
+```
+
+Change the early rehydrate cwd lookup:
+
+```python
+            _early_cwd = str(
+                workspace_manager.resolve(body.user, sync_template=False, backend=backend)
+            )
+```
+
+Change `_resolve_response_workspace` signature:
+
+```python
+async def _resolve_response_workspace(
+    body: ResponseCreateRequest,
+    session,
+    session_id: str,
+    is_new_session: bool,
+    backend: str,
+) -> Path:
+```
+
+Change new-session workspace resolution:
+
+```python
+            workspace = workspace_manager.resolve(
+                body.user,
+                sync_template=True,
+                backend=backend,
+            )
+```
+
+Change fallback resolution for sessions without stored workspace:
+
+```python
+        workspace = workspace_manager.resolve(
+            body.user,
+            sync_template=False,
+            backend=backend,
+        )
+```
+
+Change call sites in `responses()`:
+
+```python
+    session_id, session = _resolve_response_session(body, resolved.backend)
+    workspace = await _resolve_response_workspace(
+        body, session, session_id, is_new_session, resolved.backend
+    )
+```
+
+- [ ] **Step 4: Preserve legacy Claude rehydration fallback**
+
+Still in `_resolve_response_session`, after the first `get_session` attempt, add a legacy fallback for old Claude transcripts:
+
+```python
+    session = session_manager.get_session(session_id, user=body.user, cwd=_early_cwd)
+    if session is None and backend == "claude" and body.user:
+        try:
+            legacy_cwd = str(workspace_manager.resolve(body.user, sync_template=False))
+        except (ValueError, OSError):
+            legacy_cwd = None
+        if legacy_cwd and legacy_cwd != _early_cwd:
+            session = session_manager.get_session(session_id, user=body.user, cwd=legacy_cwd)
+```
+
+Keep the existing 404 behavior after that block.
+
+- [ ] **Step 5: Run response tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_responses_user.py -q
+```
+
+Expected: all `test_responses_user.py` tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/routes/responses.py tests/test_responses_user.py
+git commit -m "feat: route responses to backend workspaces"
+```
+
+---
+
+### Task 4: Backend-Aware Admin Skill Helpers
+
+**Files:**
+- Modify: `src/admin_service.py`
+- Test: `tests/test_admin_skills.py`
+
+- [ ] **Step 1: Write failing service tests**
+
+Add this fixture to `tests/test_admin_skills.py`:
+
+```python
+@pytest.fixture
+def multi_backend_workspace(tmp_path):
+    for root_name, body in [
+        (".claude", "Claude body"),
+        (".agents", "Codex body"),
+        (".opencode", "OpenCode body"),
+    ]:
+        skill_dir = tmp_path / root_name / "skills" / "hello-world"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: hello-world\ndescription: Backend skill\n---\n" + body
+        )
+    with patch("src.admin_service.get_workspace_root", return_value=tmp_path):
+        yield tmp_path
+```
+
+Add these tests near the service skill tests:
+
+```python
+class TestBackendSkillRoots:
+    def test_list_skills_uses_codex_agents_root(self, multi_backend_workspace):
+        skills = list_skills(backend="codex")
+        assert [s["name"] for s in skills] == ["hello-world"]
+
+    def test_get_skill_uses_opencode_root(self, multi_backend_workspace):
+        meta, content, etag = get_skill("hello-world", backend="opencode")
+        assert meta["description"] == "Backend skill"
+        assert content.endswith("OpenCode body")
+        assert etag
+
+    def test_create_skill_uses_codex_root(self, empty_workspace):
+        etag, created = create_or_update_skill(
+            "codex-only",
+            "---\nname: codex-only\ndescription: Codex\n---\nBody",
+            backend="codex",
+        )
+        assert created is True
+        assert etag
+        assert (empty_workspace / ".agents" / "skills" / "codex-only" / "SKILL.md").is_file()
+
+    def test_delete_skill_uses_opencode_root(self, multi_backend_workspace):
+        delete_skill("hello-world", backend="opencode")
+        assert not (
+            multi_backend_workspace / ".opencode" / "skills" / "hello-world"
+        ).exists()
+        assert (
+            multi_backend_workspace / ".claude" / "skills" / "hello-world"
+        ).exists()
+
+    def test_rejects_unknown_skill_backend(self, workspace):
+        with pytest.raises(ValueError, match="Unsupported skill backend"):
+            list_skills(backend="bad-backend")
+```
+
+- [ ] **Step 2: Run admin skill service tests and verify failure**
+
+Run:
+
+```bash
+uv run pytest tests/test_admin_skills.py::TestBackendSkillRoots -q
+```
+
+Expected: fails because skill helpers do not accept `backend`.
+
+- [ ] **Step 3: Implement skill root mapping**
+
+In `src/admin_service.py`, replace `_SKILL_DIR_PREFIX` with:
+
+```python
+_SKILL_DIR_BY_BACKEND = {
+    "claude": ".claude/skills",
+    "codex": ".agents/skills",
+    "opencode": ".opencode/skills",
+}
+```
+
+Add helper functions:
+
+```python
+def _skill_dir_prefix(backend: str = "claude") -> str:
+    try:
+        return _SKILL_DIR_BY_BACKEND[backend]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported skill backend: {backend}") from exc
+
+
+def _skill_rel_path(name: str, backend: str = "claude") -> str:
+    return f"{_skill_dir_prefix(backend)}/{name}/SKILL.md"
+
+
+def _skill_dir(root: Path, name: str, backend: str = "claude") -> Path:
+    return root / _skill_dir_prefix(backend) / name
+```
+
+Change function signatures:
+
+```python
+def list_skills(backend: str = "claude") -> List[Dict[str, Any]]:
+def get_skill(name: str, backend: str = "claude") -> Tuple[Dict[str, Any], str, str]:
+def create_or_update_skill(
+    name: str,
+    content: str,
+    expected_etag: Optional[str] = None,
+    backend: str = "claude",
+) -> Tuple[str, bool]:
+def delete_skill(name: str, backend: str = "claude") -> None:
+```
+
+Update each function body:
+
+```python
+skills_dir = root / _skill_dir_prefix(backend)
+rel_path = _skill_rel_path(name, backend)
+skill_dir = _skill_dir(root, name, backend)
+```
+
+In `create_or_update_skill`, keep backward compatibility by preserving positional `expected_etag` as the third argument and making `backend` the fourth.
+
+- [ ] **Step 4: Extend file allowlist**
+
+In `src/admin_service.py`, add backend skill directories to `_ALLOWED_DIRS`:
+
+```python
+_ALLOWED_DIRS: Tuple[str, ...] = (
+    ".claude/agents/",
+    ".claude/skills/",
+    ".claude/commands/",
+    ".agents/skills/",
+    ".opencode/skills/",
+)
+```
+
+- [ ] **Step 5: Run admin skill tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_admin_skills.py -q
+```
+
+Expected: all admin skill tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/admin_service.py tests/test_admin_skills.py
+git commit -m "feat: manage backend skill roots"
+```
+
+---
+
+### Task 5: Backend Query Parameter For Admin Skill Routes
+
+**Files:**
+- Modify: `src/routes/admin.py`
+- Test: `tests/test_admin_skills.py`
+
+- [ ] **Step 1: Write failing route tests**
+
+Add these tests inside `TestSkillsAPI` in `tests/test_admin_skills.py`:
+
+```python
+    def test_list_codex_skills_query_param(self, admin_client, workspace):
+        codex_skill = workspace / ".agents" / "skills" / "codex-skill"
+        codex_skill.mkdir(parents=True)
+        (codex_skill / "SKILL.md").write_text(
+            "---\nname: codex-skill\ndescription: Codex\n---\nBody"
+        )
+        r = admin_client.get("/admin/api/skills?backend=codex")
+        assert r.status_code == 200
+        names = {s["name"] for s in r.json()["skills"]}
+        assert names == {"codex-skill"}
+
+    def test_put_opencode_skill_query_param(self, admin_client, workspace):
+        r = admin_client.put(
+            "/admin/api/skills/open-skill?backend=opencode",
+            json={"content": "---\nname: open-skill\ndescription: OpenCode\n---\nBody"},
+        )
+        assert r.status_code == 201
+        assert (
+            workspace / ".opencode" / "skills" / "open-skill" / "SKILL.md"
+        ).is_file()
+
+    def test_invalid_skill_backend_query_param(self, admin_client):
+        r = admin_client.get("/admin/api/skills?backend=invalid")
+        assert r.status_code == 400
+        assert "Unsupported skill backend" in r.json()["error"]
+```
+
+- [ ] **Step 2: Run route tests and verify failure**
+
+Run:
+
+```bash
+uv run pytest tests/test_admin_skills.py::TestSkillsAPI -q
+```
+
+Expected: query parameter is ignored or unsupported backend is not rejected.
+
+- [ ] **Step 3: Thread backend query parameter through routes**
+
+In `src/routes/admin.py`, import `Query` if it is not already imported:
+
+```python
+from fastapi import APIRouter, Depends, Header, Query
+```
+
+Change route signatures and calls:
+
+```python
+@router.get("/api/skills")
+async def list_skills_endpoint(
+    backend: str = Query("claude"),
+    _=Depends(require_admin),
+):
+    try:
+        return {"skills": list_skills(backend=backend)}
+    except ValueError as e:
+        return JSONResponse(status_code=400, content={"error": str(e)})
+    except RuntimeError as e:
+        return JSONResponse(status_code=503, content={"error": str(e)})
+```
+
+```python
+@router.get("/api/skills/{name}")
+async def get_skill_endpoint(
+    name: str,
+    backend: str = Query("claude"),
+    _=Depends(require_admin),
+):
+    try:
+        meta, content, etag = get_skill(name, backend=backend)
+        return {"name": name, "metadata": meta, "content": content, "etag": etag}
+```
+
+```python
+@router.put("/api/skills/{name}")
+async def put_skill_endpoint(
+    name: str,
+    body: SkillWriteRequest,
+    backend: str = Query("claude"),
+    _=Depends(require_admin),
+    if_match: Optional[str] = Header(None),
+):
+    expected_etag = body.etag or if_match
+    try:
+        new_etag, created = create_or_update_skill(
+            name,
+            body.content,
+            expected_etag,
+            backend=backend,
+        )
+```
+
+```python
+@router.delete("/api/skills/{name}")
+async def delete_skill_endpoint(
+    name: str,
+    backend: str = Query("claude"),
+    _=Depends(require_admin),
+):
+    try:
+        delete_skill(name, backend=backend)
+```
+
+- [ ] **Step 4: Run admin skill tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_admin_skills.py -q
+```
+
+Expected: all admin skill tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/routes/admin.py tests/test_admin_skills.py
+git commit -m "feat: expose backend skill admin parameter"
+```
+
+---
+
+### Task 6: Full Regression And Documentation Check
+
+**Files:**
+- Modify: no production files unless tests reveal a defect.
+- Test: full relevant suite.
+
+- [ ] **Step 1: Run targeted backend workspace tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_workspace_manager.py tests/test_responses_user.py tests/test_admin_skills.py -q
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 2: Run formatting and lint checks**
+
+Run:
+
+```bash
+uv run ruff format --check src/workspace_manager.py src/routes/responses.py src/admin_service.py src/routes/admin.py tests/test_workspace_manager.py tests/test_responses_user.py tests/test_admin_skills.py
+uv run ruff check src/workspace_manager.py src/routes/responses.py src/admin_service.py src/routes/admin.py tests/test_workspace_manager.py tests/test_responses_user.py tests/test_admin_skills.py
+```
+
+Expected: both commands pass. If formatting fails, run:
+
+```bash
+uv run ruff format src/workspace_manager.py src/routes/responses.py src/admin_service.py src/routes/admin.py tests/test_workspace_manager.py tests/test_responses_user.py tests/test_admin_skills.py
+```
+
+Then rerun the two checks.
+
+- [ ] **Step 3: Run full test suite**
+
+Run:
+
+```bash
+uv run pytest -q
+```
+
+Expected: the full suite passes.
+
+- [ ] **Step 4: Update PR body**
+
+If this work remains on PR #100, update the PR description to mention:
+
+```markdown
+- Adds backend-isolated user workspaces: `<base>/<user>/<backend>`.
+- Syncs backend-native agent templates and skill roots for Claude, Codex, and OpenCode.
+- Keeps anonymous `_tmp_<uuid>` workspace behavior unchanged.
+- Adds backend-aware admin skill helpers and query parameters.
+```
+
+- [ ] **Step 5: Commit final verification note if files changed**
+
+If Step 2 formatting changed files, commit them:
+
+```bash
+git add src tests docs
+git commit -m "chore: verify backend isolated workspaces"
+```
+
+If no files changed, do not create an empty commit.

--- a/docs/superpowers/specs/2026-05-05-backend-isolated-workspaces-design.md
+++ b/docs/superpowers/specs/2026-05-05-backend-isolated-workspaces-design.md
@@ -1,0 +1,166 @@
+# Backend-Isolated Workspaces Design
+
+## Goal
+
+Treat each backend as an independent agent runtime with its own working
+directory, configuration files, skills, and runtime state. A user can still
+have a stable workspace root, but Claude, Codex, and OpenCode should no longer
+share one cwd by default.
+
+This matches the current session model: a `/v1/responses` session is already
+bound to one backend, and continuation with another backend is rejected. Since
+conversation memory is backend-specific, filesystem state should follow the
+same boundary.
+
+## Current Behavior
+
+`WorkspaceManager.resolve(user, sync_template=True)` creates one workspace per
+user under the configured base path. The base path is:
+
+1. `USER_WORKSPACES_DIR` when set.
+2. `CLAUDE_CWD` when set.
+3. A generated temporary directory such as `/tmp/claude_workspaces_<id>`.
+
+For a named user, the current workspace path is `<base>/<user>`. For an
+anonymous request, it is `<base>/_tmp_<uuid>`.
+
+New sessions sync only `.claude/` from `CLAUDE_CWD` into that workspace.
+Responses then pass that same cwd to whichever backend is selected.
+
+## Target Layout
+
+For named users, the backend becomes part of the workspace path:
+
+```text
+<base>/<user>/claude/
+<base>/<user>/codex/
+<base>/<user>/opencode/
+```
+
+Each backend-specific directory is the actual cwd passed to that backend.
+
+Anonymous requests keep the current shape:
+
+```text
+<base>/_tmp_<uuid>/
+```
+
+The anonymous path does not need another backend component because it is already
+session-scoped and cleaned up as a temporary workspace.
+
+## Backend Template Sync
+
+Template sync becomes backend-aware and runs only on new sessions.
+The template source should be the configured `CLAUDE_CWD` directory when it
+exists, even if that directory does not contain `.claude/`. The current
+`_resolve_template_source` helper is too Claude-specific for this design and
+should be generalized.
+
+Claude:
+
+- Copy `.claude/` from the template source when present.
+- Copy `CLAUDE.md` when present.
+- Preserve existing `pyproject.toml` and `uv.lock` symlink behavior.
+
+Codex:
+
+- Copy `.agents/` from the template source when present.
+- Copy `AGENTS.md` when present.
+- If `.agents/skills` is missing and `.claude/skills` exists, mirror compatible
+  Claude skills into `.agents/skills`.
+- Preserve existing `pyproject.toml` and `uv.lock` symlink behavior.
+
+OpenCode:
+
+- Copy `.opencode/` from the template source when present.
+- Prefer native `.opencode/skills`.
+- If `.opencode/skills` is missing, mirror compatible skills from
+  `.claude/skills` or `.agents/skills` into `.opencode/skills`. When both
+  compatibility sources contain the same skill name, `.claude/skills` wins
+  because it is the existing admin-managed skill location.
+- Preserve existing `pyproject.toml` and `uv.lock` symlink behavior.
+
+The mirror rule is fill-only: a backend-native skill path wins over a
+compatibility source with the same skill name.
+
+## API And Session Semantics
+
+`WorkspaceManager.resolve` should accept an optional `backend` argument.
+
+For named users:
+
+```text
+resolve(user="alice", backend="codex") -> <base>/alice/codex
+```
+
+For anonymous users:
+
+```text
+resolve(user=None, backend="codex") -> <base>/_tmp_<uuid>
+```
+
+`Session.workspace` remains a string and stores the backend-specific cwd. The
+existing backend mismatch guard remains in place, so a session cannot switch
+from one backend cwd to another.
+
+Claude jsonl rehydration continues to use `Session.workspace`. Existing
+sessions created before this change may still point at the old `<base>/<user>`
+layout; those should continue working because stored session workspace paths
+are authoritative.
+
+## Admin Surface
+
+The current admin skills API is Claude-specific because it reads `.claude/skills`
+from the global workspace root/template source. Under backend-isolated
+workspaces, admin skill management should become backend-aware at the template
+source level, not by editing already-created per-user runtime directories.
+
+Minimum viable behavior:
+
+- Existing admin endpoints continue to target Claude by default.
+- Add backend-aware service helpers that map:
+  - `claude` -> `.claude/skills`
+  - `codex` -> `.agents/skills`
+  - `opencode` -> `.opencode/skills`
+- Route changes can be incremental. Backend-aware API routes may be added after
+  the workspace split if the initial implementation only needs runtime support.
+
+## External OpenCode Caveat
+
+In external OpenCode mode, the external server must see the same filesystem
+path that the gateway passes as `directory`. Backend-isolated paths do not
+change that requirement. If the external server does not mount the same base
+workspace tree, OpenCode skill discovery and file edits will not match gateway
+expectations.
+
+## Migration
+
+No bulk migration is required.
+
+- New sessions use `<base>/<user>/<backend>`.
+- Existing in-memory sessions keep their stored `Session.workspace`.
+- Existing Claude jsonl rehydration uses the old or new stored path depending
+  on where the transcript was created.
+- Users who want old shared-workspace behavior can keep using existing
+  sessions until they expire.
+
+An explicit shared-workspace mode can be added later if a product requirement
+appears, but it is out of scope for this change.
+
+## Testing
+
+Unit tests should cover:
+
+- `WorkspaceManager.resolve(user, backend=...)` creates backend-specific paths.
+- Anonymous workspaces keep `_tmp_<uuid>` layout.
+- Backend-specific template sync copies only the relevant native config.
+- Codex skill mirroring fills `.agents/skills` only when native skills are
+  absent.
+- OpenCode skill mirroring fills `.opencode/skills` only when native skills are
+  absent.
+- `/v1/responses` passes the resolved backend-specific cwd to `create_client`.
+- Existing continuation still uses `Session.workspace` without recomputing a
+  new backend path.
+
+Integration tests should cover one new session per backend and assert that the
+backend receives isolated cwd values under the same user.

--- a/src/admin_service.py
+++ b/src/admin_service.py
@@ -28,6 +28,8 @@ _ALLOWED_DIRS: Tuple[str, ...] = (
     ".claude/agents/",
     ".claude/skills/",
     ".claude/commands/",
+    ".agents/skills/",
+    ".opencode/skills/",
 )
 _ALLOWED_FILES: Tuple[str, ...] = (
     ".claude/settings.json",
@@ -657,7 +659,26 @@ def export_session_json(session_id: str) -> Optional[Dict[str, Any]]:
 # Valid skill name: lowercase alphanumeric + hyphens, must start with a letter/digit
 _SKILL_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 
-_SKILL_DIR_PREFIX = ".claude/skills/"
+_SKILL_DIR_BY_BACKEND = {
+    "claude": ".claude/skills",
+    "codex": ".agents/skills",
+    "opencode": ".opencode/skills",
+}
+
+
+def _skill_dir_prefix(backend: str = "claude") -> str:
+    try:
+        return _SKILL_DIR_BY_BACKEND[backend]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported skill backend: {backend}") from exc
+
+
+def _skill_rel_path(name: str, backend: str = "claude") -> str:
+    return f"{_skill_dir_prefix(backend)}/{name}/SKILL.md"
+
+
+def _skill_dir(root: Path, name: str, backend: str = "claude") -> Path:
+    return root / _skill_dir_prefix(backend) / name
 
 
 def _parse_skill_frontmatter(content: str) -> Dict[str, Any]:
@@ -677,14 +698,14 @@ def _parse_skill_frontmatter(content: str) -> Dict[str, Any]:
         return {}
 
 
-def list_skills() -> List[Dict[str, Any]]:
-    """List all skills in ``.claude/skills/``.
+def list_skills(backend: str = "claude") -> List[Dict[str, Any]]:
+    """List all skills for a backend.
 
     Scans for ``SKILL.md`` files inside each subdirectory and parses their
     YAML frontmatter for metadata.
     """
     root = get_workspace_root()
-    skills_dir = root / ".claude" / "skills"
+    skills_dir = root / _skill_dir_prefix(backend)
     result: List[Dict[str, Any]] = []
 
     if not skills_dir.is_dir():
@@ -727,7 +748,7 @@ def list_skills() -> List[Dict[str, Any]]:
     return result
 
 
-def get_skill(name: str) -> Tuple[Dict[str, Any], str, str]:
+def get_skill(name: str, backend: str = "claude") -> Tuple[Dict[str, Any], str, str]:
     """Read a single skill.
 
     Returns ``(metadata, content, etag)`` where *metadata* is the parsed
@@ -737,7 +758,7 @@ def get_skill(name: str) -> Tuple[Dict[str, Any], str, str]:
     Raises ``ValueError`` for invalid skill names.
     """
     _validate_skill_name(name)
-    rel_path = f"{_SKILL_DIR_PREFIX}{name}/SKILL.md"
+    rel_path = _skill_rel_path(name, backend)
     target = validate_file_path(rel_path)
     validate_file_for_read(target)
 
@@ -752,6 +773,7 @@ def create_or_update_skill(
     name: str,
     content: str,
     expected_etag: Optional[str] = None,
+    backend: str = "claude",
 ) -> Tuple[str, bool]:
     """Create or update a skill.
 
@@ -762,7 +784,7 @@ def create_or_update_skill(
     mismatches.
     """
     _validate_skill_name(name)
-    rel_path = f"{_SKILL_DIR_PREFIX}{name}/SKILL.md"
+    rel_path = _skill_rel_path(name, backend)
     target = validate_file_path(rel_path)
 
     created = not target.is_file()
@@ -770,7 +792,7 @@ def create_or_update_skill(
     return new_etag, created
 
 
-def delete_skill(name: str) -> None:
+def delete_skill(name: str, backend: str = "claude") -> None:
     """Delete a skill directory and all its contents.
 
     Raises ``FileNotFoundError`` if the skill does not exist.
@@ -778,7 +800,7 @@ def delete_skill(name: str) -> None:
     """
     _validate_skill_name(name)
     root = get_workspace_root()
-    skill_dir = root / ".claude" / "skills" / name
+    skill_dir = _skill_dir(root, name, backend)
 
     # Security: reject symlink ancestors (.claude or .claude/skills being symlinks)
     if _has_symlink_ancestor(skill_dir, root):

--- a/src/backends/codex/client.py
+++ b/src/backends/codex/client.py
@@ -537,7 +537,11 @@ class CodexClient:
             except Exception as exc:
                 await self._close_rpc_locked()
                 logger.error("Codex app-server turn failed: %s", exc, exc_info=True)
-                yield {"type": "error", "is_error": True, "error_message": str(exc)}
+                yield {
+                    "type": "error",
+                    "is_error": True,
+                    "error_message": self._public_error_message(exc),
+                }
 
     async def resume_approval_with_client(
         self,
@@ -605,7 +609,17 @@ class CodexClient:
             except Exception as exc:
                 await self._close_rpc_locked()
                 logger.error("Codex approval continuation failed: %s", exc, exc_info=True)
-                yield {"type": "error", "is_error": True, "error_message": str(exc)}
+                yield {
+                    "type": "error",
+                    "is_error": True,
+                    "error_message": self._public_error_message(exc),
+                }
+
+    def _public_error_message(self, exc: Exception) -> str:
+        message = str(exc)
+        if isinstance(exc, CodexAppServerError):
+            message = message.split("stderr_tail=", 1)[0].rstrip()
+        return message or "Codex app-server error"
 
     @staticmethod
     def _next_chunk(iterator: Iterator[Dict[str, Any]]) -> tuple[bool, Optional[Dict[str, Any]]]:
@@ -988,6 +1002,7 @@ class CodexClient:
                 "item/fileChange/requestApproval",
             }:
                 return {"decision": parsed}
+            logger.warning("Unrecognized Codex approval output: %r", parsed)
 
         decision = self._normalize_approval_decision(parsed if parsed is not None else output)
         if method == "item/permissions/requestApproval":

--- a/src/backends/codex/client.py
+++ b/src/backends/codex/client.py
@@ -12,7 +12,7 @@ import contextlib
 import json
 import logging
 import os
-import select
+import queue
 import subprocess
 import threading
 import uuid
@@ -32,6 +32,14 @@ from src.constants import DEFAULT_TIMEOUT_MS
 from src.message_adapter import MessageAdapter
 
 logger = logging.getLogger(__name__)
+
+CODEX_APPROVAL_METHODS = {
+    "item/commandExecution/requestApproval",
+    "item/fileChange/requestApproval",
+    "item/permissions/requestApproval",
+}
+
+ASK_USER_QUESTION_TOOL_NAME = "AskUserQuestion"
 
 
 class CodexAppServerError(RuntimeError):
@@ -58,6 +66,8 @@ class CodexJsonRpcClient:
         self._proc: Optional[subprocess.Popen[str]] = None
         self._lock = threading.Lock()
         self._pending_notifications: deque[dict[str, Any]] = deque()
+        self._stdout_queue: queue.Queue[Optional[str]] = queue.Queue()
+        self._stdout_thread: Optional[threading.Thread] = None
         self._stderr_lines: deque[str] = deque(maxlen=400)
         self._stderr_thread: Optional[threading.Thread] = None
 
@@ -85,6 +95,8 @@ class CodexJsonRpcClient:
             env=proc_env,
             bufsize=1,
         )
+        self._stdout_queue = queue.Queue()
+        self._start_stdout_drain_thread()
         self._start_stderr_drain_thread()
         self._initialize()
 
@@ -106,6 +118,8 @@ class CodexJsonRpcClient:
             except subprocess.TimeoutExpired:
                 proc.kill()
                 proc.wait(timeout=2)
+        if self._stdout_thread and self._stdout_thread.is_alive():
+            self._stdout_thread.join(timeout=0.5)
         if self._stderr_thread and self._stderr_thread.is_alive():
             self._stderr_thread.join(timeout=0.5)
 
@@ -129,6 +143,9 @@ class CodexJsonRpcClient:
         while True:
             msg = self._read_message()
             if "method" in msg and "id" in msg:
+                if msg.get("method") in CODEX_APPROVAL_METHODS:
+                    self._pending_notifications.append(msg)
+                    continue
                 self._write_message({"id": msg["id"], "result": self._handle_server_request(msg)})
                 continue
             if "method" in msg and "id" not in msg:
@@ -152,10 +169,15 @@ class CodexJsonRpcClient:
         while True:
             msg = self._read_message()
             if "method" in msg and "id" in msg:
+                if msg.get("method") in CODEX_APPROVAL_METHODS:
+                    return msg
                 self._write_message({"id": msg["id"], "result": self._handle_server_request(msg)})
                 continue
             if "method" in msg and "id" not in msg:
                 return msg
+
+    def respond(self, request_id: Any, result: Dict[str, Any]) -> None:
+        self._write_message({"id": request_id, "result": result})
 
     def thread_start(self, params: Dict[str, Any]) -> Dict[str, Any]:
         result = self.request("thread/start", params)
@@ -210,16 +232,17 @@ class CodexJsonRpcClient:
     def _read_message(self) -> Dict[str, Any]:
         if self._proc is None or self._proc.stdout is None:
             raise CodexAppServerError("Codex app-server is not running")
-        stdout = self._proc.stdout
-        if self.read_timeout is not None:
-            readable, _, _ = select.select([stdout], [], [], self.read_timeout)
-            if not readable:
-                raise CodexAppServerError(
-                    "Timed out waiting for Codex app-server message "
-                    f"after {self.read_timeout:.3g}s. stderr_tail={self._stderr_tail()[:2000]}"
-                )
-        line = stdout.readline()
-        if not line:
+        try:
+            if self.read_timeout is None:
+                line = self._stdout_queue.get()
+            else:
+                line = self._stdout_queue.get(timeout=self.read_timeout)
+        except queue.Empty as exc:
+            raise CodexAppServerError(
+                "Timed out waiting for Codex app-server message "
+                f"after {self.read_timeout:.3g}s. stderr_tail={self._stderr_tail()[:2000]}"
+            ) from exc
+        if line is None:
             raise CodexAppServerError(
                 f"Codex app-server closed stdout. stderr_tail={self._stderr_tail()[:2000]}"
             )
@@ -230,6 +253,21 @@ class CodexJsonRpcClient:
         if not isinstance(message, dict):
             raise CodexAppServerError(f"Invalid Codex JSON-RPC payload: {message!r}")
         return message
+
+    def _start_stdout_drain_thread(self) -> None:
+        if self._proc is None or self._proc.stdout is None:
+            return
+        stdout = self._proc.stdout
+
+        def _drain() -> None:
+            try:
+                for line in stdout:
+                    self._stdout_queue.put(line)
+            finally:
+                self._stdout_queue.put(None)
+
+        self._stdout_thread = threading.Thread(target=_drain, daemon=True)
+        self._stdout_thread.start()
 
     def _start_stderr_drain_thread(self) -> None:
         if self._proc is None or self._proc.stderr is None:
@@ -259,6 +297,10 @@ class CodexSessionClient:
     stream_events: bool = False
     env: Optional[Dict[str, str]] = None
     owns_rpc: bool = False
+    pending_approval_request_id: Optional[Any] = None
+    pending_approval_method: Optional[str] = None
+    pending_approval_turn_id: Optional[str] = None
+    pending_approval_params: Optional[Dict[str, Any]] = None
 
     async def disconnect(self) -> None:
         if self.owns_rpc:
@@ -486,10 +528,65 @@ class CodexClient:
                     if not has_value:
                         break
                     if chunk is not None:
+                        if chunk.get("type") == "codex_approval_request":
+                            tool_chunk = self._store_pending_approval(session, client, chunk)
+                            yield tool_chunk
+                            return
                         yield chunk
             except Exception as exc:
                 await self._close_rpc_locked()
                 logger.error("Codex app-server turn failed: %s", exc, exc_info=True)
+                yield {"type": "error", "is_error": True, "error_message": str(exc)}
+
+    async def resume_approval_with_client(
+        self,
+        client: CodexSessionClient,
+        call_id: str,
+        output: str,
+        session: Any,
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        _ = session
+        async with self._rpc_lock:
+            try:
+                rpc = await self._ensure_rpc_locked(client.env or {})
+                method = client.pending_approval_method or ""
+                params = client.pending_approval_params or {}
+                request_id = client.pending_approval_request_id
+                if request_id is None or str(request_id) != str(call_id):
+                    request_id = call_id
+                turn_id = client.pending_approval_turn_id or str(params.get("turnId") or "")
+                if not turn_id:
+                    yield {
+                        "type": "error",
+                        "is_error": True,
+                        "error_message": "Codex approval continuation is missing turn id",
+                    }
+                    return
+
+                result = self._approval_result_from_output(method, output, params)
+                await asyncio.to_thread(rpc.respond, request_id, result)
+                client.pending_approval_request_id = None
+                client.pending_approval_method = None
+                client.pending_approval_turn_id = None
+                client.pending_approval_params = None
+
+                notification_iter = self._notification_iterator(rpc, client.thread_id, turn_id)
+                while True:
+                    has_value, chunk = await asyncio.to_thread(
+                        self._next_chunk,
+                        notification_iter,
+                    )
+                    if not has_value:
+                        break
+                    if chunk is not None:
+                        if chunk.get("type") == "codex_approval_request":
+                            tool_chunk = self._store_pending_approval(session, client, chunk)
+                            yield tool_chunk
+                            return
+                        yield chunk
+            except Exception as exc:
+                await self._close_rpc_locked()
+                logger.error("Codex approval continuation failed: %s", exc, exc_info=True)
                 yield {"type": "error", "is_error": True, "error_message": str(exc)}
 
     @staticmethod
@@ -555,6 +652,10 @@ class CodexClient:
         if not isinstance(params, dict):
             return
 
+        if self._is_approval_request(notification):
+            yield self._approval_request_chunk(notification, params)
+            return
+
         notification_turn_id = params.get("turnId")
         turn = params.get("turn")
         if isinstance(turn, dict):
@@ -565,6 +666,13 @@ class CodexClient:
             return
 
         if notification_turn_id != turn_id:
+            return
+
+        if method == "item/started":
+            item = params.get("item")
+            tool_use = self._tool_use_from_item(item)
+            if tool_use:
+                yield {"type": "assistant", "content": [tool_use]}
             return
 
         if method == "item/agentMessage/delta":
@@ -582,6 +690,10 @@ class CodexClient:
         if method == "item/completed":
             item = params.get("item")
             if isinstance(item, dict):
+                tool_result = self._tool_result_from_item(item)
+                if tool_result:
+                    yield {"type": "user", "content": [tool_result]}
+                    return
                 items.append(item)
             return
 
@@ -621,7 +733,301 @@ class CodexClient:
                 notification_turn_id = turn.get("id") or notification_turn_id
             return notification_turn_id == turn_id
 
+        if self._is_approval_request(notification):
+            return True
+
         return self._is_thread_idle_notification(thread_id, notification)
+
+    def _is_approval_request(self, notification: Dict[str, Any]) -> bool:
+        return "id" in notification and notification.get("method") in CODEX_APPROVAL_METHODS
+
+    def _approval_request_chunk(
+        self,
+        notification: Dict[str, Any],
+        params: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        request_id = notification.get("id")
+        method = str(notification.get("method") or "")
+        arguments = self._approval_arguments(method, params)
+        tool_block = {
+            "type": "tool_use",
+            "id": str(request_id),
+            "name": "codex_approval",
+            "input": arguments,
+            "metadata": {
+                "codex_approval_request_id": str(request_id),
+                "codex_approval_method": method,
+                "codex_thread_id": str(params.get("threadId") or ""),
+                "codex_turn_id": str(params.get("turnId") or ""),
+            },
+        }
+        return {
+            "type": "codex_approval_request",
+            "request_id": request_id,
+            "method": method,
+            "params": params,
+            "tool_chunk": {"type": "assistant", "content": [tool_block]},
+        }
+
+    def _approval_arguments(self, method: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        kind = self._approval_kind(method)
+        reason = params.get("reason")
+        arguments: Dict[str, Any] = {
+            "kind": kind,
+            "question": self._approval_question(kind, params),
+        }
+        if isinstance(params.get("command"), str):
+            arguments["command"] = params["command"]
+        if isinstance(params.get("cwd"), str):
+            arguments["cwd"] = params["cwd"]
+        if isinstance(reason, str) and reason:
+            arguments["reason"] = reason
+        if "permissions" in params:
+            arguments["permissions"] = params.get("permissions") or {}
+        if "grantRoot" in params and params.get("grantRoot"):
+            arguments["grantRoot"] = params["grantRoot"]
+        for key in (
+            "itemId",
+            "approvalId",
+            "additionalPermissions",
+            "commandActions",
+            "networkApprovalContext",
+            "proposedExecpolicyAmendment",
+            "proposedNetworkPolicyAmendments",
+        ):
+            if key in params and params.get(key) is not None:
+                arguments[key] = params[key]
+        arguments["options"] = self._approval_options(kind, params)
+        return arguments
+
+    def _approval_kind(self, method: str) -> str:
+        if method == "item/commandExecution/requestApproval":
+            return "command"
+        if method == "item/fileChange/requestApproval":
+            return "file_change"
+        if method == "item/permissions/requestApproval":
+            return "permissions"
+        return "approval"
+
+    def _approval_question(self, kind: str, params: Dict[str, Any]) -> str:
+        if kind == "command":
+            command = params.get("command")
+            if isinstance(command, str) and command:
+                return f"Codex requests approval to run command: {command}"
+            return "Codex requests approval to run a command."
+        if kind == "file_change":
+            return "Codex requests approval to apply file changes."
+        if kind == "permissions":
+            return "Codex requests additional permissions."
+        return "Codex requests approval."
+
+    def _approval_options(self, kind: str, params: Dict[str, Any]) -> list[dict[str, Any]]:
+        if kind == "permissions":
+            decisions: list[Any] = ["accept", "acceptForSession", "decline"]
+        else:
+            raw = params.get("availableDecisions")
+            decisions = raw if isinstance(raw, list) else []
+            if not decisions:
+                decisions = ["accept", "acceptForSession", "decline", "cancel"]
+        descriptions = {
+            "accept": "Approve this request once.",
+            "acceptForSession": "Approve matching requests for this session.",
+            "acceptWithExecpolicyAmendment": (
+                "Approve and apply the proposed execpolicy amendment."
+            ),
+            "applyNetworkPolicyAmendment": "Apply the proposed network policy rule.",
+            "decline": "Deny and let Codex continue.",
+            "cancel": "Deny and interrupt the turn.",
+        }
+        options = []
+        for decision in decisions:
+            label = self._approval_decision_label(decision)
+            if not label:
+                continue
+            option = {
+                "label": label,
+                "description": descriptions.get(label, f"Choose {label}."),
+            }
+            if isinstance(decision, dict):
+                option["decision"] = decision
+            options.append(option)
+        return options
+
+    def _approval_decision_label(self, decision: Any) -> str:
+        if isinstance(decision, str):
+            return decision
+        if not isinstance(decision, dict) or not decision:
+            return ""
+        if "acceptWithExecpolicyAmendment" in decision:
+            return "acceptWithExecpolicyAmendment"
+        if "applyNetworkPolicyAmendment" in decision:
+            amendment = decision.get("applyNetworkPolicyAmendment")
+            if isinstance(amendment, dict):
+                policy = amendment.get("network_policy_amendment")
+                if isinstance(policy, dict):
+                    action = policy.get("action")
+                    host = policy.get("host")
+                    if action and host:
+                        return f"applyNetworkPolicyAmendment:{action}:{host}"
+            return "applyNetworkPolicyAmendment"
+        return next(iter(decision.keys()), "")
+
+    def _store_pending_approval(
+        self,
+        session: Any,
+        client: CodexSessionClient,
+        chunk: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        tool_chunk = chunk["tool_chunk"]
+        tool_block = tool_chunk["content"][0]
+        metadata = tool_block["metadata"]
+        client.pending_approval_request_id = chunk.get("request_id")
+        client.pending_approval_method = chunk.get("method")
+        client.pending_approval_params = (
+            chunk.get("params") if isinstance(chunk.get("params"), dict) else {}
+        )
+        client.pending_approval_turn_id = metadata.get("codex_turn_id")
+        session.pending_tool_call = {
+            "call_id": metadata["codex_approval_request_id"],
+            "name": ASK_USER_QUESTION_TOOL_NAME,
+            "arguments": tool_block["input"],
+            "backend": "codex",
+            "codex_resume": "approval",
+        }
+        return tool_chunk
+
+    def _tool_use_from_item(self, item: Any) -> Optional[Dict[str, Any]]:
+        if not isinstance(item, dict):
+            return None
+        item_type = item.get("type")
+        item_id = item.get("id")
+        if item_type not in {"commandExecution", "fileChange", "mcpToolCall", "dynamicToolCall"}:
+            return None
+        if not isinstance(item_id, str) or not item_id:
+            return None
+        tool_input = {k: v for k, v in item.items() if k not in {"id", "type", "aggregatedOutput"}}
+        return {
+            "type": "tool_use",
+            "id": item_id,
+            "name": str(item_type),
+            "input": tool_input,
+        }
+
+    def _tool_result_from_item(self, item: Any) -> Optional[Dict[str, Any]]:
+        if not isinstance(item, dict):
+            return None
+        item_type = item.get("type")
+        item_id = item.get("id")
+        if item_type not in {"commandExecution", "fileChange", "mcpToolCall", "dynamicToolCall"}:
+            return None
+        if not isinstance(item_id, str) or not item_id:
+            return None
+        status = str(item.get("status") or "")
+        is_error = status in {"failed", "declined"}
+        if item_type == "commandExecution":
+            exit_code = item.get("exitCode")
+            if isinstance(exit_code, int) and exit_code != 0:
+                is_error = True
+            content = item.get("aggregatedOutput")
+            if not isinstance(content, str) or not content:
+                content = json.dumps(
+                    {
+                        "status": status,
+                        "exitCode": exit_code,
+                        "command": item.get("command"),
+                    },
+                    ensure_ascii=False,
+                )
+        else:
+            content = json.dumps(
+                {k: v for k, v in item.items() if k not in {"id", "type"}},
+                ensure_ascii=False,
+            )
+        return {
+            "type": "tool_result",
+            "tool_use_id": item_id,
+            "content": content,
+            "is_error": is_error,
+        }
+
+    def _approval_result_from_output(
+        self,
+        method: str,
+        output: str,
+        params: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        parsed: Any = None
+        if isinstance(output, str):
+            with contextlib.suppress(json.JSONDecodeError):
+                parsed = json.loads(output)
+        if isinstance(parsed, dict):
+            if method == "item/permissions/requestApproval" and "permissions" in parsed:
+                return parsed
+            if "decision" in parsed:
+                return {"decision": parsed["decision"]}
+            if method in {
+                "item/commandExecution/requestApproval",
+                "item/fileChange/requestApproval",
+            }:
+                return {"decision": parsed}
+
+        decision = self._normalize_approval_decision(parsed if parsed is not None else output)
+        if method == "item/permissions/requestApproval":
+            if decision in {"accept", "acceptForSession"}:
+                result: Dict[str, Any] = {"permissions": params.get("permissions") or {}}
+                result["scope"] = "session" if decision == "acceptForSession" else "turn"
+                return result
+            return {"permissions": {}, "scope": "turn"}
+        selected_decision = self._approval_decision_from_available_options(output, params)
+        if selected_decision is not None:
+            return {"decision": selected_decision}
+        return {"decision": decision}
+
+    def _approval_decision_from_available_options(
+        self,
+        output: str,
+        params: Dict[str, Any],
+    ) -> Optional[Any]:
+        raw = str(output or "").strip()
+        decisions = params.get("availableDecisions")
+        if not isinstance(decisions, list):
+            return None
+        for decision in decisions:
+            label = self._approval_decision_label(decision)
+            if raw == label:
+                return decision
+        return None
+
+    def _normalize_approval_decision(self, value: Any) -> str:
+        if isinstance(value, list) and value:
+            value = value[0]
+        raw = str(value or "").strip()
+        aliases = {
+            "": "decline",
+            "yes": "accept",
+            "y": "accept",
+            "allow": "accept",
+            "approve": "accept",
+            "approved": "accept",
+            "once": "accept",
+            "no": "decline",
+            "n": "decline",
+            "deny": "decline",
+            "denied": "decline",
+            "reject": "decline",
+            "rejected": "decline",
+            "always": "acceptForSession",
+            "session": "acceptForSession",
+            "stop": "cancel",
+        }
+        if raw in {
+            "accept",
+            "acceptForSession",
+            "decline",
+            "cancel",
+        }:
+            return raw
+        return aliases.get(raw, "decline")
 
     def _is_thread_idle_notification(
         self,

--- a/src/backends/codex/client.py
+++ b/src/backends/codex/client.py
@@ -220,6 +220,7 @@ class CodexJsonRpcClient:
             return {"decision": "cancel"}
         if method == "item/permissions/requestApproval":
             return {"permissions": {}, "scope": "turn"}
+        logger.warning("Unknown Codex server request method: %r", method)
         return {}
 
     def _write_message(self, payload: Dict[str, Any]) -> None:
@@ -552,8 +553,25 @@ class CodexClient:
                 method = client.pending_approval_method or ""
                 params = client.pending_approval_params or {}
                 request_id = client.pending_approval_request_id
-                if request_id is None or str(request_id) != str(call_id):
-                    request_id = call_id
+                if request_id is None:
+                    logger.error(
+                        "Codex approval continuation is missing pending request id for call_id %r",
+                        call_id,
+                    )
+                    yield {
+                        "type": "error",
+                        "is_error": True,
+                        "error_message": "Codex approval continuation is missing request id",
+                    }
+                    return
+                if str(request_id) != str(call_id):
+                    message = (
+                        "Codex approval request id mismatch: pending "
+                        f"{request_id!r}, received {call_id!r}"
+                    )
+                    logger.error(message)
+                    yield {"type": "error", "is_error": True, "error_message": message}
+                    return
                 turn_id = client.pending_approval_turn_id or str(params.get("turnId") or "")
                 if not turn_id:
                     yield {

--- a/src/routes/admin.py
+++ b/src/routes/admin.py
@@ -33,7 +33,7 @@ Blocklist:      GET  /admin/api/plugins/blocklist
 import logging
 from typing import Any, Optional
 
-from fastapi import APIRouter, Depends, Header, Request, Response
+from fastapi import APIRouter, Depends, Header, Query, Request, Response
 from fastapi.responses import HTMLResponse, JSONResponse
 from pydantic import BaseModel
 
@@ -554,19 +554,28 @@ async def reset_runtime_config(
 
 
 @router.get("/api/skills")
-async def list_skills_endpoint(_=Depends(require_admin)):
+async def list_skills_endpoint(
+    backend: str = Query("claude"),
+    _=Depends(require_admin),
+):
     """List all skills with parsed metadata."""
     try:
-        return {"skills": list_skills()}
+        return {"skills": list_skills(backend=backend)}
+    except ValueError as e:
+        return JSONResponse(status_code=400, content={"error": str(e)})
     except RuntimeError as e:
         return JSONResponse(status_code=503, content={"error": str(e)})
 
 
 @router.get("/api/skills/{name}")
-async def get_skill_endpoint(name: str, _=Depends(require_admin)):
+async def get_skill_endpoint(
+    name: str,
+    backend: str = Query("claude"),
+    _=Depends(require_admin),
+):
     """Read a skill's SKILL.md content and parsed metadata."""
     try:
-        meta, content, etag = get_skill(name)
+        meta, content, etag = get_skill(name, backend=backend)
         return {"name": name, "metadata": meta, "content": content, "etag": etag}
     except FileNotFoundError as e:
         return JSONResponse(status_code=404, content={"error": str(e)})
@@ -578,13 +587,19 @@ async def get_skill_endpoint(name: str, _=Depends(require_admin)):
 async def put_skill_endpoint(
     name: str,
     body: SkillWriteRequest,
+    backend: str = Query("claude"),
     _=Depends(require_admin),
     if_match: Optional[str] = Header(None),
 ):
     """Create or update a skill. Supports If-Match for optimistic concurrency."""
     expected_etag = body.etag or if_match
     try:
-        new_etag, created = create_or_update_skill(name, body.content, expected_etag)
+        new_etag, created = create_or_update_skill(
+            name,
+            body.content,
+            expected_etag,
+            backend=backend,
+        )
         return JSONResponse(
             status_code=201 if created else 200,
             content={"name": name, "etag": new_etag, "status": "created" if created else "updated"},
@@ -597,10 +612,14 @@ async def put_skill_endpoint(
 
 
 @router.delete("/api/skills/{name}")
-async def delete_skill_endpoint(name: str, _=Depends(require_admin)):
+async def delete_skill_endpoint(
+    name: str,
+    backend: str = Query("claude"),
+    _=Depends(require_admin),
+):
     """Delete a skill and its directory."""
     try:
-        delete_skill(name)
+        delete_skill(name, backend=backend)
         return {"name": name, "status": "deleted"}
     except FileNotFoundError as e:
         return JSONResponse(status_code=404, content={"error": str(e)})

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -433,6 +433,47 @@ async def _validate_backend_prompt(
         ) from e
 
 
+async def _ensure_response_session_client(
+    body: ResponseCreateRequest,
+    resolved: ResolvedModel,
+    backend: "BackendClient",
+    session,
+    session_id: str,
+    is_new_session: bool,
+    system_prompt: Optional[str],
+    workspace_str: str,
+) -> None:
+    """Create the persistent backend client after session preflight has passed."""
+    if session.client is not None:
+        return
+
+    from src.system_prompt import get_system_prompt, resolve_request_placeholders
+
+    if session.base_system_prompt is not None:
+        resolved_base = session.base_system_prompt
+    else:
+        resolved_base = resolve_request_placeholders(get_system_prompt(), workspace_str)
+    try:
+        session.client = await backend.create_client(
+            session=session,
+            model=resolved.provider_model,
+            system_prompt=system_prompt if is_new_session else None,
+            permission_mode=PERMISSION_MODE_BYPASS,
+            allowed_tools=body.allowed_tools,
+            mcp_servers=get_mcp_servers() if resolved.backend == "claude" else None,
+            cwd=workspace_str,
+            extra_env=body.metadata,
+            _custom_base=resolved_base,
+        )
+    except Exception:
+        logger.error("create_client failed", exc_info=True)
+        await session_manager.delete_session_async(session_id)
+        raise HTTPException(
+            status_code=503,
+            detail=f"{resolved.backend} backend unavailable; retry shortly",
+        )
+
+
 async def _unblock_pending_tool_call(
     session, backend: "BackendClient", fc_output: Dict[str, str]
 ) -> None:
@@ -787,50 +828,6 @@ async def create_response(
     # backend; other backends pass through unchanged.
     await _validate_backend_prompt(resolved, prompt, workspace_str)
 
-    # ------------------------------------------------------------------
-    # Create the persistent ClaudeSDKClient.  Every turn flows through it
-    # so PreToolUse hooks (AskUserQuestion) fire reliably and the on-disk
-    # transcript stays in lockstep with session.session_id.  If creation
-    # fails the request returns 503 — there is no longer a degraded
-    # query() fallback.
-    # bypassPermissions avoids workspace-level settings.local.json checks
-    # (temp workspaces lack shell command allow-lists).
-    # ------------------------------------------------------------------
-    if session.client is None:
-        # Pre-resolve {{WORKING_DIRECTORY}} so the persistent client's
-        # frozen system_prompt matches the cwd the SDK will actually use.
-        #
-        # Reconnect case: when an existing session lost its persistent client
-        # (e.g. SDK error/disconnect), prefer the prompt frozen at session
-        # start so admin-side prompt changes mid-conversation don't leak
-        # into in-flight sessions.
-        from src.system_prompt import get_system_prompt, resolve_request_placeholders
-
-        resolved_base: Optional[str]
-        if session.base_system_prompt is not None:
-            resolved_base = session.base_system_prompt
-        else:
-            resolved_base = resolve_request_placeholders(get_system_prompt(), workspace_str)
-        try:
-            session.client = await backend.create_client(
-                session=session,
-                model=resolved.provider_model,
-                system_prompt=system_prompt if is_new_session else None,
-                permission_mode=PERMISSION_MODE_BYPASS,
-                allowed_tools=body.allowed_tools,
-                mcp_servers=get_mcp_servers() if resolved.backend == "claude" else None,
-                cwd=workspace_str,
-                extra_env=body.metadata,
-                _custom_base=resolved_base,
-            )
-        except Exception:
-            logger.error("create_client failed", exc_info=True)
-            await session_manager.delete_session_async(session_id)
-            raise HTTPException(
-                status_code=503,
-                detail=f"{resolved.backend} backend unavailable; retry shortly",
-            )
-
     if body.stream:
         # Run preflight BEFORE StreamingResponse so HTTPExceptions produce
         # proper HTTP error status codes (not swallowed inside the generator).
@@ -842,6 +839,21 @@ async def create_response(
             is_new_session,
             workspace_str=workspace_str,
         )
+        try:
+            await _ensure_response_session_client(
+                body,
+                resolved,
+                backend,
+                session,
+                session_id,
+                is_new_session,
+                system_prompt,
+                workspace_str,
+            )
+        except Exception:
+            if preflight["lock_acquired"]:
+                session.lock.release()
+            raise
 
         next_turn = preflight["next_turn"]
         resp_id = _make_response_id(session_id, next_turn)
@@ -987,6 +999,16 @@ async def create_response(
             turn=_turn,
             workspace=workspace_str,
         ) as pf:
+            await _ensure_response_session_client(
+                body,
+                resolved,
+                backend,
+                session,
+                session_id,
+                is_new_session,
+                system_prompt,
+                workspace_str,
+            )
             # Execute backend through the persistent client.
             chunks = []
             active_client = session.client

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -516,6 +516,53 @@ async def _prepare_opencode_tool_continuation(
         raise
 
 
+async def _prepare_codex_approval_continuation(
+    session, backend: "BackendClient", fc_output: Dict[str, str]
+) -> None:
+    """Validate and reserve a Codex app-server approval continuation."""
+    await session.lock.acquire()
+    try:
+        if session.pending_tool_call is None:
+            raise HTTPException(
+                status_code=400,
+                detail="function_call_output received but no pending tool call in session",
+            )
+
+        if session.pending_tool_call["call_id"] != fc_output["call_id"]:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"call_id mismatch: pending tool call has "
+                    f"'{session.pending_tool_call['call_id']}', "
+                    f"but received '{fc_output['call_id']}'"
+                ),
+            )
+
+        if session.pending_tool_call.get("codex_resume") != "approval":
+            raise HTTPException(
+                status_code=400,
+                detail="Unsupported Codex continuation type",
+            )
+
+        resume = getattr(backend, "resume_approval_with_client", None)
+        if not callable(resume):
+            raise HTTPException(
+                status_code=400,
+                detail="Codex approval continuation is not supported by this backend",
+            )
+
+        if session.client is None:
+            raise HTTPException(
+                status_code=400,
+                detail="function_call_output received but session has no active SDK client",
+            )
+
+        session.pending_tool_call = None
+    except Exception:
+        session.lock.release()
+        raise
+
+
 def _normalize_opencode_question_arguments(input_value: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Return OpenCode question input in the public AskUserQuestion argument shape."""
     question = input_value.get("question")
@@ -620,8 +667,39 @@ def _store_opencode_pending_tool_call(
     return False
 
 
-async def _capture_opencode_pending_questions(chunk_source, resolved: ResolvedModel, session):
+def _is_codex_pending_approval_chunk(
+    resolved: ResolvedModel,
+    session,
+    chunk: Dict[str, Any],
+) -> bool:
+    """Return True when a Codex approval chunk already populated pending_tool_call."""
+    if resolved.backend != "codex" or not isinstance(chunk, dict):
+        return False
+    pending = getattr(session, "pending_tool_call", None)
+    if not isinstance(pending, dict) or pending.get("codex_resume") != "approval":
+        return False
+    content = chunk.get("content")
+    if not isinstance(content, list):
+        return False
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") != "tool_use" or block.get("name") != "codex_approval":
+            continue
+        metadata = block.get("metadata") if isinstance(block.get("metadata"), dict) else {}
+        request_id = metadata.get("codex_approval_request_id") or block.get("id")
+        if str(request_id or "") == str(pending.get("call_id") or ""):
+            return True
+    return False
+
+
+async def _capture_pending_tool_questions(chunk_source, resolved: ResolvedModel, session):
     async for chunk in chunk_source:
+        if _is_codex_pending_approval_chunk(resolved, session, chunk):
+            close = getattr(chunk_source, "aclose", None)
+            if callable(close):
+                await close()
+            return
         if resolved.backend == "opencode" and isinstance(chunk, dict):
             content = chunk.get("content")
             if isinstance(content, list) and any(
@@ -758,9 +836,7 @@ async def create_response(
 
                 _configure_client_streaming(session.client, True)
                 backend_source = backend.run_completion_with_client(session.client, prompt, session)
-                chunk_source = _capture_opencode_pending_questions(
-                    backend_source, resolved, session
-                )
+                chunk_source = _capture_pending_tool_questions(backend_source, resolved, session)
 
                 # Bridge SDK iteration through a background task to keep
                 # anyio cancel scopes task-local.
@@ -896,9 +972,7 @@ async def create_response(
             active_client = session.client
             _configure_client_streaming(active_client, False)
             backend_source = backend.run_completion_with_client(active_client, prompt, session)
-            async for chunk in _capture_opencode_pending_questions(
-                backend_source, resolved, session
-            ):
+            async for chunk in _capture_pending_tool_questions(backend_source, resolved, session):
                 chunks.append(chunk)
 
             # Check for backend errors (run_completion wraps exceptions as error chunks)
@@ -1019,6 +1093,8 @@ async def _handle_function_call_output(
         opencode_resume_kind = await _prepare_opencode_tool_continuation(
             session, backend, fc_output
         )
+    elif resolved.backend == "codex":
+        await _prepare_codex_approval_continuation(session, backend, fc_output)
     else:
         await _unblock_pending_tool_call(session, backend, fc_output)
 
@@ -1053,6 +1129,13 @@ async def _handle_function_call_output(
                             fc_output["output"],
                             session,
                         )
+                elif resolved.backend == "codex":
+                    backend_source = backend.resume_approval_with_client(
+                        active_client,
+                        fc_output["call_id"],
+                        fc_output["output"],
+                        session,
+                    )
                 else:
                     receiver = getattr(backend, "receive_response_from_client", None)
                     if receiver is not None:
@@ -1061,9 +1144,7 @@ async def _handle_function_call_output(
                         backend_source = backend.run_completion_with_client(
                             active_client, "", session
                         )
-                chunk_source = _capture_opencode_pending_questions(
-                    backend_source, resolved, session
-                )
+                chunk_source = _capture_pending_tool_questions(backend_source, resolved, session)
 
                 sse_source = streaming_utils.stream_response_chunks(
                     chunk_source=chunk_source,
@@ -1159,13 +1240,20 @@ async def _handle_function_call_output(
                     fc_output["output"],
                     session,
                 )
+        elif resolved.backend == "codex":
+            backend_source = backend.resume_approval_with_client(
+                active_client,
+                fc_output["call_id"],
+                fc_output["output"],
+                session,
+            )
         else:
             receiver = getattr(backend, "receive_response_from_client", None)
             if receiver is not None:
                 backend_source = receiver(active_client, session)
             else:
                 backend_source = backend.run_completion_with_client(active_client, "", session)
-        async for chunk in _capture_opencode_pending_questions(backend_source, resolved, session):
+        async for chunk in _capture_pending_tool_questions(backend_source, resolved, session):
             chunks.append(chunk)
 
         # Check for another pending_tool_call

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -1,6 +1,7 @@
 """Responses API endpoint (/v1/responses)."""
 
 import asyncio
+import contextlib
 import json
 import logging
 import secrets
@@ -33,7 +34,7 @@ from src.response_models import (
     ResponseUsage,
 )
 from src.rate_limiter import rate_limit_endpoint
-from src.constants import PERMISSION_MODE_BYPASS
+from src.constants import DEFAULT_TIMEOUT_MS, PERMISSION_MODE_BYPASS
 from src.mcp_config import get_mcp_servers
 from src import streaming_utils
 from src.usage_logger import usage_logger
@@ -49,6 +50,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 ASK_USER_QUESTION_TOOL_NAME = "AskUserQuestion"
+NON_STREAM_CONTINUATION_TIMEOUT_SECONDS = DEFAULT_TIMEOUT_MS / 1000
 
 
 def _generate_msg_id() -> str:
@@ -776,6 +778,30 @@ async def _capture_pending_tool_questions(chunk_source, resolved: ResolvedModel,
         yield chunk
 
 
+async def _collect_non_stream_continuation_chunks(chunk_source):
+    chunks = []
+
+    async def _consume():
+        async for chunk in chunk_source:
+            chunks.append(chunk)
+
+    try:
+        await asyncio.wait_for(
+            _consume(),
+            timeout=NON_STREAM_CONTINUATION_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError as exc:
+        close = getattr(chunk_source, "aclose", None)
+        if callable(close):
+            with contextlib.suppress(Exception):
+                await close()
+        raise HTTPException(
+            status_code=504,
+            detail=(f"Continuation timed out after {NON_STREAM_CONTINUATION_TIMEOUT_SECONDS:.3g}s"),
+        ) from exc
+    return chunks
+
+
 @router.post("/v1/responses")
 @rate_limit_endpoint("responses")
 async def create_response(
@@ -1117,12 +1143,12 @@ async def _handle_function_call_output(
     """Handle a function_call_output continuation request.
 
     Validates that the session has a pending tool call with a matching
-    ``call_id``, unblocks the SDK's PreToolUse hook, and then streams
-    the continuation response from the existing :class:`ClaudeSDKClient`.
+    ``call_id``, reserves the backend-specific continuation, and then reads
+    the continuation response from the existing backend session client.
 
-    The validation and event-unblock are performed atomically under the
+    The validation and continuation preparation are performed atomically under the
     session lock to prevent races where concurrent requests could read
-    stale ``pending_tool_call`` / ``input_event`` state.
+    stale ``pending_tool_call`` / backend resume state.
     """
     import time as _time
 
@@ -1153,9 +1179,8 @@ async def _handle_function_call_output(
             try:
                 chunks_buffer = []
                 _configure_client_streaming(active_client, True)
-                # After the hook returns deny+reason, the SDK continues
-                # processing from where it left off.  Use receive_response_from_client
-                # when available; do not start a new prompt.
+                # Resume the backend-specific pending tool request; do not
+                # start a new prompt for continuation turns.
                 if resolved.backend == "opencode":
                     if opencode_resume_kind == "permission":
                         backend_source = backend.resume_permission_with_client(
@@ -1263,9 +1288,8 @@ async def _handle_function_call_output(
     # --- Non-streaming continuation ---
     continuation_success = False
     try:
-        chunks = []
-        # After the hook returns deny+reason, the SDK continues
-        # processing from where it left off — no new query needed.
+        # Resume the backend-specific pending tool request; do not start a
+        # new prompt for continuation turns.
         _configure_client_streaming(active_client, False)
         if resolved.backend == "opencode":
             if opencode_resume_kind == "permission":
@@ -1295,8 +1319,9 @@ async def _handle_function_call_output(
                 backend_source = receiver(active_client, session)
             else:
                 backend_source = backend.run_completion_with_client(active_client, "", session)
-        async for chunk in _capture_pending_tool_questions(backend_source, resolved, session):
-            chunks.append(chunk)
+        chunks = await _collect_non_stream_continuation_chunks(
+            _capture_pending_tool_questions(backend_source, resolved, session)
+        )
 
         # Check for another pending_tool_call
         if session.pending_tool_call is not None:

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -320,6 +320,21 @@ def _resolve_response_session(body: ResponseCreateRequest, backend: str) -> tupl
             detail=f"previous_response_id '{body.previous_response_id}' is invalid",
         )
     session_id, turn = parsed
+    session = session_manager.get_session(session_id)
+    if session is not None:
+        if session.user != body.user:
+            raise HTTPException(
+                status_code=400,
+                detail=f"User mismatch: session belongs to {session.user!r}, "
+                f"but request specifies {body.user!r}",
+            )
+        if turn > session.turn_counter:
+            raise HTTPException(
+                status_code=404,
+                detail=f"previous_response_id '{body.previous_response_id}' references a future turn",
+            )
+        return session_id, session
+
     _early_cwd: Optional[str] = None
     if body.user:
         try:
@@ -343,6 +358,12 @@ def _resolve_response_session(body: ResponseCreateRequest, backend: str) -> tupl
                 f"Session for previous_response_id "
                 f"'{body.previous_response_id}' not found or expired"
             ),
+        )
+    if session.user != body.user:
+        raise HTTPException(
+            status_code=400,
+            detail=f"User mismatch: session belongs to {session.user!r}, "
+            f"but request specifies {body.user!r}",
         )
     if turn > session.turn_counter:
         raise HTTPException(

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -322,9 +322,7 @@ def _resolve_response_session(body: ResponseCreateRequest, backend: str) -> tupl
     if body.user:
         try:
             _early_cwd = str(
-                workspace_manager.resolve(
-                    body.user, sync_template=False, backend=backend
-                )
+                workspace_manager.resolve(body.user, sync_template=False, backend=backend)
             )
         except (ValueError, OSError):
             pass
@@ -335,9 +333,7 @@ def _resolve_response_session(body: ResponseCreateRequest, backend: str) -> tupl
         except (ValueError, OSError):
             legacy_cwd = None
         if legacy_cwd and legacy_cwd != _early_cwd:
-            session = session_manager.get_session(
-                session_id, user=body.user, cwd=legacy_cwd
-            )
+            session = session_manager.get_session(session_id, user=body.user, cwd=legacy_cwd)
     if not session:
         raise HTTPException(
             status_code=404,

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -306,7 +306,7 @@ def _validate_response_continuation(body: ResponseCreateRequest) -> None:
                 )
 
 
-def _resolve_response_session(body: ResponseCreateRequest) -> tuple[str, Any]:
+def _resolve_response_session(body: ResponseCreateRequest, backend: str) -> tuple[str, Any]:
     if not body.previous_response_id:
         session_id = str(uuid.uuid4())
         return session_id, session_manager.get_or_create_session(session_id)
@@ -321,10 +321,23 @@ def _resolve_response_session(body: ResponseCreateRequest) -> tuple[str, Any]:
     _early_cwd: Optional[str] = None
     if body.user:
         try:
-            _early_cwd = str(workspace_manager.resolve(body.user, sync_template=False))
+            _early_cwd = str(
+                workspace_manager.resolve(
+                    body.user, sync_template=False, backend=backend
+                )
+            )
         except (ValueError, OSError):
             pass
     session = session_manager.get_session(session_id, user=body.user, cwd=_early_cwd)
+    if session is None and backend == "claude" and body.user:
+        try:
+            legacy_cwd = str(workspace_manager.resolve(body.user, sync_template=False))
+        except (ValueError, OSError):
+            legacy_cwd = None
+        if legacy_cwd and legacy_cwd != _early_cwd:
+            session = session_manager.get_session(
+                session_id, user=body.user, cwd=legacy_cwd
+            )
     if not session:
         raise HTTPException(
             status_code=404,
@@ -346,6 +359,7 @@ async def _resolve_response_workspace(
     session,
     session_id: str,
     is_new_session: bool,
+    backend: str,
 ) -> Path:
     if not is_new_session and session.user != body.user:
         raise HTTPException(
@@ -356,7 +370,11 @@ async def _resolve_response_workspace(
 
     if is_new_session:
         try:
-            workspace = workspace_manager.resolve(body.user, sync_template=True)
+            workspace = workspace_manager.resolve(
+                body.user,
+                sync_template=True,
+                backend=backend,
+            )
         except ValueError as e:
             await session_manager.delete_session_async(session_id)
             raise HTTPException(status_code=400, detail=str(e)) from e
@@ -368,7 +386,11 @@ async def _resolve_response_workspace(
         return Path(session.workspace)
 
     try:
-        workspace = workspace_manager.resolve(body.user, sync_template=False)
+        workspace = workspace_manager.resolve(
+            body.user,
+            sync_template=False,
+            backend=backend,
+        )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
     session.workspace = str(workspace)
@@ -745,8 +767,10 @@ async def create_response(
     # Moved earlier — needed for workspace sync_template decision
     is_new_session = body.previous_response_id is None
     _validate_response_continuation(body)
-    session_id, session = _resolve_response_session(body)
-    workspace = await _resolve_response_workspace(body, session, session_id, is_new_session)
+    session_id, session = _resolve_response_session(body, resolved.backend)
+    workspace = await _resolve_response_workspace(
+        body, session, session_id, is_new_session, resolved.backend
+    )
     workspace_str = str(workspace)
 
     # ------------------------------------------------------------------

--- a/src/workspace_manager.py
+++ b/src/workspace_manager.py
@@ -103,23 +103,83 @@ class WorkspaceManager:
 
     _PROJECT_FILES = ("pyproject.toml", "uv.lock")
 
-    def _sync_template(self, workspace: Path, backend: Optional[str] = None) -> None:
-        """Copy backend template files into *workspace*."""
-        _ = backend
-        if self.template_source is None:
-            return
-        src = self.template_source / ".claude"
-        if not src.is_dir():
-            logger.debug("Template source .claude/ not found at %s, skipping sync", src)
-            return
-        dst = workspace / ".claude"
+    def _replace_tree(self, src: Path, dst: Path) -> None:
         if dst.exists():
             if dst.is_symlink():
                 dst.unlink()
             else:
                 shutil.rmtree(dst)
         shutil.copytree(src, dst)
-        logger.debug("Synced .claude/ template to %s", dst)
+
+    def _copy_template_file(self, name: str, workspace: Path) -> None:
+        if self.template_source is None:
+            return
+        src = self.template_source / name
+        if not src.is_file():
+            return
+        dst = workspace / name
+        if dst.exists() or dst.is_symlink():
+            dst.unlink()
+        shutil.copy2(src, dst)
+
+    def _copy_template_dir(self, name: str, workspace: Path) -> bool:
+        if self.template_source is None:
+            return False
+        src = self.template_source / name
+        if not src.is_dir():
+            return False
+        self._replace_tree(src, workspace / name)
+        return True
+
+    def _mirror_skill_dirs(self, sources: tuple[Path, ...], dst: Path) -> None:
+        for src in sources:
+            if not src.is_dir():
+                continue
+            dst.mkdir(parents=True, exist_ok=True)
+            for child in sorted(src.iterdir()):
+                if not child.is_dir() or child.is_symlink():
+                    continue
+                skill_file = child / "SKILL.md"
+                if not skill_file.is_file() or skill_file.is_symlink():
+                    continue
+                target = dst / child.name
+                if target.exists():
+                    continue
+                shutil.copytree(child, target)
+
+    def _sync_template(self, workspace: Path, backend: Optional[str] = None) -> None:
+        """Copy backend-native templates into *workspace*."""
+        if self.template_source is None:
+            return
+
+        if backend == "codex":
+            self._copy_template_dir(".agents", workspace)
+            self._copy_template_file("AGENTS.md", workspace)
+            skills_dst = workspace / ".agents" / "skills"
+            if not skills_dst.exists():
+                self._mirror_skill_dirs(
+                    (self.template_source / ".claude" / "skills",), skills_dst
+                )
+            logger.debug("Synced Codex template to %s", workspace)
+            return
+
+        if backend == "opencode":
+            self._copy_template_dir(".opencode", workspace)
+            skills_dst = workspace / ".opencode" / "skills"
+            if not skills_dst.exists():
+                self._mirror_skill_dirs(
+                    (
+                        self.template_source / ".claude" / "skills",
+                        self.template_source / ".agents" / "skills",
+                    ),
+                    skills_dst,
+                )
+            logger.debug("Synced OpenCode template to %s", workspace)
+            return
+
+        self._copy_template_dir(".claude", workspace)
+        self._copy_template_file("CLAUDE.md", workspace)
+        logger.debug("Synced Claude template to %s", workspace)
 
     def _sync_project_files(self, workspace: Path) -> None:
         """Symlink project files (pyproject.toml, uv.lock) into *workspace*.
@@ -161,11 +221,11 @@ def _resolve_base_path() -> Path:
 
 
 def _resolve_template_source() -> Optional[Path]:
-    """Determine the .claude template source directory."""
+    """Determine the agent template source directory."""
     claude_cwd = os.getenv("CLAUDE_CWD", "")
     if claude_cwd:
         p = Path(claude_cwd)
-        if (p / ".claude").is_dir():
+        if p.is_dir():
             return p
     return None
 

--- a/src/workspace_manager.py
+++ b/src/workspace_manager.py
@@ -96,9 +96,7 @@ class WorkspaceManager:
         if backend is None:
             return None
         if not backend or not _BACKEND_PATTERN.match(backend):
-            raise ValueError(
-                f"Invalid backend: {backend!r}. Must match ^[a-z][a-z0-9_-]{{0,31}}$"
-            )
+            raise ValueError(f"Invalid backend: {backend!r}. Must match ^[a-z][a-z0-9_-]{{0,31}}$")
         return backend
 
     _PROJECT_FILES = ("pyproject.toml", "uv.lock")
@@ -177,9 +175,7 @@ class WorkspaceManager:
             self._copy_template_file("AGENTS.md", workspace)
             skills_dst = workspace / ".agents" / "skills"
             if skills_dst.is_symlink() or not skills_dst.exists():
-                self._mirror_skill_dirs(
-                    (self.template_source / ".claude" / "skills",), skills_dst
-                )
+                self._mirror_skill_dirs((self.template_source / ".claude" / "skills",), skills_dst)
             logger.debug("Synced Codex template to %s", workspace)
             return
 

--- a/src/workspace_manager.py
+++ b/src/workspace_manager.py
@@ -155,7 +155,7 @@ class WorkspaceManager:
                 if not child.is_dir() or child.is_symlink():
                     continue
                 if self._contains_symlink(child):
-                    logger.debug("Skipping skill template with symlink: %s", child)
+                    logger.warning("Skipping skill template with symlink: %s", child)
                     continue
                 skill_file = child / "SKILL.md"
                 if not skill_file.is_file() or skill_file.is_symlink():
@@ -183,6 +183,8 @@ class WorkspaceManager:
             self._copy_template_dir(".opencode", workspace)
             skills_dst = workspace / ".opencode" / "skills"
             if skills_dst.is_symlink() or not skills_dst.exists():
+                # Compatibility mirrors prefer Claude skills over Agents skills
+                # when both sources contain the same skill name.
                 self._mirror_skill_dirs(
                     (
                         self.template_source / ".claude" / "skills",

--- a/src/workspace_manager.py
+++ b/src/workspace_manager.py
@@ -176,7 +176,7 @@ class WorkspaceManager:
             self._copy_template_dir(".agents", workspace)
             self._copy_template_file("AGENTS.md", workspace)
             skills_dst = workspace / ".agents" / "skills"
-            if not skills_dst.exists():
+            if skills_dst.is_symlink() or not skills_dst.exists():
                 self._mirror_skill_dirs(
                     (self.template_source / ".claude" / "skills",), skills_dst
                 )
@@ -186,7 +186,7 @@ class WorkspaceManager:
         if backend == "opencode":
             self._copy_template_dir(".opencode", workspace)
             skills_dst = workspace / ".opencode" / "skills"
-            if not skills_dst.exists():
+            if skills_dst.is_symlink() or not skills_dst.exists():
                 self._mirror_skill_dirs(
                     (
                         self.template_source / ".claude" / "skills",

--- a/src/workspace_manager.py
+++ b/src/workspace_manager.py
@@ -103,12 +103,15 @@ class WorkspaceManager:
 
     _PROJECT_FILES = ("pyproject.toml", "uv.lock")
 
+    def _remove_path(self, path: Path) -> None:
+        if path.is_symlink() or path.is_file():
+            path.unlink()
+        elif path.exists():
+            shutil.rmtree(path)
+
     def _replace_tree(self, src: Path, dst: Path) -> None:
-        if dst.exists():
-            if dst.is_symlink():
-                dst.unlink()
-            else:
-                shutil.rmtree(dst)
+        if dst.exists() or dst.is_symlink():
+            self._remove_path(dst)
         shutil.copytree(src, dst)
 
     def _copy_template_file(self, name: str, workspace: Path) -> None:
@@ -119,7 +122,7 @@ class WorkspaceManager:
             return
         dst = workspace / name
         if dst.exists() or dst.is_symlink():
-            dst.unlink()
+            self._remove_path(dst)
         shutil.copy2(src, dst)
 
     def _copy_template_dir(self, name: str, workspace: Path) -> bool:
@@ -131,13 +134,30 @@ class WorkspaceManager:
         self._replace_tree(src, workspace / name)
         return True
 
+    def _ensure_real_dir_path(self, root: Path, dst: Path) -> None:
+        current = root
+        current.mkdir(parents=True, exist_ok=True)
+        for part in dst.relative_to(root).parts:
+            current = current / part
+            if current.exists() or current.is_symlink():
+                if current.is_dir() and not current.is_symlink():
+                    continue
+                self._remove_path(current)
+            current.mkdir()
+
+    def _contains_symlink(self, path: Path) -> bool:
+        return path.is_symlink() or any(child.is_symlink() for child in path.rglob("*"))
+
     def _mirror_skill_dirs(self, sources: tuple[Path, ...], dst: Path) -> None:
         for src in sources:
             if not src.is_dir():
                 continue
-            dst.mkdir(parents=True, exist_ok=True)
+            self._ensure_real_dir_path(dst.parent.parent, dst)
             for child in sorted(src.iterdir()):
                 if not child.is_dir() or child.is_symlink():
+                    continue
+                if self._contains_symlink(child):
+                    logger.debug("Skipping skill template with symlink: %s", child)
                     continue
                 skill_file = child / "SKILL.md"
                 if not skill_file.is_file() or skill_file.is_symlink():

--- a/src/workspace_manager.py
+++ b/src/workspace_manager.py
@@ -14,6 +14,7 @@ from typing import Optional
 logger = logging.getLogger(__name__)
 
 _USER_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,62}$")
+_BACKEND_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,31}$")
 
 
 class WorkspaceManager:
@@ -35,24 +36,30 @@ class WorkspaceManager:
         self.template_source = Path(template_source) if template_source else None
         self.project_root = Path(project_root) if project_root else None
 
-    def resolve(self, user: Optional[str] = None, sync_template: bool = False) -> Path:
+    def resolve(
+        self,
+        user: Optional[str] = None,
+        sync_template: bool = False,
+        backend: Optional[str] = None,
+    ) -> Path:
         """Return the workspace path for *user*, creating it if necessary.
 
-        When *user* is ``None``, a temporary directory (``_tmp_{uuid}``) is
-        created under *base_path*.  When *sync_template* is ``True`` and a
-        template source is configured, the ``.claude/`` directory is copied
-        (overwriting existing files).
+        Named users use ``base_path/user/backend`` when *backend* is provided.
+        Anonymous workspaces remain session-scoped ``_tmp_{uuid}`` directories.
         """
+        backend_name = self._sanitize_backend(backend)
         if user is not None:
             sanitized = self._sanitize(user)
             workspace = self.base_path / sanitized
+            if backend_name:
+                workspace = workspace / backend_name
         else:
             workspace = self.base_path / f"_tmp_{uuid.uuid4().hex}"
 
         workspace.mkdir(parents=True, exist_ok=True)
 
         if sync_template:
-            self._sync_template(workspace)
+            self._sync_template(workspace, backend=backend_name)
             self._sync_project_files(workspace)
 
         return workspace
@@ -84,10 +91,21 @@ class WorkspaceManager:
             )
         return user
 
+    def _sanitize_backend(self, backend: Optional[str]) -> Optional[str]:
+        """Validate and return a backend directory name."""
+        if backend is None:
+            return None
+        if not backend or not _BACKEND_PATTERN.match(backend):
+            raise ValueError(
+                f"Invalid backend: {backend!r}. Must match ^[a-z][a-z0-9_-]{{0,31}}$"
+            )
+        return backend
+
     _PROJECT_FILES = ("pyproject.toml", "uv.lock")
 
-    def _sync_template(self, workspace: Path) -> None:
-        """Copy ``.claude/`` from template source into *workspace*."""
+    def _sync_template(self, workspace: Path, backend: Optional[str] = None) -> None:
+        """Copy backend template files into *workspace*."""
+        _ = backend
         if self.template_source is None:
             return
         src = self.template_source / ".claude"

--- a/tests/integration/test_codex_e2e.py
+++ b/tests/integration/test_codex_e2e.py
@@ -1,0 +1,297 @@
+"""Codex backend end-to-end tests with a fake app-server process."""
+
+import json
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+import src.main as main
+import src.routes.general as general_module
+import src.routes.responses as responses_module
+from src.backends.base import BackendRegistry
+
+
+FAKE_CODEX_APP_SERVER = r"""#!/usr/bin/env python3
+import json
+import sys
+
+thread_id = "thr_e2e"
+turn_id = "turn_1"
+approval_mode = "command"
+
+
+def log(message):
+    print(message, file=sys.stderr, flush=True)
+
+
+def send(payload):
+    log("OUT " + json.dumps(payload, sort_keys=True))
+    print(json.dumps(payload), flush=True)
+
+
+for raw in sys.stdin:
+    log("IN " + raw.strip())
+    msg = json.loads(raw)
+    method = msg.get("method")
+    msg_id = msg.get("id")
+    params = msg.get("params") or {}
+
+    if method == "initialize":
+        send({"id": msg_id, "result": {"protocolVersion": "2"}})
+        continue
+    if method == "initialized":
+        continue
+    if method == "model/list":
+        send({"id": msg_id, "result": {"data": [{"id": "gpt-5.5"}]}})
+        continue
+    if method == "thread/start":
+        send({"id": msg_id, "result": {"thread": {"id": thread_id, "path": None, "ephemeral": True}}})
+        continue
+    if method == "thread/resume":
+        send({"id": msg_id, "result": {"thread": {"id": params.get("threadId", thread_id)}}})
+        continue
+    if method == "turn/start":
+        input_items = params.get("input") or []
+        prompt = ""
+        if input_items and isinstance(input_items[0], dict):
+            prompt = input_items[0].get("text") or ""
+        if "file change" in prompt:
+            approval_mode = "file_change"
+            approval_method = "item/fileChange/requestApproval"
+            approval_params = {
+                "threadId": thread_id,
+                "turnId": turn_id,
+                "itemId": "file_1",
+                "grantRoot": params.get("cwd") or "/tmp",
+                "reason": "e2e file approval",
+            }
+        elif "permissions" in prompt:
+            approval_mode = "permissions"
+            approval_method = "item/permissions/requestApproval"
+            approval_params = {
+                "threadId": thread_id,
+                "turnId": turn_id,
+                "itemId": "perm_1",
+                "cwd": params.get("cwd") or "/tmp",
+                "permissions": {"fileSystem": {"read": [params.get("cwd") or "/tmp"]}},
+                "reason": "e2e permissions approval",
+            }
+        else:
+            approval_mode = "command"
+            approval_method = "item/commandExecution/requestApproval"
+            approval_params = {
+                "threadId": thread_id,
+                "turnId": turn_id,
+                "itemId": "cmd_1",
+                "command": "printf e2e",
+                "cwd": params.get("cwd") or "/tmp",
+                "reason": "e2e approval",
+                "availableDecisions": ["accept", "decline", "cancel"],
+            }
+        send({"id": msg_id, "result": {"turn": {"id": turn_id, "status": "inProgress"}}})
+        send({
+            "id": "approval_1",
+            "method": approval_method,
+            "params": approval_params,
+        })
+        continue
+
+    if msg_id == "approval_1":
+        if approval_mode == "file_change":
+            completed_item = {
+                "type": "fileChange",
+                "id": "file_1",
+                "status": "completed",
+                "changes": [{"path": "example.txt", "kind": "update"}],
+            }
+        elif approval_mode == "permissions":
+            completed_item = {
+                "type": "dynamicToolCall",
+                "id": "perm_1",
+                "status": "completed",
+                "name": "permissions",
+                "output": "permissions granted",
+            }
+        else:
+            completed_item = {
+                "type": "commandExecution",
+                "id": "cmd_1",
+                "command": "printf e2e",
+                "cwd": "/tmp",
+                "status": "completed",
+                "exitCode": 0,
+                "aggregatedOutput": "e2e",
+                "commandActions": [],
+            }
+        send({
+            "method": "serverRequest/resolved",
+            "params": {"threadId": thread_id, "requestId": "approval_1"},
+        })
+        send({
+            "method": "item/completed",
+            "params": {
+                "threadId": thread_id,
+                "turnId": turn_id,
+                "item": completed_item,
+            },
+        })
+        send({
+            "method": "item/completed",
+            "params": {
+                "threadId": thread_id,
+                "turnId": turn_id,
+                "item": {
+                    "type": "agentMessage",
+                    "id": "msg_1",
+                    "phase": "final_answer",
+                    "text": "Codex e2e approved.",
+                },
+            },
+        })
+        send({
+            "method": "thread/tokenUsage/updated",
+            "params": {
+                "threadId": thread_id,
+                "turnId": turn_id,
+                "tokenUsage": {
+                    "last": {"inputTokens": 2, "cachedInputTokens": 0, "outputTokens": 3}
+                },
+            },
+        })
+        send({
+            "method": "turn/completed",
+            "params": {
+                "threadId": thread_id,
+                "turn": {"id": turn_id, "status": "completed", "items": []},
+            },
+        })
+        continue
+"""
+
+
+def _write_fake_codex(tmp_path: Path) -> Path:
+    fake_bin = tmp_path / "fake-codex"
+    fake_bin.write_text(FAKE_CODEX_APP_SERVER)
+    fake_bin.chmod(0o755)
+    return fake_bin
+
+
+@contextmanager
+def codex_client_context(fake_bin: Path):
+    """Create a TestClient with the real Codex backend and fake app-server binary."""
+
+    def _mock_discover():
+        from src.backends.codex import CODEX_DESCRIPTOR
+        from src.backends.codex.client import CodexClient
+
+        BackendRegistry.register_descriptor(CODEX_DESCRIPTOR)
+        BackendRegistry.register("codex", CodexClient(timeout=3000))
+
+    if main.limiter and hasattr(main.limiter, "_storage"):
+        main.limiter._storage.reset()
+
+    with (
+        patch.dict(
+            "os.environ",
+            {
+                "CODEX_BIN": str(fake_bin),
+                "CODEX_MODELS": "gpt-5.5",
+                "BACKENDS": "codex",
+            },
+            clear=False,
+        ),
+        patch.object(main, "discover_backends", _mock_discover),
+        patch.object(responses_module, "verify_api_key", new=AsyncMock(return_value=True)),
+        patch.object(general_module, "verify_api_key", new=AsyncMock(return_value=True)),
+        patch.object(main, "validate_claude_code_auth", return_value=(True, {"method": "test"})),
+        patch.object(main.session_manager, "start_cleanup_task"),
+        patch.object(main.session_manager, "async_shutdown", new=AsyncMock()),
+    ):
+        with TestClient(main.app) as client:
+            yield client
+
+    for backend in BackendRegistry.all_backends().values():
+        close = getattr(backend, "close", None)
+        if callable(close):
+            close()
+    BackendRegistry.clear()
+    if main.limiter and hasattr(main.limiter, "_storage"):
+        main.limiter._storage.reset()
+
+
+@pytest.mark.parametrize(
+    ("prompt", "expected_kind"),
+    [
+        ("run a command", "command"),
+        ("request file change approval", "file_change"),
+        ("request permissions approval", "permissions"),
+    ],
+)
+def test_codex_responses_e2e_approval_continuation(tmp_path, prompt, expected_kind):
+    fake_bin = _write_fake_codex(tmp_path)
+
+    with codex_client_context(fake_bin) as client:
+        first = client.post(
+            "/v1/responses",
+            json={"model": "codex/gpt-5.5", "input": prompt, "stream": False},
+        )
+
+        assert first.status_code == 200
+        first_body = first.json()
+        assert first_body["status"] == "requires_action"
+        tool_call = first_body["output"][0]
+        assert tool_call["type"] == "function_call"
+        assert tool_call["name"] == "AskUserQuestion"
+        assert tool_call["call_id"] == "approval_1"
+        arguments = json.loads(tool_call["arguments"])
+        assert arguments["kind"] == expected_kind
+        if expected_kind == "command":
+            assert arguments["command"] == "printf e2e"
+        elif expected_kind == "file_change":
+            assert arguments["grantRoot"]
+        else:
+            assert arguments["permissions"]["fileSystem"]["read"]
+
+        second = client.post(
+            "/v1/responses",
+            json={
+                "model": "codex/gpt-5.5",
+                "previous_response_id": first_body["id"],
+                "input": [
+                    {
+                        "type": "function_call_output",
+                        "call_id": "approval_1",
+                        "output": "accept",
+                    }
+                ],
+                "stream": False,
+            },
+        )
+
+        assert second.status_code == 200
+        second_body = second.json()
+        assert second_body["status"] == "completed"
+        assert second_body["output"][0]["content"][0]["text"] == "Codex e2e approved."
+        assert second_body["usage"] == {"input_tokens": 2, "output_tokens": 3}
+
+
+def test_codex_streaming_approval_exposes_only_ask_user_question(tmp_path):
+    fake_bin = _write_fake_codex(tmp_path)
+
+    with codex_client_context(fake_bin) as client:
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": "codex/gpt-5.5",
+                "input": "run a command",
+                "stream": True,
+            },
+        )
+
+    assert response.status_code == 200
+    assert '"status": "requires_action"' in response.text
+    assert '"name": "AskUserQuestion"' in response.text
+    assert "codex_approval" not in response.text

--- a/tests/test_admin_skills.py
+++ b/tests/test_admin_skills.py
@@ -50,6 +50,22 @@ def empty_workspace(tmp_path):
         yield tmp_path
 
 
+@pytest.fixture
+def multi_backend_workspace(tmp_path):
+    for root_name, body in [
+        (".claude", "Claude body"),
+        (".agents", "Codex body"),
+        (".opencode", "OpenCode body"),
+    ]:
+        skill_dir = tmp_path / root_name / "skills" / "hello-world"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: hello-world\ndescription: Backend skill\n---\n" + body
+        )
+    with patch("src.admin_service.get_workspace_root", return_value=tmp_path):
+        yield tmp_path
+
+
 # ---------------------------------------------------------------------------
 # Frontmatter parsing
 # ---------------------------------------------------------------------------
@@ -171,6 +187,46 @@ class TestListSkills:
         with patch("src.admin_service.get_workspace_root", return_value=tmp_path):
             skills = list_skills()
         assert skills == []
+
+
+# ---------------------------------------------------------------------------
+# Backend skill roots
+# ---------------------------------------------------------------------------
+
+
+class TestBackendSkillRoots:
+    def test_list_skills_uses_codex_agents_root(self, multi_backend_workspace):
+        skills = list_skills(backend="codex")
+        assert [s["name"] for s in skills] == ["hello-world"]
+
+    def test_get_skill_uses_opencode_root(self, multi_backend_workspace):
+        meta, content, etag = get_skill("hello-world", backend="opencode")
+        assert meta["description"] == "Backend skill"
+        assert content.endswith("OpenCode body")
+        assert etag
+
+    def test_create_skill_uses_codex_root(self, empty_workspace):
+        etag, created = create_or_update_skill(
+            "codex-only",
+            "---\nname: codex-only\ndescription: Codex\n---\nBody",
+            backend="codex",
+        )
+        assert created is True
+        assert etag
+        assert (empty_workspace / ".agents" / "skills" / "codex-only" / "SKILL.md").is_file()
+
+    def test_delete_skill_uses_opencode_root(self, multi_backend_workspace):
+        delete_skill("hello-world", backend="opencode")
+        assert not (
+            multi_backend_workspace / ".opencode" / "skills" / "hello-world"
+        ).exists()
+        assert (
+            multi_backend_workspace / ".claude" / "skills" / "hello-world"
+        ).exists()
+
+    def test_rejects_unknown_skill_backend(self, workspace):
+        with pytest.raises(ValueError, match="Unsupported skill backend"):
+            list_skills(backend="bad-backend")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_admin_skills.py
+++ b/tests/test_admin_skills.py
@@ -392,6 +392,32 @@ class TestSkillsAPI:
         assert data["status"] == "created"
         assert data["etag"]
 
+    def test_list_codex_skills_query_param(self, admin_client, workspace):
+        codex_skill = workspace / ".agents" / "skills" / "codex-skill"
+        codex_skill.mkdir(parents=True)
+        (codex_skill / "SKILL.md").write_text(
+            "---\nname: codex-skill\ndescription: Codex\n---\nBody"
+        )
+        r = admin_client.get("/admin/api/skills?backend=codex")
+        assert r.status_code == 200
+        names = {s["name"] for s in r.json()["skills"]}
+        assert names == {"codex-skill"}
+
+    def test_put_opencode_skill_query_param(self, admin_client, workspace):
+        r = admin_client.put(
+            "/admin/api/skills/open-skill?backend=opencode",
+            json={"content": "---\nname: open-skill\ndescription: OpenCode\n---\nBody"},
+        )
+        assert r.status_code == 201
+        assert (
+            workspace / ".opencode" / "skills" / "open-skill" / "SKILL.md"
+        ).is_file()
+
+    def test_invalid_skill_backend_query_param(self, admin_client):
+        r = admin_client.get("/admin/api/skills?backend=invalid")
+        assert r.status_code == 400
+        assert "Unsupported skill backend" in r.json()["error"]
+
     def test_update_skill(self, admin_client):
         # Get current etag
         r = admin_client.get("/admin/api/skills/hello-world")

--- a/tests/test_admin_skills.py
+++ b/tests/test_admin_skills.py
@@ -217,12 +217,8 @@ class TestBackendSkillRoots:
 
     def test_delete_skill_uses_opencode_root(self, multi_backend_workspace):
         delete_skill("hello-world", backend="opencode")
-        assert not (
-            multi_backend_workspace / ".opencode" / "skills" / "hello-world"
-        ).exists()
-        assert (
-            multi_backend_workspace / ".claude" / "skills" / "hello-world"
-        ).exists()
+        assert not (multi_backend_workspace / ".opencode" / "skills" / "hello-world").exists()
+        assert (multi_backend_workspace / ".claude" / "skills" / "hello-world").exists()
 
     def test_rejects_unknown_skill_backend(self, workspace):
         with pytest.raises(ValueError, match="Unsupported skill backend"):
@@ -409,9 +405,7 @@ class TestSkillsAPI:
             json={"content": "---\nname: open-skill\ndescription: OpenCode\n---\nBody"},
         )
         assert r.status_code == 201
-        assert (
-            workspace / ".opencode" / "skills" / "open-skill" / "SKILL.md"
-        ).is_file()
+        assert (workspace / ".opencode" / "skills" / "open-skill" / "SKILL.md").is_file()
 
     def test_invalid_skill_backend_query_param(self, admin_client):
         r = admin_client.get("/admin/api/skills?backend=invalid")

--- a/tests/test_ask_user_question.py
+++ b/tests/test_ask_user_question.py
@@ -786,6 +786,60 @@ class TestContinuationNonStreaming:
         assert exc_info.value.status_code == 502
         sdk_client.disconnect.assert_awaited_once()
 
+    async def test_non_streaming_continuation_timeout_returns_504_and_releases_lock(
+        self, monkeypatch
+    ):
+        """Non-streaming continuation has a route-level timeout guard."""
+        from fastapi import HTTPException
+
+        from src.routes.responses import _handle_function_call_output
+
+        session_id = "00000000-0000-0000-0000-000000000000"
+        session = _make_continuation_session(session_id, turn=1)
+        sdk_client = AsyncMock()
+        sdk_client.disconnect = AsyncMock()
+        session.client = sdk_client
+        body = _make_body(stream=False)
+        resolved = _make_resolved()
+
+        backend = MagicMock()
+        backend.run_completion_with_client = MagicMock()
+
+        async def fake_receive(client, sess):
+            await asyncio.Event().wait()
+            yield {"type": "result", "subtype": "success", "result": "unreachable"}
+
+        backend.receive_response_from_client = fake_receive
+        backend.parse_message = MagicMock(return_value=None)
+        monkeypatch.setattr(
+            responses_module,
+            "NON_STREAM_CONTINUATION_TIMEOUT_SECONDS",
+            0.01,
+            raising=False,
+        )
+
+        with patch.object(responses_module, "session_manager") as mock_sm:
+            mock_sm.add_assistant_response = MagicMock()
+
+            with pytest.raises(HTTPException) as exc_info:
+                await asyncio.wait_for(
+                    _handle_function_call_output(
+                        body,
+                        resolved,
+                        backend,
+                        session,
+                        session_id,
+                        "/tmp/ws/test",
+                        {"call_id": "toolu_abc", "output": "yes"},
+                    ),
+                    timeout=0.5,
+                )
+
+        assert exc_info.value.status_code == 504
+        assert "timed out" in exc_info.value.detail
+        assert not session.lock.locked()
+        sdk_client.disconnect.assert_awaited_once()
+
     async def test_empty_response_returns_502(self):
         """When backend yields no text, returns 502."""
         from fastapi import HTTPException

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -638,6 +638,45 @@ async def test_codex_client_resumes_command_approval_and_continues_turn(monkeypa
 
 
 @pytest.mark.asyncio
+async def test_codex_resume_approval_rejects_request_id_mismatch(monkeypatch):
+    """Approval resume refuses corrupted request state instead of falling back silently."""
+    fake_rpc = FakeRpc()
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(session=session, model="gpt-5.5")
+    client.pending_approval_request_id = "approval_other"
+    client.pending_approval_method = "item/commandExecution/requestApproval"
+    client.pending_approval_turn_id = "turn_1"
+    client.pending_approval_params = {"turnId": "turn_1"}
+
+    chunks = [
+        chunk
+        async for chunk in backend.resume_approval_with_client(
+            client,
+            "approval_1",
+            "accept",
+            session,
+        )
+    ]
+
+    assert fake_rpc.respond_calls == []
+    assert chunks == [
+        {
+            "type": "error",
+            "is_error": True,
+            "error_message": (
+                "Codex approval request id mismatch: pending 'approval_other', "
+                "received 'approval_1'"
+            ),
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_codex_client_reuses_shared_rpc_process(monkeypatch):
     """One Codex backend process is reused across gateway sessions."""
     created = []
@@ -844,6 +883,19 @@ def test_codex_json_rpc_client_does_not_auto_accept_approval_requests():
         "permissions": {},
         "scope": "turn",
     }
+
+
+def test_codex_json_rpc_client_logs_unknown_server_request(caplog):
+    """Unknown app-server request methods stay deny-neutral but visible in logs."""
+    from src.backends.codex.client import CodexJsonRpcClient
+
+    rpc = CodexJsonRpcClient()
+
+    with caplog.at_level("WARNING", logger="src.backends.codex.client"):
+        assert rpc._handle_server_request({"method": "item/newFeature/requestApproval"}) == {}
+
+    assert "Unknown Codex server request method" in caplog.text
+    assert "item/newFeature/requestApproval" in caplog.text
 
 
 def test_codex_json_rpc_client_queues_approval_requests_while_waiting_for_response(

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -552,6 +552,24 @@ def test_codex_client_maps_permission_approval_outputs():
     ) == {"permissions": {}, "scope": "turn"}
 
 
+def test_codex_client_logs_unrecognized_structured_approval_output(caplog):
+    """Unknown structured approval outputs fail closed but leave an operator breadcrumb."""
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+
+    with caplog.at_level("WARNING", logger="src.backends.codex.client"):
+        result = backend._approval_result_from_output(
+            "item/permissions/requestApproval",
+            '{"foo": 1}',
+            {"permissions": {"fileSystem": {"read": ["/repo"]}}},
+        )
+
+    assert result == {"permissions": {}, "scope": "turn"}
+    assert "Unrecognized Codex approval output" in caplog.text
+    assert "{'foo': 1}" in caplog.text
+
+
 @pytest.mark.asyncio
 async def test_codex_client_resumes_command_approval_and_continues_turn(monkeypatch):
     """Codex approval continuation responds to app-server and reads remaining events."""
@@ -635,6 +653,43 @@ async def test_codex_client_resumes_command_approval_and_continues_turn(monkeypa
     } in chunks
     assert chunks[-2]["content"] == [{"type": "text", "text": "Tests passed."}]
     assert chunks[-1]["result"] == "Tests passed."
+
+
+@pytest.mark.asyncio
+async def test_codex_run_completion_redacts_stderr_tail_from_public_error(monkeypatch):
+    """Transport details are logged internally but not returned to API clients."""
+    from src.backends.codex.client import CodexAppServerError, CodexClient, CodexSessionClient
+
+    backend = CodexClient()
+
+    async def fail_ensure_rpc(_env):
+        raise CodexAppServerError("Timed out waiting. stderr_tail=/repo/secret-token")
+
+    monkeypatch.setattr(backend, "_ensure_rpc_locked", fail_ensure_rpc)
+    monkeypatch.setattr(backend, "_close_rpc_locked", AsyncMock())
+
+    chunks = [
+        chunk
+        async for chunk in backend.run_completion_with_client(
+            CodexSessionClient(
+                rpc=FakeRpc(),
+                thread_id="thr_codex",
+                model=None,
+                cwd="/repo",
+                env={},
+            ),
+            "hello",
+            SimpleNamespace(session_id="gw-session"),
+        )
+    ]
+
+    assert chunks == [
+        {
+            "type": "error",
+            "is_error": True,
+            "error_message": "Timed out waiting.",
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -4,6 +4,7 @@ import asyncio
 import importlib
 import subprocess
 import sys
+from unittest.mock import AsyncMock
 from types import SimpleNamespace
 
 import pytest
@@ -98,6 +99,7 @@ class FakeRpc:
         self.thread_start_calls = []
         self.thread_resume_calls = []
         self.turn_start_calls = []
+        self.respond_calls = []
         self.notifications = []
 
     def start(self):
@@ -122,6 +124,9 @@ class FakeRpc:
         if not self.notifications:
             raise AssertionError("test exhausted notifications")
         return self.notifications.pop(0)
+
+    def respond(self, request_id, result):
+        self.respond_calls.append((request_id, result))
 
 
 @pytest.mark.asyncio
@@ -310,6 +315,329 @@ async def test_codex_client_finishes_when_thread_returns_idle_without_turn_compl
 
 
 @pytest.mark.asyncio
+async def test_codex_client_exposes_command_approval_as_pending_tool_call(monkeypatch):
+    """Codex approval JSON-RPC requests pause the turn as AskUserQuestion."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = [
+        {
+            "id": "approval_1",
+            "method": "item/commandExecution/requestApproval",
+            "params": {
+                "threadId": "thr_codex",
+                "turnId": "turn_1",
+                "itemId": "cmd_1",
+                "command": "pytest -q",
+                "cwd": "/repo",
+                "reason": "Run the test suite",
+                "availableDecisions": ["accept", "acceptForSession", "decline"],
+            },
+        }
+    ]
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(session=session, model="gpt-5.5")
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "test", session)]
+
+    assert chunks == [
+        {
+            "type": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "approval_1",
+                    "name": "codex_approval",
+                    "input": {
+                        "kind": "command",
+                        "question": "Codex requests approval to run command: pytest -q",
+                        "command": "pytest -q",
+                        "cwd": "/repo",
+                        "reason": "Run the test suite",
+                        "itemId": "cmd_1",
+                        "options": [
+                            {"label": "accept", "description": "Approve this request once."},
+                            {
+                                "label": "acceptForSession",
+                                "description": "Approve matching requests for this session.",
+                            },
+                            {"label": "decline", "description": "Deny and let Codex continue."},
+                        ],
+                    },
+                    "metadata": {
+                        "codex_approval_request_id": "approval_1",
+                        "codex_approval_method": "item/commandExecution/requestApproval",
+                        "codex_thread_id": "thr_codex",
+                        "codex_turn_id": "turn_1",
+                    },
+                }
+            ],
+        }
+    ]
+    assert session.pending_tool_call == {
+        "call_id": "approval_1",
+        "name": "AskUserQuestion",
+        "arguments": {
+            "kind": "command",
+            "question": "Codex requests approval to run command: pytest -q",
+            "command": "pytest -q",
+            "cwd": "/repo",
+            "reason": "Run the test suite",
+            "itemId": "cmd_1",
+            "options": [
+                {"label": "accept", "description": "Approve this request once."},
+                {
+                    "label": "acceptForSession",
+                    "description": "Approve matching requests for this session.",
+                },
+                {"label": "decline", "description": "Deny and let Codex continue."},
+            ],
+        },
+        "backend": "codex",
+        "codex_resume": "approval",
+    }
+
+
+def test_codex_client_exposes_file_change_and_permission_approval_arguments():
+    """Non-command approval kinds preserve the app-server approval context."""
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+
+    file_chunks = list(
+        backend._chunks_from_notifications(
+            thread_id="thr_codex",
+            turn_id="turn_1",
+            notifications=[
+                {
+                    "id": "file_approval_1",
+                    "method": "item/fileChange/requestApproval",
+                    "params": {
+                        "threadId": "thr_codex",
+                        "turnId": "turn_1",
+                        "itemId": "file_1",
+                        "grantRoot": "/repo",
+                        "reason": "Need write access",
+                    },
+                }
+            ],
+        )
+    )
+    file_input = file_chunks[0]["tool_chunk"]["content"][0]["input"]
+    assert file_input["kind"] == "file_change"
+    assert file_input["grantRoot"] == "/repo"
+    assert file_input["itemId"] == "file_1"
+    assert [option["label"] for option in file_input["options"]] == [
+        "accept",
+        "acceptForSession",
+        "decline",
+        "cancel",
+    ]
+
+    permissions = {"fileSystem": {"read": ["/repo"]}, "network": {"enabled": True}}
+    permission_chunks = list(
+        backend._chunks_from_notifications(
+            thread_id="thr_codex",
+            turn_id="turn_1",
+            notifications=[
+                {
+                    "id": "permission_approval_1",
+                    "method": "item/permissions/requestApproval",
+                    "params": {
+                        "threadId": "thr_codex",
+                        "turnId": "turn_1",
+                        "itemId": "perm_1",
+                        "cwd": "/repo",
+                        "permissions": permissions,
+                        "reason": "Need broader access",
+                    },
+                }
+            ],
+        )
+    )
+    permission_input = permission_chunks[0]["tool_chunk"]["content"][0]["input"]
+    assert permission_input["kind"] == "permissions"
+    assert permission_input["cwd"] == "/repo"
+    assert permission_input["permissions"] == permissions
+    assert permission_input["itemId"] == "perm_1"
+    assert [option["label"] for option in permission_input["options"]] == [
+        "accept",
+        "acceptForSession",
+        "decline",
+    ]
+
+
+def test_codex_client_preserves_structured_command_approval_decisions():
+    """Structured Codex decisions can be displayed and selected by label."""
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    execpolicy_decision = {
+        "acceptWithExecpolicyAmendment": {"execpolicy_amendment": ["allow command pytest"]}
+    }
+    network_decision = {
+        "applyNetworkPolicyAmendment": {
+            "network_policy_amendment": {"action": "allow", "host": "example.com"}
+        }
+    }
+    params = {
+        "threadId": "thr_codex",
+        "turnId": "turn_1",
+        "itemId": "cmd_1",
+        "command": "curl https://example.com",
+        "proposedExecpolicyAmendment": ["allow command pytest"],
+        "proposedNetworkPolicyAmendments": [{"action": "allow", "host": "example.com"}],
+        "availableDecisions": [execpolicy_decision, network_decision, "decline"],
+    }
+
+    arguments = backend._approval_arguments(
+        "item/commandExecution/requestApproval",
+        params,
+    )
+
+    assert arguments["proposedExecpolicyAmendment"] == ["allow command pytest"]
+    assert arguments["proposedNetworkPolicyAmendments"] == [
+        {"action": "allow", "host": "example.com"}
+    ]
+    assert arguments["options"] == [
+        {
+            "label": "acceptWithExecpolicyAmendment",
+            "description": "Approve and apply the proposed execpolicy amendment.",
+            "decision": execpolicy_decision,
+        },
+        {
+            "label": "applyNetworkPolicyAmendment:allow:example.com",
+            "description": "Choose applyNetworkPolicyAmendment:allow:example.com.",
+            "decision": network_decision,
+        },
+        {"label": "decline", "description": "Deny and let Codex continue."},
+    ]
+    assert backend._approval_result_from_output(
+        "item/commandExecution/requestApproval",
+        "acceptWithExecpolicyAmendment",
+        params,
+    ) == {"decision": execpolicy_decision}
+    assert backend._approval_result_from_output(
+        "item/commandExecution/requestApproval",
+        "applyNetworkPolicyAmendment:allow:example.com",
+        params,
+    ) == {"decision": network_decision}
+
+
+def test_codex_client_maps_permission_approval_outputs():
+    """Permission approvals return the schema-required permissions/scope object."""
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    permissions = {"fileSystem": {"read": ["/repo"]}, "network": {"enabled": True}}
+    params = {"permissions": permissions}
+
+    assert backend._approval_result_from_output(
+        "item/permissions/requestApproval",
+        "accept",
+        params,
+    ) == {"permissions": permissions, "scope": "turn"}
+    assert backend._approval_result_from_output(
+        "item/permissions/requestApproval",
+        "always",
+        params,
+    ) == {"permissions": permissions, "scope": "session"}
+    assert backend._approval_result_from_output(
+        "item/permissions/requestApproval",
+        "decline",
+        params,
+    ) == {"permissions": {}, "scope": "turn"}
+
+
+@pytest.mark.asyncio
+async def test_codex_client_resumes_command_approval_and_continues_turn(monkeypatch):
+    """Codex approval continuation responds to app-server and reads remaining events."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = [
+        {
+            "method": "serverRequest/resolved",
+            "params": {"threadId": "thr_codex", "requestId": "approval_1"},
+        },
+        {
+            "method": "item/completed",
+            "params": {
+                "threadId": "thr_codex",
+                "turnId": "turn_1",
+                "item": {
+                    "type": "commandExecution",
+                    "id": "cmd_1",
+                    "command": "pytest -q",
+                    "cwd": "/repo",
+                    "status": "completed",
+                    "exitCode": 0,
+                    "aggregatedOutput": "18 passed",
+                    "commandActions": [],
+                },
+            },
+        },
+        {
+            "method": "item/completed",
+            "params": {
+                "threadId": "thr_codex",
+                "turnId": "turn_1",
+                "item": {
+                    "type": "agentMessage",
+                    "id": "msg_1",
+                    "phase": "final_answer",
+                    "text": "Tests passed.",
+                },
+            },
+        },
+        {
+            "method": "turn/completed",
+            "params": {
+                "threadId": "thr_codex",
+                "turn": {"id": "turn_1", "status": "completed", "items": []},
+            },
+        },
+    ]
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(session=session, model="gpt-5.5")
+    client.pending_approval_request_id = "approval_1"
+    client.pending_approval_method = "item/commandExecution/requestApproval"
+    client.pending_approval_turn_id = "turn_1"
+    client.pending_approval_params = {"turnId": "turn_1"}
+
+    chunks = [
+        chunk
+        async for chunk in backend.resume_approval_with_client(
+            client,
+            "approval_1",
+            "accept",
+            session,
+        )
+    ]
+
+    assert fake_rpc.respond_calls == [("approval_1", {"decision": "accept"})]
+    assert {
+        "type": "user",
+        "content": [
+            {
+                "type": "tool_result",
+                "tool_use_id": "cmd_1",
+                "content": "18 passed",
+                "is_error": False,
+            }
+        ],
+    } in chunks
+    assert chunks[-2]["content"] == [{"type": "text", "text": "Tests passed."}]
+    assert chunks[-1]["result"] == "Tests passed."
+
+
+@pytest.mark.asyncio
 async def test_codex_client_reuses_shared_rpc_process(monkeypatch):
     """One Codex backend process is reused across gateway sessions."""
     created = []
@@ -417,9 +745,7 @@ async def test_codex_client_restarts_shared_rpc_after_turn_error(monkeypatch):
 
     chunks = [chunk async for chunk in backend.run_completion_with_client(client, "hi", session)]
 
-    assert chunks == [
-        {"type": "error", "is_error": True, "error_message": "transport failed"}
-    ]
+    assert chunks == [{"type": "error", "is_error": True, "error_message": "transport failed"}]
     assert created[0].closed is True
 
     await backend.create_client(session=SimpleNamespace(session_id="gw-session-2"), model="gpt-5.5")
@@ -503,14 +829,14 @@ def test_codex_json_rpc_client_times_out_waiting_for_message():
 
 
 def test_codex_json_rpc_client_does_not_auto_accept_approval_requests():
-    """Approval requests are cancelled until the gateway has an explicit approval flow."""
+    """Unexpected direct approval requests use a deny-safe fallback."""
     from src.backends.codex.client import CodexJsonRpcClient
 
     rpc = CodexJsonRpcClient()
 
-    assert rpc._handle_server_request(
-        {"method": "item/commandExecution/requestApproval"}
-    ) == {"decision": "cancel"}
+    assert rpc._handle_server_request({"method": "item/commandExecution/requestApproval"}) == {
+        "decision": "cancel"
+    }
     assert rpc._handle_server_request({"method": "item/fileChange/requestApproval"}) == {
         "decision": "cancel"
     }
@@ -518,6 +844,34 @@ def test_codex_json_rpc_client_does_not_auto_accept_approval_requests():
         "permissions": {},
         "scope": "turn",
     }
+
+
+def test_codex_json_rpc_client_queues_approval_requests_while_waiting_for_response(
+    monkeypatch,
+):
+    """Approval requests interleaved with regular responses are not cancelled."""
+    from src.backends.codex.client import CodexJsonRpcClient
+
+    rpc = CodexJsonRpcClient()
+    writes = []
+    messages = iter(
+        [
+            {
+                "id": "approval_1",
+                "method": "item/commandExecution/requestApproval",
+                "params": {"threadId": "thr", "turnId": "turn"},
+            },
+            {"id": "req_1", "result": {"ok": True}},
+        ]
+    )
+
+    monkeypatch.setattr("src.backends.codex.client.uuid.uuid4", lambda: "req_1")
+    monkeypatch.setattr(rpc, "_write_message", writes.append)
+    monkeypatch.setattr(rpc, "_read_message", lambda: next(messages))
+
+    assert rpc.request("turn/start", {"threadId": "thr"}) == {"ok": True}
+    assert writes == [{"id": "req_1", "method": "turn/start", "params": {"threadId": "thr"}}]
+    assert rpc.next_notification()["id"] == "approval_1"
 
 
 @pytest.mark.asyncio
@@ -532,3 +886,75 @@ async def test_codex_session_disconnect_is_async(monkeypatch):
     await asyncio.wait_for(client.disconnect(), timeout=1)
 
     assert fake_rpc.closed is False
+
+
+@pytest.mark.asyncio
+async def test_codex_function_call_output_uses_approval_resume_without_input_event(monkeypatch):
+    """Codex approval continuations use the Codex resume hook, not Claude input_event."""
+    from src.backends import ResolvedModel
+    from src.response_models import ResponseCreateRequest
+    from src.routes.responses import _handle_function_call_output
+    from src.session_manager import Session
+
+    session = Session(session_id="00000000-0000-0000-0000-000000000000", backend="codex")
+    session.client = object()
+    session.workspace = "/tmp/ws/test"
+    session.turn_counter = 1
+    session.pending_tool_call = {
+        "call_id": "approval_1",
+        "name": "AskUserQuestion",
+        "arguments": {"question": "Approve?"},
+        "backend": "codex",
+        "codex_resume": "approval",
+    }
+    session.input_event = None
+
+    body = ResponseCreateRequest(
+        model="codex/gpt-5.5",
+        input=[
+            {
+                "type": "function_call_output",
+                "call_id": "approval_1",
+                "output": "accept",
+            }
+        ],
+        previous_response_id="resp_00000000-0000-0000-0000-000000000000_1",
+        stream=False,
+    )
+    resolved = ResolvedModel("codex/gpt-5.5", "codex", "gpt-5.5")
+
+    calls = []
+
+    class FakeBackend:
+        name = "codex"
+
+        async def resume_approval_with_client(self, client, call_id, output, sess):
+            calls.append((client, call_id, output, sess))
+            yield {"type": "result", "subtype": "success", "result": "approved"}
+
+        def parse_message(self, chunks):
+            return "approved"
+
+        def estimate_token_usage(self, prompt, completion, model=None):
+            return {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3}
+
+    monkeypatch.setattr(
+        "src.routes.responses.usage_logger.log_turn_from_context",
+        AsyncMock(),
+    )
+
+    result = await _handle_function_call_output(
+        body,
+        resolved,
+        FakeBackend(),
+        session,
+        session.session_id,
+        "/tmp/ws/test",
+        {"call_id": "approval_1", "output": "accept"},
+    )
+
+    assert result["status"] == "completed"
+    assert result["output"][0]["content"][0]["text"] == "approved"
+    assert session.turn_counter == 2
+    assert session.pending_tool_call is None
+    assert calls == [(session.client, "approval_1", "accept", session)]

--- a/tests/test_main_api_unit.py
+++ b/tests/test_main_api_unit.py
@@ -925,9 +925,7 @@ async def test_opencode_question_capture_stops_waiting_for_stream_end():
         finally:
             source_closed = True
 
-    captured = responses_module._capture_opencode_pending_questions(
-        chunk_source(), resolved, session
-    )
+    captured = responses_module._capture_pending_tool_questions(chunk_source(), resolved, session)
 
     try:
         await asyncio.wait_for(captured.__anext__(), timeout=0.05)

--- a/tests/test_main_coverage_unit.py
+++ b/tests/test_main_coverage_unit.py
@@ -203,6 +203,7 @@ class TestResponsesApiSessionValidation:
             yield {"subtype": "success", "result": "Hi"}
 
         with client_context() as (client, mock_cli):
+            mock_cli.create_client = AsyncMock(return_value=object())
             mock_cli.run_completion_with_client = fake_run
             mock_cli.parse_message.return_value = "Hi"
 
@@ -218,6 +219,7 @@ class TestResponsesApiSessionValidation:
 
         assert response.status_code == 409
         assert "Stale" in response.json()["error"]["message"]
+        mock_cli.create_client.assert_not_called()
 
     def test_future_turn_response_id_returns_404(self):
         """Future turn previous_response_id."""
@@ -228,7 +230,8 @@ class TestResponsesApiSessionValidation:
 
         future_resp_id = f"resp_{session_id}_5"
 
-        with client_context() as (client, _mock_cli):
+        with client_context() as (client, mock_cli):
+            mock_cli.create_client = AsyncMock(return_value=object())
             response = client.post(
                 "/v1/responses",
                 json={
@@ -241,6 +244,7 @@ class TestResponsesApiSessionValidation:
 
         assert response.status_code == 404
         assert "future turn" in response.json()["error"]["message"]
+        mock_cli.create_client.assert_not_called()
 
     def test_backend_mismatch_returns_400(self):
         """Backend mismatch on follow-up."""
@@ -252,7 +256,8 @@ class TestResponsesApiSessionValidation:
 
         resp_id = f"resp_{session_id}_1"
 
-        with client_context() as (client, _mock_cli):
+        with client_context() as (client, mock_cli):
+            mock_cli.create_client = AsyncMock(return_value=object())
             response = client.post(
                 "/v1/responses",
                 json={
@@ -265,6 +270,7 @@ class TestResponsesApiSessionValidation:
 
         assert response.status_code == 400
         assert "Cannot mix backends" in response.json()["error"]["message"]
+        mock_cli.create_client.assert_not_called()
 
     def test_create_client_failure_returns_503_and_deletes_session(self):
         """When backend.create_client raises, the route returns 503 and clears the session."""
@@ -485,7 +491,8 @@ class TestResponsesStreamingValidationViaEndpoint:
 
         stale_resp_id = f"resp_{session_id}_2"
 
-        with client_context() as (client, _mock_cli):
+        with client_context() as (client, mock_cli):
+            mock_cli.create_client = AsyncMock(return_value=object())
             response = client.post(
                 "/v1/responses",
                 json={
@@ -497,6 +504,31 @@ class TestResponsesStreamingValidationViaEndpoint:
             )
 
         assert response.status_code == 409
+        mock_cli.create_client.assert_not_called()
+
+    def test_streaming_future_response_id_returns_404(self):
+        """Future previous_response_id in streaming mode returns 404."""
+        session_id = str(uuid.uuid4())
+        session = session_manager.get_or_create_session(session_id)
+        session.turn_counter = 1
+        session.backend = "claude"
+
+        future_resp_id = f"resp_{session_id}_5"
+
+        with client_context() as (client, mock_cli):
+            mock_cli.create_client = AsyncMock(return_value=object())
+            response = client.post(
+                "/v1/responses",
+                json={
+                    "model": DEFAULT_MODEL,
+                    "input": "Hi",
+                    "previous_response_id": future_resp_id,
+                    "stream": True,
+                },
+            )
+
+        assert response.status_code == 404
+        mock_cli.create_client.assert_not_called()
 
     def test_streaming_backend_mismatch_returns_400(self):
         """Backend mismatch in streaming mode returns 400."""
@@ -507,7 +539,8 @@ class TestResponsesStreamingValidationViaEndpoint:
 
         resp_id = f"resp_{session_id}_1"
 
-        with client_context() as (client, _mock_cli):
+        with client_context() as (client, mock_cli):
+            mock_cli.create_client = AsyncMock(return_value=object())
             response = client.post(
                 "/v1/responses",
                 json={
@@ -519,6 +552,7 @@ class TestResponsesStreamingValidationViaEndpoint:
             )
 
         assert response.status_code == 400
+        mock_cli.create_client.assert_not_called()
 
 
 # ===========================================================================

--- a/tests/test_main_coverage_unit.py
+++ b/tests/test_main_coverage_unit.py
@@ -554,6 +554,32 @@ class TestResponsesStreamingValidationViaEndpoint:
         assert response.status_code == 400
         mock_cli.create_client.assert_not_called()
 
+    def test_streaming_create_client_failure_returns_503_and_releases_lock(self):
+        """Streaming client creation failure cleans up before returning a response."""
+        captured = {}
+
+        async def failing_create_client(**kwargs):
+            captured["session"] = kwargs["session"]
+            raise RuntimeError("simulated streaming SDK boot failure")
+
+        with client_context() as (client, mock_cli):
+            mock_cli.create_client = AsyncMock(side_effect=failing_create_client)
+
+            response = client.post(
+                "/v1/responses",
+                json={
+                    "model": DEFAULT_MODEL,
+                    "input": "Hi",
+                    "stream": True,
+                },
+            )
+
+        session = captured["session"]
+        assert response.status_code == 503
+        assert not session.lock.locked()
+        assert session.client is None
+        assert session_manager.get_session(session.session_id) is None
+
 
 # ===========================================================================
 # Validation handler body read exception in DEBUG mode

--- a/tests/test_responses_user.py
+++ b/tests/test_responses_user.py
@@ -71,9 +71,7 @@ class TestUserParam:
             )
 
         assert resp.status_code == 200
-        mock_wm.resolve.assert_called_once_with(
-            "alice", sync_template=True, backend="claude"
-        )
+        mock_wm.resolve.assert_called_once_with("alice", sync_template=True, backend="claude")
 
     def test_user_none_creates_temp_workspace(self, isolated_session_manager):
         mock_wm = MagicMock()
@@ -91,9 +89,7 @@ class TestUserParam:
             )
 
         assert resp.status_code == 200
-        mock_wm.resolve.assert_called_once_with(
-            None, sync_template=True, backend="claude"
-        )
+        mock_wm.resolve.assert_called_once_with(None, sync_template=True, backend="claude")
 
     def test_cwd_passed_to_run_completion(self, isolated_session_manager):
         """cwd is forwarded to create_client (which spawns the persistent SDK session)."""
@@ -121,9 +117,7 @@ class TestUserParam:
         assert len(create_calls) == 1
         assert create_calls[0]["cwd"] == "/tmp/ws/alice/claude"
 
-    def test_responses_resolves_codex_workspace_with_codex_backend(
-        self, isolated_session_manager
-    ):
+    def test_responses_resolves_codex_workspace_with_codex_backend(self, isolated_session_manager):
         mock_wm = MagicMock()
         mock_wm.resolve.return_value = Path("/tmp/ws/alice/codex")
         create_calls = []
@@ -151,9 +145,7 @@ class TestUserParam:
             )
 
         assert resp.status_code == 200
-        mock_wm.resolve.assert_called_once_with(
-            "alice", sync_template=True, backend="codex"
-        )
+        mock_wm.resolve.assert_called_once_with("alice", sync_template=True, backend="codex")
         assert create_calls[0]["cwd"] == "/tmp/ws/alice/codex"
 
     def test_invalid_user_returns_400(self, isolated_session_manager):
@@ -258,15 +250,11 @@ class TestUserSessionBinding:
         assert resp.status_code == 200
         # workspace_manager.resolve is called once with sync_template=False for the
         # early cwd lookup used by get_session rehydrate-on-miss; never with sync_template=True.
-        mock_wm.resolve.assert_called_once_with(
-            "alice", sync_template=False, backend="claude"
-        )
+        mock_wm.resolve.assert_called_once_with("alice", sync_template=False, backend="claude")
         # cwd should be the stored workspace path (from session.workspace, not the early resolve)
         assert create_calls[0]["cwd"] == "/tmp/ws/alice"
 
-    def test_claude_followup_falls_back_to_legacy_workspace_lookup(
-        self, isolated_session_manager
-    ):
+    def test_claude_followup_falls_back_to_legacy_workspace_lookup(self, isolated_session_manager):
         """Claude continuations can rehydrate sessions from the legacy user workspace."""
         existing_session_id = "c2f6d3fd-1f1a-4c13-9c60-46b4df1d4d5f"
         session = isolated_session_manager.get_or_create_session(existing_session_id)
@@ -371,9 +359,7 @@ class TestUserSessionBinding:
             )
 
         assert resp.status_code == 200
-        mock_wm.resolve.assert_called_once_with(
-            "alice", sync_template=False, backend="codex"
-        )
+        mock_wm.resolve.assert_called_once_with("alice", sync_template=False, backend="codex")
         assert mock_get_session.call_args_list == [
             call(existing_session_id, user="alice", cwd="/tmp/ws/alice/codex"),
             call(existing_session_id),

--- a/tests/test_responses_user.py
+++ b/tests/test_responses_user.py
@@ -214,6 +214,7 @@ class TestUserSessionBinding:
 
         assert resp.status_code == 400
         assert "user mismatch" in resp.json()["error"]["message"].lower()
+        mock_wm.resolve.assert_not_called()
 
     def test_followup_reuses_stored_workspace(self, isolated_session_manager):
         """Follow-up requests reuse the workspace stored in the session."""
@@ -248,9 +249,7 @@ class TestUserSessionBinding:
             )
 
         assert resp.status_code == 200
-        # workspace_manager.resolve is called once with sync_template=False for the
-        # early cwd lookup used by get_session rehydrate-on-miss; never with sync_template=True.
-        mock_wm.resolve.assert_called_once_with("alice", sync_template=False, backend="claude")
+        mock_wm.resolve.assert_not_called()
         # cwd should be the stored workspace path (from session.workspace, not the early resolve)
         assert create_calls[0]["cwd"] == "/tmp/ws/alice"
 
@@ -284,7 +283,7 @@ class TestUserSessionBinding:
             patch.object(
                 isolated_session_manager,
                 "get_session",
-                side_effect=[None, session, session],
+                side_effect=[None, None, session, session],
             ) as mock_get_session,
             client_context_with_workspace(mock_wm) as (client, mock_cli),
         ):
@@ -308,6 +307,7 @@ class TestUserSessionBinding:
             call("alice", sync_template=False),
         ]
         assert mock_get_session.call_args_list == [
+            call(existing_session_id),
             call(existing_session_id, user="alice", cwd="/tmp/ws/alice/claude"),
             call(existing_session_id, user="alice", cwd="/tmp/ws/alice"),
             call(existing_session_id),
@@ -339,7 +339,7 @@ class TestUserSessionBinding:
             patch.object(
                 isolated_session_manager,
                 "get_session",
-                return_value=session,
+                side_effect=[None, session, session],
             ) as mock_get_session,
             client_context_with_workspace(mock_wm) as (client, mock_cli),
         ):
@@ -361,6 +361,7 @@ class TestUserSessionBinding:
         assert resp.status_code == 200
         mock_wm.resolve.assert_called_once_with("alice", sync_template=False, backend="codex")
         assert mock_get_session.call_args_list == [
+            call(existing_session_id),
             call(existing_session_id, user="alice", cwd="/tmp/ws/alice/codex"),
             call(existing_session_id),
         ]

--- a/tests/test_responses_user.py
+++ b/tests/test_responses_user.py
@@ -71,7 +71,9 @@ class TestUserParam:
             )
 
         assert resp.status_code == 200
-        mock_wm.resolve.assert_called_once_with("alice", sync_template=True)
+        mock_wm.resolve.assert_called_once_with(
+            "alice", sync_template=True, backend="claude"
+        )
 
     def test_user_none_creates_temp_workspace(self, isolated_session_manager):
         mock_wm = MagicMock()
@@ -89,12 +91,14 @@ class TestUserParam:
             )
 
         assert resp.status_code == 200
-        mock_wm.resolve.assert_called_once_with(None, sync_template=True)
+        mock_wm.resolve.assert_called_once_with(
+            None, sync_template=True, backend="claude"
+        )
 
     def test_cwd_passed_to_run_completion(self, isolated_session_manager):
         """cwd is forwarded to create_client (which spawns the persistent SDK session)."""
         mock_wm = MagicMock()
-        mock_wm.resolve.return_value = Path("/tmp/ws/alice")
+        mock_wm.resolve.return_value = Path("/tmp/ws/alice/claude")
         create_calls = []
 
         async def fake_create_client(**kwargs):
@@ -115,7 +119,42 @@ class TestUserParam:
 
         assert resp.status_code == 200
         assert len(create_calls) == 1
-        assert create_calls[0]["cwd"] == "/tmp/ws/alice"
+        assert create_calls[0]["cwd"] == "/tmp/ws/alice/claude"
+
+    def test_responses_resolves_codex_workspace_with_codex_backend(
+        self, isolated_session_manager
+    ):
+        mock_wm = MagicMock()
+        mock_wm.resolve.return_value = Path("/tmp/ws/alice/codex")
+        create_calls = []
+
+        async def fake_create_client(**kwargs):
+            create_calls.append(kwargs)
+            return object()
+
+        async def fake_run_completion(client, prompt, session):
+            yield {"subtype": "success", "result": "Hello from Codex"}
+
+        with client_context_with_workspace(mock_wm) as (client, mock_cli):
+            BackendRegistry.unregister("claude")
+            BackendRegistry.register("codex", mock_cli)
+            mock_cli.create_client = fake_create_client
+            mock_cli.run_completion_with_client = fake_run_completion
+            mock_cli.parse_message = MagicMock(return_value="Hello from Codex")
+            resp = client.post(
+                "/v1/responses",
+                json={
+                    "model": "codex/gpt-5.5",
+                    "input": "hello",
+                    "user": "alice",
+                },
+            )
+
+        assert resp.status_code == 200
+        mock_wm.resolve.assert_called_once_with(
+            "alice", sync_template=True, backend="codex"
+        )
+        assert create_calls[0]["cwd"] == "/tmp/ws/alice/codex"
 
     def test_invalid_user_returns_400(self, isolated_session_manager):
         mock_wm = MagicMock()
@@ -219,6 +258,8 @@ class TestUserSessionBinding:
         assert resp.status_code == 200
         # workspace_manager.resolve is called once with sync_template=False for the
         # early cwd lookup used by get_session rehydrate-on-miss; never with sync_template=True.
-        mock_wm.resolve.assert_called_once_with("alice", sync_template=False)
+        mock_wm.resolve.assert_called_once_with(
+            "alice", sync_template=False, backend="claude"
+        )
         # cwd should be the stored workspace path (from session.workspace, not the early resolve)
         assert create_calls[0]["cwd"] == "/tmp/ws/alice"

--- a/tests/test_responses_user.py
+++ b/tests/test_responses_user.py
@@ -1,7 +1,7 @@
 """Integration tests for user parameter in /v1/responses."""
 
 from contextlib import contextmanager
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 from pathlib import Path
 
 from fastapi.testclient import TestClient
@@ -263,3 +263,119 @@ class TestUserSessionBinding:
         )
         # cwd should be the stored workspace path (from session.workspace, not the early resolve)
         assert create_calls[0]["cwd"] == "/tmp/ws/alice"
+
+    def test_claude_followup_falls_back_to_legacy_workspace_lookup(
+        self, isolated_session_manager
+    ):
+        """Claude continuations can rehydrate sessions from the legacy user workspace."""
+        existing_session_id = "c2f6d3fd-1f1a-4c13-9c60-46b4df1d4d5f"
+        session = isolated_session_manager.get_or_create_session(existing_session_id)
+        session.user = "alice"
+        session.workspace = "/tmp/ws/alice"
+        session.turn_counter = 1
+
+        mock_wm = MagicMock()
+        create_calls = []
+
+        def fake_resolve(user, *, sync_template, backend=None):
+            assert user == "alice"
+            assert sync_template is False
+            if backend == "claude":
+                return Path("/tmp/ws/alice/claude")
+            assert backend is None
+            return Path("/tmp/ws/alice")
+
+        async def fake_create_client(**kwargs):
+            create_calls.append(kwargs)
+            return object()
+
+        async def fake_run_completion(client, prompt, session):
+            yield {"subtype": "success", "result": "Legacy follow-up answer"}
+
+        with (
+            patch.object(
+                isolated_session_manager,
+                "get_session",
+                side_effect=[None, session, session],
+            ) as mock_get_session,
+            client_context_with_workspace(mock_wm) as (client, mock_cli),
+        ):
+            mock_wm.resolve.side_effect = fake_resolve
+            mock_cli.create_client = fake_create_client
+            mock_cli.run_completion_with_client = fake_run_completion
+            mock_cli.parse_message = MagicMock(return_value="Legacy follow-up answer")
+            resp = client.post(
+                "/v1/responses",
+                json={
+                    "model": DEFAULT_MODEL,
+                    "input": "follow up",
+                    "user": "alice",
+                    "previous_response_id": f"resp_{existing_session_id}_1",
+                },
+            )
+
+        assert resp.status_code == 200
+        assert mock_wm.resolve.call_args_list == [
+            call("alice", sync_template=False, backend="claude"),
+            call("alice", sync_template=False),
+        ]
+        assert mock_get_session.call_args_list == [
+            call(existing_session_id, user="alice", cwd="/tmp/ws/alice/claude"),
+            call(existing_session_id, user="alice", cwd="/tmp/ws/alice"),
+            call(existing_session_id),
+        ]
+        assert create_calls[0]["cwd"] == "/tmp/ws/alice"
+
+    def test_codex_followup_rehydrate_uses_backend_specific_workspace(
+        self, isolated_session_manager
+    ):
+        existing_session_id = "c2f6d3fd-1f1a-4c13-9c60-46b4df1d4d5f"
+        session = isolated_session_manager.get_or_create_session(existing_session_id)
+        session.backend = "codex"
+        session.user = "alice"
+        session.workspace = "/tmp/ws/alice/codex"
+        session.turn_counter = 1
+
+        mock_wm = MagicMock()
+        mock_wm.resolve.return_value = Path("/tmp/ws/alice/codex")
+        create_calls = []
+
+        async def fake_create_client(**kwargs):
+            create_calls.append(kwargs)
+            return object()
+
+        async def fake_run_completion(client, prompt, session):
+            yield {"subtype": "success", "result": "Codex follow-up answer"}
+
+        with (
+            patch.object(
+                isolated_session_manager,
+                "get_session",
+                return_value=session,
+            ) as mock_get_session,
+            client_context_with_workspace(mock_wm) as (client, mock_cli),
+        ):
+            BackendRegistry.unregister("claude")
+            BackendRegistry.register("codex", mock_cli)
+            mock_cli.create_client = fake_create_client
+            mock_cli.run_completion_with_client = fake_run_completion
+            mock_cli.parse_message = MagicMock(return_value="Codex follow-up answer")
+            resp = client.post(
+                "/v1/responses",
+                json={
+                    "model": "codex/gpt-5.5",
+                    "input": "follow up",
+                    "user": "alice",
+                    "previous_response_id": f"resp_{existing_session_id}_1",
+                },
+            )
+
+        assert resp.status_code == 200
+        mock_wm.resolve.assert_called_once_with(
+            "alice", sync_template=False, backend="codex"
+        )
+        assert mock_get_session.call_args_list == [
+            call(existing_session_id, user="alice", cwd="/tmp/ws/alice/codex"),
+            call(existing_session_id),
+        ]
+        assert create_calls[0]["cwd"] == "/tmp/ws/alice/codex"

--- a/tests/test_workspace_manager.py
+++ b/tests/test_workspace_manager.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from src.session_manager import Session
-from src.workspace_manager import WorkspaceManager, _resolve_project_root
+from src.workspace_manager import WorkspaceManager, _resolve_project_root, _resolve_template_source
 
 
 @pytest.fixture
@@ -204,6 +204,43 @@ class TestResolve:
 
         assert (workspace / ".agents" / "config.json").is_file()
 
+    def test_codex_mirror_replaces_symlinked_agents_dir(self, tmp_base, tmp_path):
+        template = tmp_path / "template"
+        skill = template / ".claude" / "skills" / "shared-skill"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(
+            "---\nname: shared-skill\ndescription: Claude skill\n---\nClaude"
+        )
+        target = tmp_path / "outside"
+        target.mkdir()
+
+        mgr = WorkspaceManager(base_path=tmp_base, template_source=template)
+        workspace = mgr.resolve("alice", backend="codex", sync_template=False)
+        (workspace / ".agents").symlink_to(target, target_is_directory=True)
+
+        mgr.resolve("alice", backend="codex", sync_template=True)
+
+        assert (workspace / ".agents").is_dir()
+        assert not (workspace / ".agents").is_symlink()
+        assert (workspace / ".agents" / "skills" / "shared-skill" / "SKILL.md").is_file()
+        assert not (target / "skills").exists()
+
+    def test_skill_dirs_containing_symlinks_are_not_mirrored(self, tmp_base, tmp_path):
+        template = tmp_path / "template"
+        skill = template / ".claude" / "skills" / "unsafe-skill"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(
+            "---\nname: unsafe-skill\ndescription: Unsafe skill\n---\nUnsafe"
+        )
+        linked = tmp_path / "linked.txt"
+        linked.write_text("secret")
+        (skill / "linked.txt").symlink_to(linked)
+
+        mgr = WorkspaceManager(base_path=tmp_base, template_source=template)
+        workspace = mgr.resolve("alice", backend="codex", sync_template=True)
+
+        assert not (workspace / ".agents" / "skills" / "unsafe-skill").exists()
+
     def test_sync_template_false_skips_copy(self, manager, tmp_base):
         workspace = manager.resolve("carol", sync_template=False)
         assert not (workspace / ".claude").exists()
@@ -274,6 +311,16 @@ class TestSessionUserField:
 
 
 class TestResolveProjectRoot:
+    def test_resolve_template_source_returns_directory_without_claude_dir(
+        self, tmp_path, monkeypatch
+    ):
+        claude_cwd = tmp_path / "repo"
+        claude_cwd.mkdir()
+
+        monkeypatch.setenv("CLAUDE_CWD", str(claude_cwd))
+
+        assert _resolve_template_source() == claude_cwd
+
     def test_prefers_claude_cwd_when_it_has_pyproject(self, tmp_path, monkeypatch):
         claude_cwd = tmp_path / "repo"
         claude_cwd.mkdir()

--- a/tests/test_workspace_manager.py
+++ b/tests/test_workspace_manager.py
@@ -225,6 +225,52 @@ class TestResolve:
         assert (workspace / ".agents" / "skills" / "shared-skill" / "SKILL.md").is_file()
         assert not (target / "skills").exists()
 
+    def test_codex_mirror_replaces_symlinked_skills_dir(self, tmp_base, tmp_path):
+        template = tmp_path / "template"
+        skill = template / ".claude" / "skills" / "shared-skill"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(
+            "---\nname: shared-skill\ndescription: Claude skill\n---\nClaude"
+        )
+        target = tmp_path / "outside-skills"
+        target.mkdir()
+
+        mgr = WorkspaceManager(base_path=tmp_base, template_source=template)
+        workspace = mgr.resolve("alice", backend="codex", sync_template=False)
+        (workspace / ".agents").mkdir()
+        (workspace / ".agents" / "skills").symlink_to(target, target_is_directory=True)
+
+        mgr.resolve("alice", backend="codex", sync_template=True)
+
+        skills = workspace / ".agents" / "skills"
+        assert skills.is_dir()
+        assert not skills.is_symlink()
+        assert (skills / "shared-skill" / "SKILL.md").is_file()
+        assert not (target / "shared-skill").exists()
+
+    def test_opencode_mirror_replaces_symlinked_skills_dir(self, tmp_base, tmp_path):
+        template = tmp_path / "template"
+        skill = template / ".claude" / "skills" / "shared-skill"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(
+            "---\nname: shared-skill\ndescription: Claude skill\n---\nClaude"
+        )
+        target = tmp_path / "outside-skills"
+        target.mkdir()
+
+        mgr = WorkspaceManager(base_path=tmp_base, template_source=template)
+        workspace = mgr.resolve("alice", backend="opencode", sync_template=False)
+        (workspace / ".opencode").mkdir()
+        (workspace / ".opencode" / "skills").symlink_to(target, target_is_directory=True)
+
+        mgr.resolve("alice", backend="opencode", sync_template=True)
+
+        skills = workspace / ".opencode" / "skills"
+        assert skills.is_dir()
+        assert not skills.is_symlink()
+        assert (skills / "shared-skill" / "SKILL.md").is_file()
+        assert not (target / "shared-skill").exists()
+
     def test_skill_dirs_containing_symlinks_are_not_mirrored(self, tmp_base, tmp_path):
         template = tmp_path / "template"
         skill = template / ".claude" / "skills" / "unsafe-skill"

--- a/tests/test_workspace_manager.py
+++ b/tests/test_workspace_manager.py
@@ -17,13 +17,30 @@ def tmp_base(tmp_path):
 
 @pytest.fixture
 def tmp_template(tmp_path):
-    """Provide a temporary CLAUDE_CWD with a .claude folder."""
+    """Provide a temporary CLAUDE_CWD-style template directory."""
     template = tmp_path / "template"
+
     claude_dir = template / ".claude"
     claude_dir.mkdir(parents=True)
     (claude_dir / "settings.json").write_text('{"key": "value"}')
     (claude_dir / "subdir").mkdir()
     (claude_dir / "subdir" / "nested.txt").write_text("nested content")
+    claude_skill = claude_dir / "skills" / "shared-skill"
+    claude_skill.mkdir(parents=True)
+    (claude_skill / "SKILL.md").write_text(
+        "---\nname: shared-skill\ndescription: Claude skill\n---\nClaude"
+    )
+    (template / "CLAUDE.md").write_text("# Claude instructions\n")
+
+    agents_dir = template / ".agents"
+    agents_dir.mkdir()
+    (agents_dir / "config.json").write_text('{"agent": true}')
+    (template / "AGENTS.md").write_text("# Agent instructions\n")
+
+    opencode_dir = template / ".opencode"
+    opencode_dir.mkdir()
+    (opencode_dir / "opencode.json").write_text('{"permission": {}}')
+
     return template
 
 
@@ -127,6 +144,65 @@ class TestResolve:
         assert claude_dir.is_dir()
         assert (claude_dir / "settings.json").read_text() == '{"key": "value"}'
         assert (claude_dir / "subdir" / "nested.txt").read_text() == "nested content"
+
+    def test_claude_sync_copies_only_claude_native_files(self, manager):
+        workspace = manager.resolve("alice", backend="claude", sync_template=True)
+        assert (workspace / ".claude" / "settings.json").is_file()
+        assert (workspace / "CLAUDE.md").read_text() == "# Claude instructions\n"
+        assert not (workspace / ".agents").exists()
+        assert not (workspace / ".opencode").exists()
+
+    def test_codex_sync_copies_agents_and_mirrors_claude_skills(self, manager):
+        workspace = manager.resolve("alice", backend="codex", sync_template=True)
+        assert (workspace / ".agents" / "config.json").is_file()
+        assert (workspace / "AGENTS.md").read_text() == "# Agent instructions\n"
+        mirrored = workspace / ".agents" / "skills" / "shared-skill" / "SKILL.md"
+        assert mirrored.read_text().endswith("Claude")
+        assert not (workspace / ".claude").exists()
+        assert not (workspace / ".opencode").exists()
+
+    def test_opencode_sync_copies_opencode_and_mirrors_claude_skills(self, manager):
+        workspace = manager.resolve("alice", backend="opencode", sync_template=True)
+        assert (workspace / ".opencode" / "opencode.json").is_file()
+        mirrored = workspace / ".opencode" / "skills" / "shared-skill" / "SKILL.md"
+        assert mirrored.read_text().endswith("Claude")
+        assert not (workspace / ".claude").exists()
+        assert not (workspace / ".agents").exists()
+
+    def test_codex_native_skills_win_over_claude_mirror(self, tmp_base, tmp_template):
+        native = tmp_template / ".agents" / "skills" / "shared-skill"
+        native.mkdir(parents=True)
+        (native / "SKILL.md").write_text(
+            "---\nname: shared-skill\ndescription: Codex native\n---\nCodex"
+        )
+        mgr = WorkspaceManager(base_path=tmp_base, template_source=tmp_template)
+        workspace = mgr.resolve("alice", backend="codex", sync_template=True)
+        skill = workspace / ".agents" / "skills" / "shared-skill" / "SKILL.md"
+        assert skill.read_text().endswith("Codex")
+
+    def test_opencode_claude_compatibility_wins_over_agents_duplicate(
+        self, tmp_base, tmp_template
+    ):
+        agent_skill = tmp_template / ".agents" / "skills" / "shared-skill"
+        agent_skill.mkdir(parents=True)
+        (agent_skill / "SKILL.md").write_text(
+            "---\nname: shared-skill\ndescription: Agent copy\n---\nAgent"
+        )
+        mgr = WorkspaceManager(base_path=tmp_base, template_source=tmp_template)
+        workspace = mgr.resolve("alice", backend="opencode", sync_template=True)
+        skill = workspace / ".opencode" / "skills" / "shared-skill" / "SKILL.md"
+        assert skill.read_text().endswith("Claude")
+
+    def test_template_source_without_claude_dir_can_sync_agents(self, tmp_base, tmp_path):
+        template = tmp_path / "template"
+        agents = template / ".agents"
+        agents.mkdir(parents=True)
+        (agents / "config.json").write_text('{"agent": true}')
+        mgr = WorkspaceManager(base_path=tmp_base, template_source=template)
+
+        workspace = mgr.resolve("alice", backend="codex", sync_template=True)
+
+        assert (workspace / ".agents" / "config.json").is_file()
 
     def test_sync_template_false_skips_copy(self, manager, tmp_base):
         workspace = manager.resolve("carol", sync_template=False)

--- a/tests/test_workspace_manager.py
+++ b/tests/test_workspace_manager.py
@@ -269,7 +269,7 @@ class TestResolve:
         assert (skills / "shared-skill" / "SKILL.md").is_file()
         assert not (target / "shared-skill").exists()
 
-    def test_skill_dirs_containing_symlinks_are_not_mirrored(self, tmp_base, tmp_path):
+    def test_skill_dirs_containing_symlinks_are_not_mirrored(self, tmp_base, tmp_path, caplog):
         template = tmp_path / "template"
         skill = template / ".claude" / "skills" / "unsafe-skill"
         skill.mkdir(parents=True)
@@ -281,9 +281,11 @@ class TestResolve:
         (skill / "linked.txt").symlink_to(linked)
 
         mgr = WorkspaceManager(base_path=tmp_base, template_source=template)
-        workspace = mgr.resolve("alice", backend="codex", sync_template=True)
+        with caplog.at_level("WARNING", logger="src.workspace_manager"):
+            workspace = mgr.resolve("alice", backend="codex", sync_template=True)
 
         assert not (workspace / ".agents" / "skills" / "unsafe-skill").exists()
+        assert "Skipping skill template with symlink" in caplog.text
 
     def test_sync_template_false_skips_copy(self, manager, tmp_base):
         workspace = manager.resolve("carol", sync_template=False)

--- a/tests/test_workspace_manager.py
+++ b/tests/test_workspace_manager.py
@@ -180,9 +180,7 @@ class TestResolve:
         skill = workspace / ".agents" / "skills" / "shared-skill" / "SKILL.md"
         assert skill.read_text().endswith("Codex")
 
-    def test_opencode_claude_compatibility_wins_over_agents_duplicate(
-        self, tmp_base, tmp_template
-    ):
+    def test_opencode_claude_compatibility_wins_over_agents_duplicate(self, tmp_base, tmp_template):
         agent_skill = tmp_template / ".agents" / "skills" / "shared-skill"
         agent_skill.mkdir(parents=True)
         (agent_skill / "SKILL.md").write_text(

--- a/tests/test_workspace_manager.py
+++ b/tests/test_workspace_manager.py
@@ -95,6 +95,27 @@ class TestResolve:
         assert workspace.parent == tmp_base
         assert workspace.name.startswith("_tmp_")
 
+    def test_named_user_backend_creates_backend_directory(self, manager, tmp_base):
+        workspace = manager.resolve("alice", backend="codex", sync_template=False)
+        assert workspace == tmp_base / "alice" / "codex"
+        assert workspace.is_dir()
+
+    def test_named_user_backend_directories_are_independent(self, manager, tmp_base):
+        claude = manager.resolve("alice", backend="claude", sync_template=False)
+        codex = manager.resolve("alice", backend="codex", sync_template=False)
+        assert claude == tmp_base / "alice" / "claude"
+        assert codex == tmp_base / "alice" / "codex"
+        assert claude != codex
+
+    def test_anonymous_ignores_backend_for_tmp_layout(self, manager, tmp_base):
+        workspace = manager.resolve(None, backend="opencode", sync_template=False)
+        assert workspace.parent == tmp_base
+        assert workspace.name.startswith("_tmp_")
+
+    def test_rejects_invalid_backend_name(self, manager):
+        with pytest.raises(ValueError, match="Invalid backend"):
+            manager.resolve("alice", backend="../codex", sync_template=False)
+
     def test_anonymous_returns_different_dirs(self, manager):
         w1 = manager.resolve(None, sync_template=False)
         w2 = manager.resolve(None, sync_template=False)


### PR DESCRIPTION
## Summary

- Map Codex app-server command, file-change, and permission approval requests into the existing Responses `AskUserQuestion` requires-action flow.
- Add Codex approval continuation handling so `function_call_output` responds to the app-server request and resumes the same turn.
- Preserve richer Codex approval context, including item ids, extra permission details, and structured command approval decisions such as execpolicy/network policy amendments.
- Replace the Codex JSON-RPC stdout timeout path with a queued reader to avoid buffered-line races during fast notification bursts.
- Harden Codex approval continuation state checks, log unknown app-server request methods, warn on unrecognized structured approval outputs, and redact `stderr_tail` from client-facing Codex transport errors.
- Add a route-level timeout guard for non-streaming continuations.
- Add backend-isolated user workspaces: named users now resolve to `<base>/<user>/<backend>` while anonymous `_tmp_<uuid>` workspaces remain unchanged.
- Sync backend-native agent templates and skill roots for Claude (`.claude`), Codex (`.agents`), and OpenCode (`.opencode`), including compatibility skill mirrors with symlink hardening and visible warnings for skipped symlinked templates.
- Route Responses session creation through backend-specific workspaces and validate stale/backend-mismatched continuations before client creation.
- Reject cached response user mismatches before attempting backend workspace lookup or jsonl rehydrate.
- Add backend-aware admin skill helpers and `backend=` query parameters for admin skill routes.
- Update Codex/backend workspace docs and design/implementation plans.

## Why

Codex approval requests previously could not be completed through the Responses API, which blocked command/tool workflows from reaching Claude-like usability. During E2E validation, the old `select()` + `TextIOWrapper.readline()` path also exposed a race where already-buffered JSON-RPC lines could still time out.

Backend runtimes also need isolated working directories and native skill/config roots. Claude, Codex, and OpenCode do not share conversation memory, so treating them as independent agent environments avoids `.claude`, `.agents`, and `.opencode` config collisions.

## Validation

- `uv run pytest tests/test_codex_backend.py tests/test_workspace_manager.py tests/integration/test_codex_e2e.py -q` → `75 passed`
- `uv run pytest tests/test_responses_user.py tests/test_main_coverage_unit.py::TestResponsesApiSessionValidation tests/test_main_coverage_unit.py::TestResponsesStreamingValidationViaEndpoint -q` → `18 passed`
- `uv run ruff format --check src/backends/codex/client.py src/workspace_manager.py tests/test_codex_backend.py tests/test_workspace_manager.py`
- `uv run ruff check src/backends/codex/client.py src/workspace_manager.py tests/test_codex_backend.py tests/test_workspace_manager.py`
- `uv run pytest -q` → `1390 passed, 3 skipped, 4 deselected`