### PR TITLE
feat(codex): bring Codex backend to Claude parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,10 +225,13 @@ Effective `/v1/responses` request fields:
 - `previous_response_id`: continue the latest turn of an existing session.
 - `stream`: emit Responses-style SSE events.
 - `metadata`: stored on responses; allowlisted keys can be forwarded to Claude with `METADATA_ENV_ALLOWLIST`.
-- `allowed_tools`: explicit Claude tool allowlist.
+- `allowed_tools`: explicit tool allowlist for backends that support tool policy enforcement.
+- `disallowed_tools`: explicit tool blocklist; merged with the global `DISALLOWED_TOOLS` setting where supported.
+- `permission_mode`: set or update the session permission mode (`default`, `acceptEdits`, `bypassPermissions`, or `plan`); omitted continuation requests keep the current session mode.
+- `temperature` and `max_output_tokens`: forwarded to Codex as generation controls; accepted for compatibility elsewhere.
 - `user`: per-user workspace key.
 
-The request model also accepts `store`, `temperature`, and `max_output_tokens` for client compatibility, but those fields are not currently forwarded as generation controls.
+The request model also accepts `store` for client compatibility.
 
 Notable deviations from OpenAI Responses API behavior:
 

--- a/docs/codex/README.md
+++ b/docs/codex/README.md
@@ -56,6 +56,12 @@ JSON-RPC client instead of adding an unavailable package dependency.
 ## Supported Behavior
 
 - Text prompts and text responses are supported.
+- Responses `input_image` parts are forwarded to Codex as native image input
+  items when the request uses a Codex model.
+- `temperature` and `max_output_tokens` are forwarded to Codex `turn/start`
+  params as generation controls.
+- Gateway `allowed_tools`, `disallowed_tools`, `permission_mode`, and the
+  global `DISALLOWED_TOOLS` setting are enforced at Codex approval time.
 - Codex app-server command, file-change, and permission approval requests are
   exposed as Responses `requires_action` entries with the existing
   `AskUserQuestion` function-call shape. Send a matching
@@ -64,6 +70,9 @@ JSON-RPC client instead of adding an unavailable package dependency.
 - Command/file approvals accept Codex decision strings such as `accept`,
   `acceptForSession`, `decline`, and `cancel`. Short aliases like `yes`,
   `no`, and `always` are normalized by the gateway.
+- MCP server configuration is forwarded to Codex thread params; MCP approvals
+  honor both the `mcpToolCall` bucket and Claude-style
+  `mcp__<server>__*` / `mcp__<server>__<tool>` policy names.
 
 ## Current Limits
 
@@ -73,5 +82,6 @@ JSON-RPC client instead of adding an unavailable package dependency.
   environment changes between requests.
 - A Codex turn or approval transport error closes the shared app-server so the
   next request starts from a fresh process.
-- Image input is not exposed through the gateway Codex backend yet, even though
-  Codex app-server models may support images.
+- Codex app-server payload field names follow the current in-tree fixtures and
+  local CLI conventions; they should be rechecked when the Codex app-server
+  protocol changes.

--- a/src/backends/base.py
+++ b/src/backends/base.py
@@ -93,6 +93,7 @@ class BackendClient(Protocol):
         task_budget: Optional[int] = None,
         cwd: Optional[str] = None,
         extra_env: Optional[Dict[str, str]] = None,
+        model_params: Optional[Dict[str, Any]] = None,
         _custom_base: Any = None,
     ) -> Any: ...
 

--- a/src/backends/base.py
+++ b/src/backends/base.py
@@ -15,6 +15,7 @@ from typing import (
     List,
     Optional,
     Protocol,
+    Union,
     runtime_checkable,
 )
 
@@ -100,9 +101,18 @@ class BackendClient(Protocol):
     def run_completion_with_client(
         self,
         client: Any,
-        prompt: str,
+        prompt: Union[str, List[Dict[str, Any]]],
         session: Any,
-    ) -> AsyncIterator[Dict[str, Any]]: ...
+    ) -> AsyncIterator[Dict[str, Any]]:
+        """Execute a turn against an existing backend client.
+
+        ``prompt`` may be either a plain string or a list of backend-native
+        input items. Backends that don't carry multimodal payloads natively
+        (Claude, OpenCode) should ignore the list shape; only Codex emits a
+        list, and only when the request body carried Codex-supported
+        multimodal parts.
+        """
+        ...
 
     def parse_message(self, messages: List[Dict[str, Any]]) -> Optional[str]: ...
 

--- a/src/backends/claude/client.py
+++ b/src/backends/claude/client.py
@@ -85,6 +85,15 @@ def _get_setting_sources() -> List[str]:
     return deduped
 
 
+class UnsupportedContinuationPolicy(ValueError):
+    """Raised when a continuation request asks for a policy change the SDK can't apply mid-session.
+
+    The Claude SDK has no runtime API for swapping ``allowed_tools`` /
+    ``disallowed_tools``; route handlers should surface this as a 400 so the
+    caller can either drop the tool change or start a fresh session.
+    """
+
+
 class ClaudeCodeCLI:
     """Gateway for Claude Agent SDK queries.
 
@@ -588,6 +597,51 @@ class ClaudeCodeCLI:
             }
 
         return hook
+
+    async def update_request_policy(
+        self,
+        client: ClaudeSDKClient,
+        *,
+        allowed_tools: Optional[List[str]] = None,
+        disallowed_tools: Optional[List[str]] = None,
+        permission_mode: Optional[str] = None,
+        model_params: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Refresh per-request policy on an existing Claude SDK client.
+
+        Mirrors the Codex backend's contract (added in Step 1 of the Codex
+        parity work) so the gateway's continuation paths apply per-request
+        policy changes for Claude sessions, too — but fails closed when the
+        request asks for changes Claude cannot honor mid-session.
+
+        ``permission_mode`` is delegated to the SDK's
+        ``client.set_permission_mode``. If the SDK rejects the update, the
+        exception propagates so the route can surface the failure rather than
+        running the turn with the previous (potentially weaker) mode.
+
+        ``allowed_tools`` / ``disallowed_tools`` raise
+        :class:`UnsupportedContinuationPolicy` because the SDK has no runtime
+        API to swap them: silently dropping a ``disallowed_tools`` hard-block
+        on a continuation would be a security gap. Callers should surface
+        this as a 400 to the client and (if needed) start a fresh session
+        with the new tool lists.
+
+        ``model_params`` is accepted for contract parity with the Codex
+        backend but ignored — the SDK bakes model params at create time and
+        does not expose a mid-session update.
+        """
+        _ = model_params
+        if allowed_tools is not None or disallowed_tools is not None:
+            raise UnsupportedContinuationPolicy(
+                "Claude does not support changing allowed_tools / disallowed_tools "
+                "on a continuation turn; start a new session to apply the new "
+                "tool policy."
+            )
+        if permission_mode is not None:
+            # Let SDK exceptions propagate so the route can fail closed —
+            # silently running the next turn under the old mode could be a
+            # downgrade (e.g. from acceptEdits back to default).
+            await client.set_permission_mode(permission_mode)
 
     async def create_client(
         self,

--- a/src/backends/claude/client.py
+++ b/src/backends/claude/client.py
@@ -601,6 +601,7 @@ class ClaudeCodeCLI:
         task_budget: Optional[int] = None,
         cwd: Optional[str] = None,
         extra_env: Optional[Dict[str, str]] = None,
+        model_params: Optional[Dict[str, Any]] = None,
         _custom_base: object = _UNSET,
     ) -> ClaudeSDKClient:
         """Create and connect a :class:`ClaudeSDKClient` for *session*.

--- a/src/backends/codex/client.py
+++ b/src/backends/codex/client.py
@@ -376,6 +376,10 @@ class CodexSessionClient:
     pending_approval_method: Optional[str] = None
     pending_approval_turn_id: Optional[str] = None
     pending_approval_params: Optional[Dict[str, Any]] = None
+    # Identity of the RPC instance that surfaced the pending approval, used to
+    # fail-fast if a transport reset replaces the shared RPC between the
+    # approval being shown and the user responding.
+    pending_approval_rpc: Optional[CodexJsonRpcClient] = None
 
     async def disconnect(self) -> None:
         if self.owns_rpc:
@@ -631,6 +635,94 @@ class CodexClient:
     def _client_has_tool_policy(cls, client: CodexSessionClient) -> bool:
         return cls._has_tool_policy(client.allowed_tools, client.disallowed_tools)
 
+    async def _start_turn_with_retry(
+        self,
+        client: CodexSessionClient,
+        prompt: str,
+    ) -> tuple[CodexJsonRpcClient, Dict[str, Any]]:
+        """Run turn/start with a single conservative retry on transport failure.
+
+        ``turn/start`` is idempotent only until the app-server accepts it. We
+        detect "accepted" two ways:
+
+        - The call returns normally → accepted, no retry needed.
+        - Any inbound notification for this turn lands in the RPC's pending
+          queue while the request was in flight → the app-server is already
+          executing the turn. Retrying could double-run a command/edit, so
+          we surface the error instead.
+
+        Otherwise, on transport failure, we close the dead shared RPC, bring
+        up a fresh one, re-establish the gateway session's Codex thread via
+        ``thread/resume``, and try ``turn/start`` once more. The retry budget
+        is intentionally exactly one attempt.
+
+        Callers must hold ``self._rpc_lock``.
+        """
+        input_items = [{"type": "text", "text": prompt}]
+        turn_params = self._turn_params(client)
+        thread_params = self._thread_params(
+            model=client.model,
+            cwd=client.cwd,
+            system_prompt=None,
+            permission_mode=client.permission_mode,
+            has_tool_policy=self._client_has_tool_policy(client),
+        )
+
+        last_exc: Optional[BaseException] = None
+        for attempt in range(2):
+            rpc = await self._ensure_rpc_locked(client.env or {})
+            queued_before = self._pending_notification_count(rpc)
+            try:
+                if attempt > 0 and client.thread_id:
+                    # New RPC instance has no thread context; re-establish before
+                    # the retried turn/start so the app-server recognizes the id.
+                    await asyncio.to_thread(rpc.thread_resume, client.thread_id, thread_params)
+                turn = await asyncio.to_thread(rpc.turn_start, client.thread_id, input_items, turn_params)
+                return rpc, turn
+            except Exception as exc:
+                last_exc = exc
+                if attempt > 0:
+                    break
+                # Did the app-server queue any inbound notification for this
+                # turn while turn/start was in flight? If yes, retrying risks
+                # duplicating the turn's side effects on the app-server side.
+                queued_after = self._pending_notification_count(rpc)
+                if queued_after > queued_before:
+                    logger.warning(
+                        "Codex turn/start failed but app-server queued %d notification(s) "
+                        "while turn/start was in flight; skipping retry to avoid duplicate "
+                        "side effects: %s",
+                        queued_after - queued_before,
+                        exc,
+                    )
+                    break
+                logger.warning(
+                    "Codex turn/start failed before turn was accepted, "
+                    "restarting RPC and retrying once: %s",
+                    exc,
+                )
+                await self._close_rpc_locked()
+                continue
+
+        assert last_exc is not None
+        raise last_exc
+
+    @staticmethod
+    def _pending_notification_count(rpc: CodexJsonRpcClient) -> int:
+        """Number of inbound notifications buffered by the JSON-RPC client.
+
+        ``_pending_notifications`` is the real client's queue; fakes used in
+        tests may expose the same attribute as a plain list. Treat missing
+        attributes as zero (acts as a no-op for legacy transports).
+        """
+        pending = getattr(rpc, "_pending_notifications", None)
+        if pending is None:
+            return 0
+        try:
+            return len(pending)
+        except TypeError:
+            return 0
+
     async def run_completion_with_client(
         self,
         client: CodexSessionClient,
@@ -640,13 +732,10 @@ class CodexClient:
         _ = session
         async with self._rpc_lock:
             try:
-                rpc = await self._ensure_rpc_locked(client.env or {})
-                turn = await asyncio.to_thread(
-                    rpc.turn_start,
-                    client.thread_id,
-                    [{"type": "text", "text": prompt}],
-                    self._turn_params(client),
-                )
+                rpc, turn = await self._start_turn_with_retry(client, prompt)
+                # Keep the session client's RPC reference in sync with the live
+                # shared RPC; retry may have swapped to a fresh instance.
+                client.rpc = rpc
                 turn_obj = turn.get("turn")
                 if not isinstance(turn_obj, dict) or not turn_obj.get("id"):
                     yield {
@@ -668,7 +757,9 @@ class CodexClient:
                         break
                     if chunk is not None:
                         if chunk.get("type") == "codex_approval_request":
-                            tool_chunk = self._store_pending_approval(session, client, chunk)
+                            tool_chunk = self._store_pending_approval(
+                                session, client, chunk, rpc=rpc
+                            )
                             yield tool_chunk
                             return
                         yield chunk
@@ -714,6 +805,25 @@ class CodexClient:
                     logger.error(message)
                     yield {"type": "error", "is_error": True, "error_message": message}
                     return
+                pending_rpc = client.pending_approval_rpc
+                if pending_rpc is not None and pending_rpc is not rpc:
+                    # The RPC that surfaced this approval is gone (likely a
+                    # transport reset between the approval being shown and the
+                    # user's response). The new RPC has no record of the
+                    # pending request, so responding now would be a no-op or
+                    # confuse the app-server. Surface a clear error instead.
+                    message = (
+                        "Codex approval transport was lost before the response "
+                        "arrived; please retry the original request"
+                    )
+                    logger.error(message + " (call_id=%r)", call_id)
+                    client.pending_approval_request_id = None
+                    client.pending_approval_method = None
+                    client.pending_approval_turn_id = None
+                    client.pending_approval_params = None
+                    client.pending_approval_rpc = None
+                    yield {"type": "error", "is_error": True, "error_message": message}
+                    return
                 turn_id = client.pending_approval_turn_id or str(params.get("turnId") or "")
                 if not turn_id:
                     yield {
@@ -729,6 +839,7 @@ class CodexClient:
                 client.pending_approval_method = None
                 client.pending_approval_turn_id = None
                 client.pending_approval_params = None
+                client.pending_approval_rpc = None
 
                 notification_iter = self._notification_iterator(
                     rpc, client.thread_id, turn_id, client=client
@@ -742,7 +853,9 @@ class CodexClient:
                         break
                     if chunk is not None:
                         if chunk.get("type") == "codex_approval_request":
-                            tool_chunk = self._store_pending_approval(session, client, chunk)
+                            tool_chunk = self._store_pending_approval(
+                                session, client, chunk, rpc=rpc
+                            )
                             yield tool_chunk
                             return
                         yield chunk
@@ -1137,6 +1250,8 @@ class CodexClient:
         session: Any,
         client: CodexSessionClient,
         chunk: Dict[str, Any],
+        *,
+        rpc: Optional[CodexJsonRpcClient] = None,
     ) -> Dict[str, Any]:
         tool_chunk = chunk["tool_chunk"]
         tool_block = tool_chunk["content"][0]
@@ -1147,6 +1262,9 @@ class CodexClient:
             chunk.get("params") if isinstance(chunk.get("params"), dict) else {}
         )
         client.pending_approval_turn_id = metadata.get("codex_turn_id")
+        # Remember which RPC instance owns this pending request so resume can
+        # fail fast if a transport reset replaces the shared RPC underneath us.
+        client.pending_approval_rpc = rpc
         session.pending_tool_call = {
             "call_id": metadata["codex_approval_request_id"],
             "name": ASK_USER_QUESTION_TOOL_NAME,

--- a/src/backends/codex/client.py
+++ b/src/backends/codex/client.py
@@ -404,6 +404,7 @@ class CodexSessionClient:
     disallowed_tools: Optional[List[str]] = None
     permission_mode: Optional[str] = None
     model_params: Optional[Dict[str, Any]] = None
+    mcp_servers: Optional[Dict[str, Any]] = None
     pending_approval_request_id: Optional[Any] = None
     pending_approval_method: Optional[str] = None
     pending_approval_turn_id: Optional[str] = None
@@ -519,7 +520,7 @@ class CodexClient:
         model_params: Optional[Dict[str, Any]] = None,
         _custom_base: Any = None,
     ) -> CodexSessionClient:
-        _ = (mcp_servers, task_budget)
+        _ = (task_budget,)
         env = self._metadata_env(extra_env)
         async with self._rpc_lock:
             try:
@@ -531,6 +532,7 @@ class CodexClient:
                     system_prompt=self._combine_system_prompt(_custom_base, system_prompt),
                     permission_mode=permission_mode,
                     has_tool_policy=self._has_tool_policy(allowed_tools, disallowed_tools),
+                    mcp_servers=mcp_servers,
                 )
                 thread_id = getattr(session, "codex_thread_id", None)
                 if thread_id:
@@ -564,6 +566,7 @@ class CodexClient:
             ),
             permission_mode=permission_mode,
             model_params=dict(model_params) if model_params else None,
+            mcp_servers=dict(mcp_servers) if mcp_servers else None,
         )
 
     async def _ensure_rpc_locked(self, env: Dict[str, str]) -> CodexJsonRpcClient:
@@ -630,6 +633,7 @@ class CodexClient:
         system_prompt: Optional[str],
         permission_mode: Optional[str] = None,
         has_tool_policy: bool = False,
+        mcp_servers: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         params: Dict[str, Any] = {
             "approvalPolicy": _resolve_approval_policy(
@@ -643,6 +647,12 @@ class CodexClient:
             params["cwd"] = cwd
         if system_prompt:
             params["developerInstructions"] = system_prompt
+        if mcp_servers:
+            # Forward server-level MCP configuration so Codex can route tool
+            # calls to the configured upstream MCP servers. An empty dict
+            # behaves like "no servers" and the key is left out so the
+            # app-server keeps its defaults.
+            params["mcpServers"] = dict(mcp_servers)
         return params
 
     def _turn_params(self, client: CodexSessionClient) -> Dict[str, Any]:
@@ -710,6 +720,7 @@ class CodexClient:
             system_prompt=None,
             permission_mode=client.permission_mode,
             has_tool_policy=self._client_has_tool_policy(client),
+            mcp_servers=client.mcp_servers,
         )
 
         last_exc: Optional[BaseException] = None

--- a/src/backends/codex/client.py
+++ b/src/backends/codex/client.py
@@ -692,9 +692,15 @@ class CodexClient:
     async def _start_turn_with_retry(
         self,
         client: CodexSessionClient,
-        prompt: str,
+        prompt: Any,
     ) -> tuple[CodexJsonRpcClient, Dict[str, Any]]:
         """Run turn/start with a single conservative retry on transport failure.
+
+        ``prompt`` may be either a plain string (wrapped into a single
+        ``{"type": "text"}`` item for backward compatibility) or a
+        pre-normalized list of Codex input items (text plus image/file
+        attachments). Invalid item shapes raise ``ValueError`` before any
+        side effect on the app-server side.
 
         ``turn/start`` is idempotent only until the app-server accepts it. We
         detect "accepted" two ways:
@@ -712,7 +718,7 @@ class CodexClient:
 
         Callers must hold ``self._rpc_lock``.
         """
-        input_items = [{"type": "text", "text": prompt}]
+        input_items = self._coerce_turn_input_items(prompt)
         turn_params = self._turn_params(client)
         thread_params = self._thread_params(
             model=client.model,
@@ -763,6 +769,34 @@ class CodexClient:
         raise last_exc
 
     @staticmethod
+    def _coerce_turn_input_items(prompt: Any) -> list[Dict[str, Any]]:
+        """Normalize the run_completion ``prompt`` argument into Codex input items.
+
+        - ``str``: wrapped into a single ``{"type": "text", "text": ...}`` item
+          so existing string callers stay unchanged.
+        - ``list``: must contain only dicts; each is forwarded verbatim so
+          callers can express multimodal payloads (text + image/file). Order
+          and metadata are preserved.
+        - anything else: ``ValueError`` (the route catches this and surfaces a
+          clean error chunk).
+        """
+        if isinstance(prompt, str):
+            return [{"type": "text", "text": prompt}]
+        if isinstance(prompt, list):
+            if not prompt:
+                raise ValueError("Codex turn input list must contain at least one item")
+            for index, item in enumerate(prompt):
+                if not isinstance(item, dict):
+                    raise ValueError(
+                        f"Codex turn input item at index {index} must be a dict, "
+                        f"got {type(item).__name__}"
+                    )
+            return [dict(item) for item in prompt]
+        raise ValueError(
+            f"Codex turn input must be a string or list of dicts, got {type(prompt).__name__}"
+        )
+
+    @staticmethod
     def _pending_notification_count(rpc: CodexJsonRpcClient) -> int:
         """Number of inbound notifications buffered by the JSON-RPC client.
 
@@ -781,7 +815,7 @@ class CodexClient:
     async def run_completion_with_client(
         self,
         client: CodexSessionClient,
-        prompt: str,
+        prompt: Any,
         session: Any,
     ) -> AsyncGenerator[Dict[str, Any], None]:
         _ = session

--- a/src/backends/codex/client.py
+++ b/src/backends/codex/client.py
@@ -73,6 +73,37 @@ CODEX_PERMISSION_MODE_TO_APPROVAL: Dict[str, str] = {
     "plan": "on-request",
 }
 
+# OpenAI Responses-style sampling/control field -> Codex app-server payload key.
+# Used by ``_translate_model_params`` so request bodies can carry the standard
+# OpenAI names (temperature, max_output_tokens, ...) while we forward them in
+# the Codex camelCase convention.
+CODEX_MODEL_PARAM_KEY_MAP: Dict[str, str] = {
+    "temperature": "temperature",
+    "top_p": "topP",
+    "max_output_tokens": "maxOutputTokens",
+    # Legacy alias from the chat-completions era; treat the same as the new name.
+    "max_tokens": "maxOutputTokens",
+}
+
+
+def _translate_model_params(model_params: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Translate OpenAI-style model params into the Codex turn/start vocabulary.
+
+    - ``None`` or empty dict yields ``{}`` (no payload pollution when the
+      request didn't ask for overrides).
+    - Unknown keys are passed through unchanged so future params can be added
+      without code changes here.
+    - ``None`` values are skipped (Pydantic optional fields default to None).
+    """
+    if not model_params:
+        return {}
+    out: Dict[str, Any] = {}
+    for key, value in model_params.items():
+        if value is None:
+            continue
+        out[CODEX_MODEL_PARAM_KEY_MAP.get(key, key)] = value
+    return out
+
 
 _UNKNOWN_PERMISSION_MODE_FALLBACK = "on-request"
 
@@ -372,6 +403,7 @@ class CodexSessionClient:
     allowed_tools: Optional[List[str]] = None
     disallowed_tools: Optional[List[str]] = None
     permission_mode: Optional[str] = None
+    model_params: Optional[Dict[str, Any]] = None
     pending_approval_request_id: Optional[Any] = None
     pending_approval_method: Optional[str] = None
     pending_approval_turn_id: Optional[str] = None
@@ -412,6 +444,7 @@ class CodexClient:
         allowed_tools: Optional[List[str]] = None,
         disallowed_tools: Optional[List[str]] = None,
         permission_mode: Optional[str] = None,
+        model_params: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Replace the per-request tool policy stored on an existing session client.
 
@@ -431,6 +464,9 @@ class CodexClient:
         client.disallowed_tools = (
             list(disallowed_tools) if disallowed_tools is not None else None
         )
+        # ``model_params`` is per-request like tool lists; ``None`` resets so the
+        # next turn doesn't inherit a previous request's sampling overrides.
+        client.model_params = dict(model_params) if model_params else None
         if permission_mode is not None:
             client.permission_mode = permission_mode
 
@@ -480,6 +516,7 @@ class CodexClient:
         task_budget: Optional[int] = None,
         cwd: Optional[str] = None,
         extra_env: Optional[Dict[str, str]] = None,
+        model_params: Optional[Dict[str, Any]] = None,
         _custom_base: Any = None,
     ) -> CodexSessionClient:
         _ = (mcp_servers, task_budget)
@@ -526,6 +563,7 @@ class CodexClient:
                 list(disallowed_tools) if disallowed_tools is not None else None
             ),
             permission_mode=permission_mode,
+            model_params=dict(model_params) if model_params else None,
         )
 
     async def _ensure_rpc_locked(self, env: Dict[str, str]) -> CodexJsonRpcClient:
@@ -618,6 +656,12 @@ class CodexClient:
             params["model"] = client.model
         if client.cwd:
             params["cwd"] = client.cwd
+        # Sampling / output-control overrides (temperature, max_output_tokens, ...)
+        # supplied by the request body. Unset request fields stay absent from the
+        # payload so the app-server's defaults still apply.
+        translated = _translate_model_params(client.model_params)
+        if translated:
+            params.update(translated)
         return params
 
     @staticmethod

--- a/src/backends/codex/client.py
+++ b/src/backends/codex/client.py
@@ -26,6 +26,7 @@ from src.backends.codex.constants import (
     approval_policy,
     codex_bin,
     configured_config_overrides,
+    disallowed_tools_from_env,
     sandbox_mode,
 )
 from src.constants import DEFAULT_TIMEOUT_MS
@@ -37,9 +38,68 @@ CODEX_APPROVAL_METHODS = {
     "item/commandExecution/requestApproval",
     "item/fileChange/requestApproval",
     "item/permissions/requestApproval",
+    "item/mcpToolCall/requestApproval",
+    "item/dynamicToolCall/requestApproval",
 }
 
 ASK_USER_QUESTION_TOOL_NAME = "AskUserQuestion"
+
+# Gateway tool names (Claude-style) mapped to the Codex item type they map onto.
+# ``allowed_tools``/``disallowed_tools`` may use either the Claude alias or the
+# Codex-native name; both resolve to the same enforcement bucket.
+CODEX_TOOL_NAME_ALIASES: Dict[str, str] = {
+    "Bash": "commandExecution",
+    "BashOutput": "commandExecution",
+    "KillShell": "commandExecution",
+    "Edit": "fileChange",
+    "Write": "fileChange",
+    "NotebookEdit": "fileChange",
+}
+
+_APPROVAL_METHOD_TO_TOOL: Dict[str, str] = {
+    "item/commandExecution/requestApproval": "commandExecution",
+    "item/fileChange/requestApproval": "fileChange",
+    "item/mcpToolCall/requestApproval": "mcpToolCall",
+    "item/dynamicToolCall/requestApproval": "dynamicToolCall",
+}
+
+# Gateway permission_mode (Claude vocabulary) -> Codex approvalPolicy.
+# ``bypassPermissions`` translates to ``never`` (skip approvals); the remaining
+# modes default to ``on-request`` so risky operations still pause for review.
+CODEX_PERMISSION_MODE_TO_APPROVAL: Dict[str, str] = {
+    "bypassPermissions": "never",
+    "default": "on-request",
+    "acceptEdits": "on-request",
+    "plan": "on-request",
+}
+
+
+def _resolve_approval_policy(
+    permission_mode: Optional[str],
+    *,
+    has_tool_policy: bool = False,
+) -> str:
+    """Map gateway permission_mode onto Codex approvalPolicy.
+
+    Falls back to the ``CODEX_APPROVAL_POLICY`` env when no override is given.
+
+    When ``has_tool_policy`` is set (the caller has allowed_tools/disallowed_tools
+    or a global DISALLOWED_TOOLS env), a resolved ``never`` is upgraded to
+    ``on-request`` so Codex actually emits approval requests; otherwise the
+    gateway's auto-deny hook never runs and the tool policy is silently bypassed.
+    """
+    if permission_mode is not None:
+        mapped = CODEX_PERMISSION_MODE_TO_APPROVAL.get(permission_mode)
+        if mapped is not None:
+            resolved = mapped
+        else:
+            resolved = approval_policy()
+    else:
+        resolved = approval_policy()
+
+    if has_tool_policy and resolved == "never":
+        return "on-request"
+    return resolved
 
 
 class CodexAppServerError(RuntimeError):
@@ -298,6 +358,9 @@ class CodexSessionClient:
     stream_events: bool = False
     env: Optional[Dict[str, str]] = None
     owns_rpc: bool = False
+    allowed_tools: Optional[List[str]] = None
+    disallowed_tools: Optional[List[str]] = None
+    permission_mode: Optional[str] = None
     pending_approval_request_id: Optional[Any] = None
     pending_approval_method: Optional[str] = None
     pending_approval_turn_id: Optional[str] = None
@@ -326,6 +389,28 @@ class CodexClient:
 
     def get_auth_provider(self) -> CodexAuthProvider:
         return CodexAuthProvider()
+
+    def update_request_policy(
+        self,
+        client: CodexSessionClient,
+        *,
+        allowed_tools: Optional[List[str]] = None,
+        disallowed_tools: Optional[List[str]] = None,
+    ) -> None:
+        """Replace the per-request tool policy stored on an existing session client.
+
+        Codex reuses one persistent ``CodexSessionClient`` for the lifetime of a
+        gateway session, but the gateway's tool-policy fields (``allowed_tools``
+        / ``disallowed_tools``) are per-request. Continuation requests must be
+        able to refresh those fields so each turn honors its own body.
+
+        An explicit empty list ``[]`` is preserved as a block-all policy; only
+        ``None`` clears the field.
+        """
+        client.allowed_tools = list(allowed_tools) if allowed_tools is not None else None
+        client.disallowed_tools = (
+            list(disallowed_tools) if disallowed_tools is not None else None
+        )
 
     def runtime_metadata(self) -> Dict[str, Any]:
         return {
@@ -375,7 +460,7 @@ class CodexClient:
         extra_env: Optional[Dict[str, str]] = None,
         _custom_base: Any = None,
     ) -> CodexSessionClient:
-        _ = (allowed_tools, disallowed_tools, permission_mode, mcp_servers, task_budget)
+        _ = (mcp_servers, task_budget)
         env = self._metadata_env(extra_env)
         async with self._rpc_lock:
             try:
@@ -385,6 +470,8 @@ class CodexClient:
                     model=model,
                     cwd=cwd,
                     system_prompt=self._combine_system_prompt(_custom_base, system_prompt),
+                    permission_mode=permission_mode,
+                    has_tool_policy=self._has_tool_policy(allowed_tools, disallowed_tools),
                 )
                 thread_id = getattr(session, "codex_thread_id", None)
                 if thread_id:
@@ -410,6 +497,13 @@ class CodexClient:
             cwd=cwd,
             env=env,
             owns_rpc=False,
+            # Preserve an explicit empty list as a block-all policy; only ``None``
+            # means "no per-request allow-list / disallow-list was set."
+            allowed_tools=list(allowed_tools) if allowed_tools is not None else None,
+            disallowed_tools=(
+                list(disallowed_tools) if disallowed_tools is not None else None
+            ),
+            permission_mode=permission_mode,
         )
 
     async def _ensure_rpc_locked(self, env: Dict[str, str]) -> CodexJsonRpcClient:
@@ -474,9 +568,13 @@ class CodexClient:
         model: Optional[str],
         cwd: Optional[str],
         system_prompt: Optional[str],
+        permission_mode: Optional[str] = None,
+        has_tool_policy: bool = False,
     ) -> Dict[str, Any]:
         params: Dict[str, Any] = {
-            "approvalPolicy": approval_policy(),
+            "approvalPolicy": _resolve_approval_policy(
+                permission_mode, has_tool_policy=has_tool_policy
+            ),
             "sandbox": sandbox_mode(),
         }
         if model:
@@ -488,12 +586,32 @@ class CodexClient:
         return params
 
     def _turn_params(self, client: CodexSessionClient) -> Dict[str, Any]:
-        params: Dict[str, Any] = {"approvalPolicy": approval_policy()}
+        params: Dict[str, Any] = {
+            "approvalPolicy": _resolve_approval_policy(
+                client.permission_mode,
+                has_tool_policy=self._client_has_tool_policy(client),
+            ),
+        }
         if client.model:
             params["model"] = client.model
         if client.cwd:
             params["cwd"] = client.cwd
         return params
+
+    @staticmethod
+    def _has_tool_policy(
+        allowed_tools: Optional[List[str]],
+        disallowed_tools: Optional[List[str]],
+    ) -> bool:
+        # ``allowed_tools is not None`` matters because ``[]`` is a real
+        # block-all policy that must still flip approvalPolicy off ``never``.
+        if allowed_tools is not None or disallowed_tools:
+            return True
+        return bool(disallowed_tools_from_env())
+
+    @classmethod
+    def _client_has_tool_policy(cls, client: CodexSessionClient) -> bool:
+        return cls._has_tool_policy(client.allowed_tools, client.disallowed_tools)
 
     async def run_completion_with_client(
         self,
@@ -520,7 +638,9 @@ class CodexClient:
                     }
                     return
                 turn_id = str(turn_obj["id"])
-                notification_iter = self._notification_iterator(rpc, client.thread_id, turn_id)
+                notification_iter = self._notification_iterator(
+                    rpc, client.thread_id, turn_id, client=client
+                )
                 while True:
                     has_value, chunk = await asyncio.to_thread(
                         self._next_chunk,
@@ -592,7 +712,9 @@ class CodexClient:
                 client.pending_approval_turn_id = None
                 client.pending_approval_params = None
 
-                notification_iter = self._notification_iterator(rpc, client.thread_id, turn_id)
+                notification_iter = self._notification_iterator(
+                    rpc, client.thread_id, turn_id, client=client
+                )
                 while True:
                     has_value, chunk = await asyncio.to_thread(
                         self._next_chunk,
@@ -633,11 +755,17 @@ class CodexClient:
         rpc: CodexJsonRpcClient,
         thread_id: str,
         turn_id: str,
+        *,
+        client: Optional["CodexSessionClient"] = None,
     ) -> Iterator[Dict[str, Any]]:
         items: list[dict[str, Any]] = []
         usage_box: dict[str, Optional[dict[str, int]]] = {"usage": None}
         while True:
             notification = rpc.next_notification()
+            if client is not None and self._is_approval_request(notification):
+                if self._should_auto_deny_approval(client, notification):
+                    self._auto_deny_approval(rpc, notification)
+                    continue
             yield from self._chunks_from_notification(
                 thread_id=thread_id,
                 turn_id=turn_id,
@@ -651,6 +779,54 @@ class CodexClient:
                 notification=notification,
             ):
                 break
+
+    def _should_auto_deny_approval(
+        self,
+        client: "CodexSessionClient",
+        notification: Dict[str, Any],
+    ) -> bool:
+        method = str(notification.get("method") or "")
+        codex_tool = _APPROVAL_METHOD_TO_TOOL.get(method)
+        if codex_tool is None:
+            return False
+        request_disallowed = list(client.disallowed_tools or [])
+        env_disallowed = disallowed_tools_from_env()
+        disallowed = self._normalize_tool_names(request_disallowed + env_disallowed)
+        if codex_tool in disallowed:
+            return True
+        # ``allowed_tools is not None`` distinguishes an explicit policy (even
+        # an empty block-all list) from "no allow-list set".
+        if client.allowed_tools is not None:
+            allowed = self._normalize_tool_names(client.allowed_tools)
+            if codex_tool not in allowed:
+                return True
+        return False
+
+    @staticmethod
+    def _normalize_tool_names(names: Optional[List[str]]) -> set[str]:
+        if not names:
+            return set()
+        return {CODEX_TOOL_NAME_ALIASES.get(name, name) for name in names}
+
+    def _auto_deny_approval(
+        self,
+        rpc: CodexJsonRpcClient,
+        notification: Dict[str, Any],
+    ) -> None:
+        request_id = notification.get("id")
+        if request_id is None:
+            return
+        method = str(notification.get("method") or "")
+        if method == "item/permissions/requestApproval":
+            result: Dict[str, Any] = {"permissions": {}, "scope": "turn"}
+        else:
+            result = {"decision": "decline"}
+        logger.info(
+            "Codex auto-denied approval: method=%s request_id=%s",
+            method,
+            request_id,
+        )
+        rpc.respond(request_id, result)
 
     def _chunks_from_notifications(
         self,

--- a/src/backends/codex/client.py
+++ b/src/backends/codex/client.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import fnmatch
 import json
 import logging
 import os
@@ -461,9 +462,7 @@ class CodexClient:
         existing value is preserved. Pass an explicit string to change it.
         """
         client.allowed_tools = list(allowed_tools) if allowed_tools is not None else None
-        client.disallowed_tools = (
-            list(disallowed_tools) if disallowed_tools is not None else None
-        )
+        client.disallowed_tools = list(disallowed_tools) if disallowed_tools is not None else None
         # ``model_params`` is per-request like tool lists; ``None`` resets so the
         # next turn doesn't inherit a previous request's sampling overrides.
         client.model_params = dict(model_params) if model_params else None
@@ -560,9 +559,7 @@ class CodexClient:
             # Preserve an explicit empty list as a block-all policy; only ``None``
             # means "no per-request allow-list / disallow-list was set."
             allowed_tools=list(allowed_tools) if allowed_tools is not None else None,
-            disallowed_tools=(
-                list(disallowed_tools) if disallowed_tools is not None else None
-            ),
+            disallowed_tools=(list(disallowed_tools) if disallowed_tools is not None else None),
             permission_mode=permission_mode,
             model_params=dict(model_params) if model_params else None,
             mcp_servers=dict(mcp_servers) if mcp_servers else None,
@@ -746,7 +743,9 @@ class CodexClient:
                     # New RPC instance has no thread context; re-establish before
                     # the retried turn/start so the app-server recognizes the id.
                     await asyncio.to_thread(rpc.thread_resume, client.thread_id, thread_params)
-                turn = await asyncio.to_thread(rpc.turn_start, client.thread_id, input_items, turn_params)
+                turn = await asyncio.to_thread(
+                    rpc.turn_start, client.thread_id, input_items, turn_params
+                )
                 return rpc, turn
             except Exception as exc:
                 last_exc = exc
@@ -1019,28 +1018,63 @@ class CodexClient:
         client: "CodexSessionClient",
         notification: Dict[str, Any],
     ) -> bool:
-        method = str(notification.get("method") or "")
-        codex_tool = _APPROVAL_METHOD_TO_TOOL.get(method)
-        if codex_tool is None:
+        tool_identities = self._approval_tool_identities(notification)
+        if not tool_identities:
             return False
         request_disallowed = list(client.disallowed_tools or [])
         env_disallowed = disallowed_tools_from_env()
         disallowed = self._normalize_tool_names(request_disallowed + env_disallowed)
-        if codex_tool in disallowed:
+        if self._tool_policy_matches(disallowed, tool_identities):
             return True
         # ``allowed_tools is not None`` distinguishes an explicit policy (even
         # an empty block-all list) from "no allow-list set".
         if client.allowed_tools is not None:
             allowed = self._normalize_tool_names(client.allowed_tools)
-            if codex_tool not in allowed:
+            if not self._tool_policy_matches(allowed, tool_identities):
                 return True
         return False
+
+    @staticmethod
+    def _approval_tool_identities(notification: Dict[str, Any]) -> set[str]:
+        method = str(notification.get("method") or "")
+        codex_tool = _APPROVAL_METHOD_TO_TOOL.get(method)
+        if codex_tool is None:
+            return set()
+
+        identities = {codex_tool}
+        params = notification.get("params")
+        if not isinstance(params, dict):
+            return identities
+
+        if codex_tool == "mcpToolCall":
+            server_label = params.get("serverLabel") or params.get("serverName")
+            tool_name = params.get("toolName")
+            if isinstance(server_label, str) and server_label:
+                server_names = {server_label, "_".join(server_label.split("-"))}
+                if isinstance(tool_name, str) and tool_name:
+                    for server_name in server_names:
+                        identities.add(f"mcp__{server_name}__{tool_name}")
+                else:
+                    for server_name in server_names:
+                        identities.add(f"mcp__{server_name}__*")
+
+        return identities
 
     @staticmethod
     def _normalize_tool_names(names: Optional[List[str]]) -> set[str]:
         if not names:
             return set()
         return {CODEX_TOOL_NAME_ALIASES.get(name, name) for name in names}
+
+    @staticmethod
+    def _tool_policy_matches(policy_names: set[str], tool_identities: set[str]) -> bool:
+        for policy_name in policy_names:
+            for identity in tool_identities:
+                if policy_name == identity:
+                    return True
+                if policy_name.startswith("mcp__") and fnmatch.fnmatchcase(identity, policy_name):
+                    return True
+        return False
 
     def _auto_deny_approval(
         self,
@@ -1314,7 +1348,7 @@ class CodexClient:
             label = self._approval_decision_label(decision)
             if not label:
                 continue
-            option = {
+            option: Dict[str, Any] = {
                 "label": label,
                 "description": descriptions.get(label, f"Choose {label}."),
             }

--- a/src/backends/codex/client.py
+++ b/src/backends/codex/client.py
@@ -1281,7 +1281,12 @@ class CodexClient:
         if not isinstance(last, dict):
             return None
         input_tokens = int(last.get("inputTokens") or 0) + int(last.get("cachedInputTokens") or 0)
-        output_tokens = int(last.get("outputTokens") or 0)
+        # Reasoning tokens are emitted by the model alongside visible output;
+        # OpenAI-compatible usage reporting rolls them into output_tokens so
+        # totals match (input + output == totalTokens).
+        output_tokens = int(last.get("outputTokens") or 0) + int(
+            last.get("reasoningOutputTokens") or 0
+        )
         return {"input_tokens": input_tokens, "output_tokens": output_tokens}
 
     def _turn_error_message(self, turn: dict[str, Any]) -> str:

--- a/src/backends/codex/client.py
+++ b/src/backends/codex/client.py
@@ -397,7 +397,6 @@ class CodexSessionClient:
     thread_id: str
     model: Optional[str]
     cwd: Optional[str]
-    stream_events: bool = False
     env: Optional[Dict[str, str]] = None
     owns_rpc: bool = False
     allowed_tools: Optional[List[str]] = None

--- a/src/backends/codex/client.py
+++ b/src/backends/codex/client.py
@@ -651,6 +651,15 @@ class CodexClient:
             # calls to the configured upstream MCP servers. An empty dict
             # behaves like "no servers" and the key is left out so the
             # app-server keeps its defaults.
+            #
+            # Filtering note: unlike the Claude backend (which narrows
+            # ``mcp_servers`` against the per-request ``allowed_tools``
+            # patterns via ``mcp__<server>__*`` — see
+            # ``src/backends/claude/client.py::_configure_mcp_servers``),
+            # Codex forwards the full server set and enforces per-tool policy
+            # at approval time via ``item/mcpToolCall/requestApproval``. The
+            # net effect is the same (disallowed MCP tools never execute) but
+            # the enforcement point differs.
             params["mcpServers"] = dict(mcp_servers)
         return params
 

--- a/src/backends/codex/client.py
+++ b/src/backends/codex/client.py
@@ -74,6 +74,9 @@ CODEX_PERMISSION_MODE_TO_APPROVAL: Dict[str, str] = {
 }
 
 
+_UNKNOWN_PERMISSION_MODE_FALLBACK = "on-request"
+
+
 def _resolve_approval_policy(
     permission_mode: Optional[str],
     *,
@@ -81,21 +84,29 @@ def _resolve_approval_policy(
 ) -> str:
     """Map gateway permission_mode onto Codex approvalPolicy.
 
-    Falls back to the ``CODEX_APPROVAL_POLICY`` env when no override is given.
+    When ``permission_mode`` is ``None``, fall back to the operator's
+    ``CODEX_APPROVAL_POLICY`` env (defaults to ``never``). When it is set to
+    an *unknown* value, fall back to a safe ``on-request`` rather than the env,
+    so a typo or invalid mode can't silently bypass approval-time enforcement.
 
     When ``has_tool_policy`` is set (the caller has allowed_tools/disallowed_tools
     or a global DISALLOWED_TOOLS env), a resolved ``never`` is upgraded to
     ``on-request`` so Codex actually emits approval requests; otherwise the
     gateway's auto-deny hook never runs and the tool policy is silently bypassed.
     """
-    if permission_mode is not None:
-        mapped = CODEX_PERMISSION_MODE_TO_APPROVAL.get(permission_mode)
-        if mapped is not None:
-            resolved = mapped
-        else:
-            resolved = approval_policy()
-    else:
+    if permission_mode is None:
         resolved = approval_policy()
+    else:
+        mapped = CODEX_PERMISSION_MODE_TO_APPROVAL.get(permission_mode)
+        if mapped is None:
+            logger.warning(
+                "Codex received unknown permission_mode %r; falling back to %s",
+                permission_mode,
+                _UNKNOWN_PERMISSION_MODE_FALLBACK,
+            )
+            resolved = _UNKNOWN_PERMISSION_MODE_FALLBACK
+        else:
+            resolved = mapped
 
     if has_tool_policy and resolved == "never":
         return "on-request"
@@ -396,6 +407,7 @@ class CodexClient:
         *,
         allowed_tools: Optional[List[str]] = None,
         disallowed_tools: Optional[List[str]] = None,
+        permission_mode: Optional[str] = None,
     ) -> None:
         """Replace the per-request tool policy stored on an existing session client.
 
@@ -404,13 +416,19 @@ class CodexClient:
         / ``disallowed_tools``) are per-request. Continuation requests must be
         able to refresh those fields so each turn honors its own body.
 
-        An explicit empty list ``[]`` is preserved as a block-all policy; only
-        ``None`` clears the field.
+        An explicit empty list ``[]`` for tool fields is preserved as a
+        block-all policy; only ``None`` clears them.
+
+        ``permission_mode`` is session-level (acceptEdits / bypassPermissions /
+        ...). ``None`` here means "no override sent by this request"; the
+        existing value is preserved. Pass an explicit string to change it.
         """
         client.allowed_tools = list(allowed_tools) if allowed_tools is not None else None
         client.disallowed_tools = (
             list(disallowed_tools) if disallowed_tools is not None else None
         )
+        if permission_mode is not None:
+            client.permission_mode = permission_mode
 
     def runtime_metadata(self) -> Dict[str, Any]:
         return {
@@ -763,8 +781,14 @@ class CodexClient:
         while True:
             notification = rpc.next_notification()
             if client is not None and self._is_approval_request(notification):
+                # Disallow / allowlist policies always take precedence over
+                # ``acceptEdits`` auto-accept so an explicit block can't be
+                # silently turned into an accept.
                 if self._should_auto_deny_approval(client, notification):
                     self._auto_deny_approval(rpc, notification)
+                    continue
+                if self._should_auto_accept_approval(client, notification):
+                    self._auto_accept_approval(rpc, notification)
                     continue
             yield from self._chunks_from_notification(
                 thread_id=thread_id,
@@ -827,6 +851,34 @@ class CodexClient:
             request_id,
         )
         rpc.respond(request_id, result)
+
+    def _should_auto_accept_approval(
+        self,
+        client: "CodexSessionClient",
+        notification: Dict[str, Any],
+    ) -> bool:
+        # ``acceptEdits`` mirrors Claude's permission_mode: only file edits are
+        # auto-accepted; commands and other approvals still need explicit user
+        # consent.
+        if client.permission_mode != "acceptEdits":
+            return False
+        return notification.get("method") == "item/fileChange/requestApproval"
+
+    def _auto_accept_approval(
+        self,
+        rpc: CodexJsonRpcClient,
+        notification: Dict[str, Any],
+    ) -> None:
+        request_id = notification.get("id")
+        if request_id is None:
+            return
+        method = str(notification.get("method") or "")
+        logger.info(
+            "Codex auto-accepted approval (acceptEdits): method=%s request_id=%s",
+            method,
+            request_id,
+        )
+        rpc.respond(request_id, {"decision": "accept"})
 
     def _chunks_from_notifications(
         self,

--- a/src/backends/codex/constants.py
+++ b/src/backends/codex/constants.py
@@ -48,5 +48,10 @@ def sandbox_mode() -> str:
     return legacy_aliases.get(raw, raw)
 
 
+def disallowed_tools_from_env() -> list[str]:
+    """Read DISALLOWED_TOOLS env (shared with Claude backend) for hard-block tool names."""
+    return _parse_csv(os.getenv("DISALLOWED_TOOLS", ""))
+
+
 CODEX_PROVIDER_MODELS = configured_provider_models()
 CODEX_MODELS = configured_public_models()

--- a/src/backends/opencode/client.py
+++ b/src/backends/opencode/client.py
@@ -293,9 +293,18 @@ class OpenCodeClient:
         task_budget: Optional[int] = None,
         cwd: Optional[str] = None,
         extra_env: Optional[Dict[str, str]] = None,
+        model_params: Optional[Dict[str, Any]] = None,
         _custom_base: Any = None,
     ) -> OpenCodeSessionClient:
-        _ = (allowed_tools, disallowed_tools, permission_mode, mcp_servers, task_budget, extra_env)
+        _ = (
+            allowed_tools,
+            disallowed_tools,
+            permission_mode,
+            mcp_servers,
+            task_budget,
+            extra_env,
+            model_params,
+        )
         opencode_session_id = getattr(session, "opencode_session_id", None)
         if opencode_session_id is None:
             async with httpx.AsyncClient(**self._client_kwargs()) as client:

--- a/src/main.py
+++ b/src/main.py
@@ -260,7 +260,9 @@ async def lifespan(app: FastAPI):
     # Log Responses API parameter notice
     logger.info("Responses API parameters:")
     logger.info(
-        "  Supported: model, input, instructions, previous_response_id, stream, allowed_tools, metadata"
+        "  Supported: model, input, instructions, previous_response_id, stream, "
+        "allowed_tools, disallowed_tools, permission_mode, temperature, "
+        "max_output_tokens, metadata"
     )
     logger.info("  See README.md for details")
 

--- a/src/response_models.py
+++ b/src/response_models.py
@@ -91,6 +91,13 @@ class ResponseCreateRequest(BaseModel):
         default=None,
         description="Explicit list of allowed tools. Overrides default tool list.",
     )
+    disallowed_tools: Optional[List[str]] = Field(
+        default=None,
+        description=(
+            "Tools that must be blocked for this request. Hard-blocked even when "
+            "permission_mode bypasses checks. Merged with the DISALLOWED_TOOLS env var."
+        ),
+    )
     user: Optional[str] = Field(
         default=None,
         description="Unique user identifier for workspace isolation",

--- a/src/response_models.py
+++ b/src/response_models.py
@@ -103,8 +103,9 @@ class ResponseCreateRequest(BaseModel):
     permission_mode: Optional[PermissionMode] = Field(
         default=None,
         description=(
-            "Per-request permission mode override. One of: default, acceptEdits, "
-            "bypassPermissions, plan. Falls back to the gateway default when not set."
+            "Session permission mode override. One of: default, acceptEdits, "
+            "bypassPermissions, plan. Continuation requests that omit this field "
+            "keep the current session mode."
         ),
     )
     user: Optional[str] = Field(

--- a/src/response_models.py
+++ b/src/response_models.py
@@ -7,6 +7,8 @@ from pydantic import BaseModel, Discriminator, Field, Tag
 
 from src.runtime_config import get_default_model
 
+PermissionMode = Literal["default", "acceptEdits", "bypassPermissions", "plan"]
+
 
 class ResponseInputTextPart(BaseModel):
     """A text content part within a Responses API input item."""
@@ -96,6 +98,13 @@ class ResponseCreateRequest(BaseModel):
         description=(
             "Tools that must be blocked for this request. Hard-blocked even when "
             "permission_mode bypasses checks. Merged with the DISALLOWED_TOOLS env var."
+        ),
+    )
+    permission_mode: Optional[PermissionMode] = Field(
+        default=None,
+        description=(
+            "Per-request permission mode override. One of: default, acceptEdits, "
+            "bypassPermissions, plan. Falls back to the gateway default when not set."
         ),
     )
     user: Optional[str] = Field(

--- a/src/routes/deps.py
+++ b/src/routes/deps.py
@@ -83,7 +83,10 @@ def validate_image_request(request: Any, backend: BackendClient) -> None:
     if not request_has_images(request):
         return
 
-    if getattr(backend, "name", None) == "opencode":
+    backend_name = getattr(backend, "name", None)
+    # OpenCode and Codex both accept multimodal input via their own paths
+    # (Codex turn input items in `run_completion_with_client`).
+    if backend_name in {"opencode", "codex"}:
         return
 
     # Check backend supports images

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import contextlib
+import inspect
 import json
 import logging
 import secrets
@@ -18,6 +19,7 @@ from src.message_adapter import MessageAdapter
 from src.auth import verify_api_key, security
 from src.session_manager import session_manager
 from src.backends import BackendClient, ResolvedModel
+from src.backends.claude.client import UnsupportedContinuationPolicy
 from src.backends.claude.slash_commands import (
     SlashCommandError,
     validate_prompt as validate_slash_prompt,
@@ -486,13 +488,25 @@ async def _ensure_response_session_client(
     if session.client is not None:
         update_policy = getattr(backend, "update_request_policy", None)
         if callable(update_policy):
-            update_policy(
-                session.client,
-                allowed_tools=body.allowed_tools,
-                disallowed_tools=body.disallowed_tools,
-                permission_mode=body.permission_mode,
-                model_params=_response_model_params(body),
-            )
+            try:
+                result = update_policy(
+                    session.client,
+                    allowed_tools=body.allowed_tools,
+                    disallowed_tools=body.disallowed_tools,
+                    permission_mode=body.permission_mode,
+                    model_params=_response_model_params(body),
+                )
+                # Backends may implement update_request_policy as either a sync
+                # call (Codex) or an async one (Claude — needs SDK await). Await
+                # whichever shape comes back.
+                if inspect.iscoroutine(result):
+                    await result
+            except UnsupportedContinuationPolicy as exc:
+                # Backend explicitly signaled the continuation can't honor the
+                # requested policy change. Fail closed at the API boundary.
+                # Other exceptions (e.g. an SDK ValueError) propagate so they
+                # surface as 5xx instead of being misclassified as 400.
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
         return
 
     from src.system_prompt import get_system_prompt, resolve_request_placeholders
@@ -529,6 +543,17 @@ async def _ensure_response_session_client(
 async def _unblock_pending_tool_call(
     session, backend: "BackendClient", fc_output: Dict[str, str]
 ) -> None:
+    """Validate the function_call_output and reserve the continuation.
+
+    On success the session lock is held by the caller and ``session
+    .input_response`` is stashed, but the SDK has NOT been woken yet —
+    ``pending_tool_call`` is still set and ``input_event`` has not been
+    fired. The caller is expected to call
+    :func:`_commit_pending_tool_call_locked` once any follow-up
+    invariants (e.g. mid-session policy refresh) have passed. This
+    split lets a rejected policy change fail closed before the SDK is
+    irreversibly resumed under the old policy.
+    """
     await session.lock.acquire()
     try:
         if session.pending_tool_call is None:
@@ -559,18 +584,29 @@ async def _unblock_pending_tool_call(
                 detail="function_call_output received but session has no active SDK client",
             )
 
-        session.input_response = fc_output["output"]
-        pending_event = session.input_event
-        if pending_event is None:
+        if session.input_event is None:
             raise HTTPException(
                 status_code=400,
                 detail="function_call_output received but session has no pending input event",
             )
-        pending_event.set()
-        session.pending_tool_call = None
+
+        session.input_response = fc_output["output"]
     except Exception:
         session.lock.release()
         raise
+
+
+def _commit_pending_tool_call_locked(session) -> None:
+    """Wake the SDK and clear pending state for a Claude continuation.
+
+    Caller must hold ``session.lock``. Pair with
+    :func:`_unblock_pending_tool_call` once mid-session policy refresh has
+    been accepted.
+    """
+    pending_event = session.input_event
+    if pending_event is not None:
+        pending_event.set()
+    session.pending_tool_call = None
 
 
 async def _prepare_opencode_tool_continuation(
@@ -1214,22 +1250,50 @@ async def _handle_function_call_output(
     elif resolved.backend == "codex":
         await _prepare_codex_approval_continuation(session, backend, fc_output)
     else:
+        # Claude path: validate + reserve, but DO NOT wake the SDK yet. We
+        # need to run policy refresh first so a rejected change can fail
+        # closed before the SDK is irreversibly resumed.
         await _unblock_pending_tool_call(session, backend, fc_output)
 
     # Refresh per-request tool policy on the existing session client *after*
     # validation has accepted the function_call_output, so an invalid
-    # continuation can't mutate session state. The continuation chunk source
-    # (built below from session.client) will see the refreshed policy.
+    # continuation can't mutate session state. The prepare/unblock helpers
+    # above hand the session lock off to us on success, so any failure here
+    # must release it before raising — otherwise the lock leaks for the rest
+    # of the session.
+    policy_refresh_failed = False
     if session.client is not None:
         update_policy = getattr(backend, "update_request_policy", None)
         if callable(update_policy):
-            update_policy(
-                session.client,
-                allowed_tools=body.allowed_tools,
-                disallowed_tools=body.disallowed_tools,
-                permission_mode=body.permission_mode,
-                model_params=_response_model_params(body),
-            )
+            try:
+                result = update_policy(
+                    session.client,
+                    allowed_tools=body.allowed_tools,
+                    disallowed_tools=body.disallowed_tools,
+                    permission_mode=body.permission_mode,
+                    model_params=_response_model_params(body),
+                )
+                if inspect.iscoroutine(result):
+                    await result
+            except UnsupportedContinuationPolicy as exc:
+                policy_refresh_failed = True
+                if session.lock.locked():
+                    session.lock.release()
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+            except Exception:
+                policy_refresh_failed = True
+                if session.lock.locked():
+                    session.lock.release()
+                raise
+
+    # All policy invariants passed — fire the irreversible Claude wake-up now
+    # that we know the next turn won't run under a rejected policy. OpenCode
+    # and Codex paths already committed their state inside their respective
+    # prepare/unblock helpers (their continuations don't carry
+    # UnsupportedContinuationPolicy semantics, so there's nothing to roll
+    # back).
+    if not policy_refresh_failed and resolved.backend not in {"opencode", "codex"}:
+        _commit_pending_tool_call_locked(session)
 
     # --- Stream continuation from the client ---
     next_turn = session.turn_counter + 1

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -468,6 +468,13 @@ async def _ensure_response_session_client(
 ) -> None:
     """Create the persistent backend client after session preflight has passed."""
     if session.client is not None:
+        update_policy = getattr(backend, "update_request_policy", None)
+        if callable(update_policy):
+            update_policy(
+                session.client,
+                allowed_tools=body.allowed_tools,
+                disallowed_tools=body.disallowed_tools,
+            )
         return
 
     from src.system_prompt import get_system_prompt, resolve_request_placeholders
@@ -483,6 +490,7 @@ async def _ensure_response_session_client(
             system_prompt=system_prompt if is_new_session else None,
             permission_mode=PERMISSION_MODE_BYPASS,
             allowed_tools=body.allowed_tools,
+            disallowed_tools=body.disallowed_tools,
             mcp_servers=get_mcp_servers() if resolved.backend == "claude" else None,
             cwd=workspace_str,
             extra_env=body.metadata,
@@ -1186,6 +1194,19 @@ async def _handle_function_call_output(
         await _prepare_codex_approval_continuation(session, backend, fc_output)
     else:
         await _unblock_pending_tool_call(session, backend, fc_output)
+
+    # Refresh per-request tool policy on the existing session client *after*
+    # validation has accepted the function_call_output, so an invalid
+    # continuation can't mutate session state. The continuation chunk source
+    # (built below from session.client) will see the refreshed policy.
+    if session.client is not None:
+        update_policy = getattr(backend, "update_request_policy", None)
+        if callable(update_policy):
+            update_policy(
+                session.client,
+                allowed_tools=body.allowed_tools,
+                disallowed_tools=body.disallowed_tools,
+            )
 
     # --- Stream continuation from the client ---
     next_turn = session.turn_counter + 1

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -416,6 +416,22 @@ async def _resolve_response_workspace(
     return workspace
 
 
+def _response_model_params(body: ResponseCreateRequest) -> Optional[Dict[str, Any]]:
+    """Collect OpenAI-style model overrides from the request body.
+
+    Returns ``None`` when the caller supplied no sampling/output-control
+    overrides so backends keep their existing defaults. Only fields the
+    Responses API natively exposes are forwarded; backends that can't honor
+    a given key are expected to ignore it.
+    """
+    params: Dict[str, Any] = {}
+    if body.temperature is not None:
+        params["temperature"] = body.temperature
+    if body.max_output_tokens is not None:
+        params["max_output_tokens"] = body.max_output_tokens
+    return params or None
+
+
 def _response_prompt_and_system(
     body: ResponseCreateRequest,
     workspace: Path,
@@ -475,6 +491,7 @@ async def _ensure_response_session_client(
                 allowed_tools=body.allowed_tools,
                 disallowed_tools=body.disallowed_tools,
                 permission_mode=body.permission_mode,
+                model_params=_response_model_params(body),
             )
         return
 
@@ -495,6 +512,7 @@ async def _ensure_response_session_client(
             mcp_servers=get_mcp_servers() if resolved.backend == "claude" else None,
             cwd=workspace_str,
             extra_env=body.metadata,
+            model_params=_response_model_params(body),
             _custom_base=resolved_base,
         )
     except Exception:
@@ -1208,6 +1226,7 @@ async def _handle_function_call_output(
                 allowed_tools=body.allowed_tools,
                 disallowed_tools=body.disallowed_tools,
                 permission_mode=body.permission_mode,
+                model_params=_response_model_params(body),
             )
 
     # --- Stream continuation from the client ---

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -474,6 +474,7 @@ async def _ensure_response_session_client(
                 session.client,
                 allowed_tools=body.allowed_tools,
                 disallowed_tools=body.disallowed_tools,
+                permission_mode=body.permission_mode,
             )
         return
 
@@ -488,7 +489,7 @@ async def _ensure_response_session_client(
             session=session,
             model=resolved.provider_model,
             system_prompt=system_prompt if is_new_session else None,
-            permission_mode=PERMISSION_MODE_BYPASS,
+            permission_mode=body.permission_mode or PERMISSION_MODE_BYPASS,
             allowed_tools=body.allowed_tools,
             disallowed_tools=body.disallowed_tools,
             mcp_servers=get_mcp_servers() if resolved.backend == "claude" else None,
@@ -1206,6 +1207,7 @@ async def _handle_function_call_output(
                 session.client,
                 allowed_tools=body.allowed_tools,
                 disallowed_tools=body.disallowed_tools,
+                permission_mode=body.permission_mode,
             )
 
     # --- Stream continuation from the client ---

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -449,6 +449,81 @@ def _response_prompt_and_system(
     return MessageAdapter.filter_content(prompt), system_prompt
 
 
+_CODEX_SUPPORTED_INPUT_PART_TYPES = frozenset({"input_image"})
+
+
+def _has_multimodal_input(body: ResponseCreateRequest) -> bool:
+    """True when the request carries an input part Codex can carry natively
+    (currently only ``input_image``).
+
+    Narrow on purpose: an unknown type alone would otherwise route us into
+    the multimodal branch and then drop out as an empty items list.
+    """
+    if isinstance(body.input, str):
+        return False
+    for item in body.input:
+        content = getattr(item, "content", None)
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            ptype = part.get("type") if isinstance(part, dict) else getattr(part, "type", None)
+            if ptype in _CODEX_SUPPORTED_INPUT_PART_TYPES:
+                return True
+    return False
+
+
+def _response_input_to_codex_items(
+    body: ResponseCreateRequest,
+) -> tuple[list[Dict[str, Any]], Optional[str]]:
+    """Build a Codex turn-input items list from a Responses request.
+
+    Preserves the order of ``input_text`` and ``input_image`` parts inside
+    each message so multimodal turns keep the user's intended sequence. Plain
+    string inputs become a single text item. Unknown part types are skipped
+    (forward-compat with new Responses fields).
+    """
+    system_prompt, input_for_prompt = _split_response_input(body)
+
+    if isinstance(input_for_prompt, str):
+        text = input_for_prompt.strip()
+        items: list[Dict[str, Any]] = []
+        if text:
+            items.append({"type": "text", "text": text})
+        return items, system_prompt
+
+    items = []
+    for input_item in input_for_prompt:
+        content = getattr(input_item, "content", None)
+        if isinstance(content, str):
+            if content:
+                items.append({"type": "text", "text": content})
+            continue
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            ptype = part.get("type") if isinstance(part, dict) else getattr(part, "type", None)
+            if ptype == "input_text":
+                text_value = (
+                    part.get("text") if isinstance(part, dict) else getattr(part, "text", "")
+                )
+                if text_value:
+                    items.append({"type": "text", "text": text_value})
+            elif ptype == "input_image":
+                image_url = (
+                    part.get("image_url")
+                    if isinstance(part, dict)
+                    else getattr(part, "image_url", None)
+                )
+                if image_url:
+                    # Use the Codex-native shape (``type=image`` / ``url``)
+                    # matching the in-tree fixture
+                    # tests/test_codex_backend.py multi-item case.
+                    items.append({"type": "image", "url": image_url})
+            # Other / unknown part types are ignored — they'll be added as
+            # explicit cases when their Codex item shape is known.
+    return items, system_prompt
+
+
 async def _validate_backend_prompt(
     resolved: ResolvedModel,
     prompt: str,
@@ -933,12 +1008,30 @@ async def create_response(
             body, resolved, backend, session, session_id, workspace_str, fc_output
         )
 
-    prompt, system_prompt = _response_prompt_and_system(body, workspace)
+    # Codex carries multimodal turns as a list of input items rather than a
+    # single collapsed text prompt. Build the list directly from the request
+    # body so we don't run through the disk-saving image_handler path (which
+    # rejects non-``data:`` URLs and would collapse the image into a text
+    # placeholder anyway).
+    if resolved.backend == "codex" and _has_multimodal_input(body):
+        codex_items, system_prompt = _response_input_to_codex_items(body)
+        if not codex_items:
+            # Defensive — _has_multimodal_input said yes but conversion
+            # produced nothing (e.g. an empty image_url). Fail at the API
+            # boundary instead of letting the backend reject an empty turn.
+            raise HTTPException(
+                status_code=400,
+                detail="Codex multimodal input produced no usable items",
+            )
+        prompt: Any = codex_items
+    else:
+        prompt, system_prompt = _response_prompt_and_system(body, workspace)
 
     # Reject slash-prefixed prompts that would be intercepted by the SDK as
     # unknown skills or run destructive built-ins.  Only applies to the Claude
     # backend; other backends pass through unchanged.
-    await _validate_backend_prompt(resolved, prompt, workspace_str)
+    if isinstance(prompt, str):
+        await _validate_backend_prompt(resolved, prompt, workspace_str)
 
     if body.stream:
         # Run preflight BEFORE StreamingResponse so HTTPExceptions produce

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -8,7 +8,7 @@ import logging
 import secrets
 import uuid
 from pathlib import Path
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, cast
 
 from fastapi import APIRouter, HTTPException, Request, Depends
 from fastapi.security import HTTPAuthorizationCredentials
@@ -514,11 +514,15 @@ def _response_input_to_codex_items(
                     if isinstance(part, dict)
                     else getattr(part, "image_url", None)
                 )
-                if image_url:
-                    # Use the Codex-native shape (``type=image`` / ``url``)
-                    # matching the in-tree fixture
-                    # tests/test_codex_backend.py multi-item case.
-                    items.append({"type": "image", "url": image_url})
+                if not isinstance(image_url, str) or not image_url.strip():
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Codex multimodal input contains an empty image_url",
+                    )
+                # Use the Codex-native shape (``type=image`` / ``url``)
+                # matching the in-tree fixture
+                # tests/test_codex_backend.py multi-item case.
+                items.append({"type": "image", "url": image_url})
             # Other / unknown part types are ignored — they'll be added as
             # explicit cases when their Codex item shape is known.
     return items, system_prompt
@@ -598,9 +602,7 @@ async def _ensure_response_session_client(
             permission_mode=body.permission_mode or PERMISSION_MODE_BYPASS,
             allowed_tools=body.allowed_tools,
             disallowed_tools=body.disallowed_tools,
-            mcp_servers=(
-                get_mcp_servers() if resolved.backend in {"claude", "codex"} else None
-            ),
+            mcp_servers=(get_mcp_servers() if resolved.backend in {"claude", "codex"} else None),
             cwd=workspace_str,
             extra_env=body.metadata,
             model_params=_response_model_params(body),
@@ -854,8 +856,14 @@ def _store_opencode_pending_tool_call(
         if block.get("type") != "tool_use":
             continue
         tool_name = block.get("name")
-        metadata = block.get("metadata") if isinstance(block.get("metadata"), dict) else {}
-        input_value = block.get("input") if isinstance(block.get("input"), dict) else {}
+        metadata = cast(
+            Dict[str, Any],
+            block.get("metadata") if isinstance(block.get("metadata"), dict) else {},
+        )
+        input_value = cast(
+            Dict[str, Any],
+            block.get("input") if isinstance(block.get("input"), dict) else {},
+        )
         if tool_name == "question":
             request_id = metadata.get("opencode_question_request_id")
             if not isinstance(request_id, str) or not request_id:
@@ -908,7 +916,10 @@ def _is_codex_pending_approval_chunk(
             continue
         if block.get("type") != "tool_use" or block.get("name") != "codex_approval":
             continue
-        metadata = block.get("metadata") if isinstance(block.get("metadata"), dict) else {}
+        metadata = cast(
+            Dict[str, Any],
+            block.get("metadata") if isinstance(block.get("metadata"), dict) else {},
+        )
         request_id = metadata.get("codex_approval_request_id") or block.get("id")
         if str(request_id or "") == str(pending.get("call_id") or ""):
             return True
@@ -1513,23 +1524,24 @@ async def _handle_function_call_output(
         # Resume the backend-specific pending tool request; do not start a
         # new prompt for continuation turns.
         _configure_client_streaming(active_client, False)
+        backend_with_resume = cast(Any, backend)
         if resolved.backend == "opencode":
             if opencode_resume_kind == "permission":
-                backend_source = backend.resume_permission_with_client(
+                backend_source = backend_with_resume.resume_permission_with_client(
                     active_client,
                     fc_output["call_id"],
                     fc_output["output"],
                     session,
                 )
             else:
-                backend_source = backend.resume_question_with_client(
+                backend_source = backend_with_resume.resume_question_with_client(
                     active_client,
                     fc_output["call_id"],
                     fc_output["output"],
                     session,
                 )
         elif resolved.backend == "codex":
-            backend_source = backend.resume_approval_with_client(
+            backend_source = backend_with_resume.resume_approval_with_client(
                 active_client,
                 fc_output["call_id"],
                 fc_output["output"],

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -509,7 +509,9 @@ async def _ensure_response_session_client(
             permission_mode=body.permission_mode or PERMISSION_MODE_BYPASS,
             allowed_tools=body.allowed_tools,
             disallowed_tools=body.disallowed_tools,
-            mcp_servers=get_mcp_servers() if resolved.backend == "claude" else None,
+            mcp_servers=(
+                get_mcp_servers() if resolved.backend in {"claude", "codex"} else None
+            ),
             cwd=workspace_str,
             extra_env=body.metadata,
             model_params=_response_model_params(body),

--- a/tests/integration/test_codex_e2e.py
+++ b/tests/integration/test_codex_e2e.py
@@ -186,7 +186,12 @@ for raw in sys.stdin:
                 "threadId": thread_id,
                 "turnId": turn_id,
                 "tokenUsage": {
-                    "last": {"inputTokens": 2, "cachedInputTokens": 0, "outputTokens": 3}
+                    "last": {
+                        "inputTokens": 2,
+                        "cachedInputTokens": 0,
+                        "outputTokens": 3,
+                        "reasoningOutputTokens": 2,
+                    }
                 },
             },
         })
@@ -305,7 +310,8 @@ def test_codex_responses_e2e_approval_continuation(tmp_path, prompt, expected_ki
         second_body = second.json()
         assert second_body["status"] == "completed"
         assert second_body["output"][0]["content"][0]["text"] == "Codex e2e approved."
-        assert second_body["usage"] == {"input_tokens": 2, "output_tokens": 3}
+        # Reasoning tokens (2) roll into output (3) for OpenAI-compatible usage reporting.
+        assert second_body["usage"] == {"input_tokens": 2, "output_tokens": 5}
 
 
 def test_codex_streaming_approval_exposes_only_ask_user_question(tmp_path):

--- a/tests/integration/test_codex_e2e.py
+++ b/tests/integration/test_codex_e2e.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
+import src.admin_auth as admin_auth_module
 import src.main as main
 import src.routes.general as general_module
 import src.routes.responses as responses_module
@@ -100,6 +101,34 @@ for raw in sys.stdin:
         continue
 
     if msg_id == "approval_1":
+        decision = ""
+        result_payload = msg.get("result") or {}
+        if isinstance(result_payload, dict):
+            decision_field = result_payload.get("decision")
+            if isinstance(decision_field, str):
+                decision = decision_field
+        if decision == "decline":
+            send({
+                "method": "item/completed",
+                "params": {
+                    "threadId": thread_id,
+                    "turnId": turn_id,
+                    "item": {
+                        "type": "agentMessage",
+                        "id": "msg_decline",
+                        "phase": "final_answer",
+                        "text": "Codex stopped: approval was declined.",
+                    },
+                },
+            })
+            send({
+                "method": "turn/completed",
+                "params": {
+                    "threadId": thread_id,
+                    "turn": {"id": turn_id, "status": "completed", "items": []},
+                },
+            })
+            continue
         if approval_mode == "file_change":
             completed_item = {
                 "type": "fileChange",
@@ -180,7 +209,7 @@ def _write_fake_codex(tmp_path: Path) -> Path:
 
 
 @contextmanager
-def codex_client_context(fake_bin: Path):
+def codex_client_context(fake_bin: Path, extra_env: dict | None = None):
     """Create a TestClient with the real Codex backend and fake app-server binary."""
 
     def _mock_discover():
@@ -193,16 +222,17 @@ def codex_client_context(fake_bin: Path):
     if main.limiter and hasattr(main.limiter, "_storage"):
         main.limiter._storage.reset()
 
+    env_overrides = {
+        "CODEX_BIN": str(fake_bin),
+        "CODEX_MODELS": "gpt-5.5",
+        "BACKENDS": "codex",
+    }
+    if extra_env:
+        env_overrides.update(extra_env)
+
     with (
-        patch.dict(
-            "os.environ",
-            {
-                "CODEX_BIN": str(fake_bin),
-                "CODEX_MODELS": "gpt-5.5",
-                "BACKENDS": "codex",
-            },
-            clear=False,
-        ),
+        patch.dict("os.environ", env_overrides, clear=False),
+        patch.object(admin_auth_module, "ADMIN_API_KEY", "test-admin-key"),
         patch.object(main, "discover_backends", _mock_discover),
         patch.object(responses_module, "verify_api_key", new=AsyncMock(return_value=True)),
         patch.object(general_module, "verify_api_key", new=AsyncMock(return_value=True)),
@@ -295,3 +325,98 @@ def test_codex_streaming_approval_exposes_only_ask_user_question(tmp_path):
     assert '"status": "requires_action"' in response.text
     assert '"name": "AskUserQuestion"' in response.text
     assert "codex_approval" not in response.text
+
+
+def test_codex_global_disallowed_tools_blocks_command_approval_e2e(tmp_path):
+    """DISALLOWED_TOOLS=Bash auto-denies commandExecution approvals at the route level."""
+    fake_bin = _write_fake_codex(tmp_path)
+
+    with codex_client_context(fake_bin, extra_env={"DISALLOWED_TOOLS": "Bash"}) as client:
+        response = client.post(
+            "/v1/responses",
+            json={"model": "codex/gpt-5.5", "input": "run a command", "stream": False},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    # No requires_action: the approval was auto-denied and the turn completed without prompting.
+    assert body["status"] == "completed"
+    # The fake server's decline branch emits this exact final message.
+    assert body["output"][0]["content"][0]["text"] == "Codex stopped: approval was declined."
+
+
+def test_codex_request_body_disallowed_tools_blocks_command_approval_e2e(tmp_path):
+    """Per-request ``disallowed_tools`` in the Responses API body reaches Codex enforcement."""
+    fake_bin = _write_fake_codex(tmp_path)
+
+    with codex_client_context(fake_bin) as client:
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": "codex/gpt-5.5",
+                "input": "run a command",
+                "stream": False,
+                "disallowed_tools": ["Bash"],
+            },
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "completed"
+    assert body["output"][0]["content"][0]["text"] == "Codex stopped: approval was declined."
+
+
+def test_codex_continuation_request_refreshes_disallowed_tools(tmp_path):
+    """A continuation request's disallowed_tools applies even when the session client already exists.
+
+    Scenario:
+      1. First request has no tool policy -> Codex emits approval -> requires_action.
+      2. Second request (continuation) provides function_call_output "accept" -> turn completes.
+      3. Third request (new turn, same session) adds ``disallowed_tools=['Bash']``.
+         The gateway must auto-deny that turn's command approval instead of
+         silently dropping the new policy.
+    """
+    fake_bin = _write_fake_codex(tmp_path)
+
+    with codex_client_context(fake_bin) as client:
+        first = client.post(
+            "/v1/responses",
+            json={"model": "codex/gpt-5.5", "input": "run a command", "stream": False},
+        )
+        assert first.status_code == 200
+        first_body = first.json()
+        assert first_body["status"] == "requires_action"
+
+        second = client.post(
+            "/v1/responses",
+            json={
+                "model": "codex/gpt-5.5",
+                "previous_response_id": first_body["id"],
+                "input": [
+                    {
+                        "type": "function_call_output",
+                        "call_id": "approval_1",
+                        "output": "accept",
+                    }
+                ],
+                "stream": False,
+            },
+        )
+        assert second.status_code == 200
+        assert second.json()["status"] == "completed"
+
+        third = client.post(
+            "/v1/responses",
+            json={
+                "model": "codex/gpt-5.5",
+                "previous_response_id": second.json()["id"],
+                "input": "run another command",
+                "stream": False,
+                "disallowed_tools": ["Bash"],
+            },
+        )
+
+    assert third.status_code == 200
+    third_body = third.json()
+    assert third_body["status"] == "completed"
+    assert third_body["output"][0]["content"][0]["text"] == "Codex stopped: approval was declined."

--- a/tests/integration/test_codex_e2e.py
+++ b/tests/integration/test_codex_e2e.py
@@ -17,15 +17,29 @@ from src.backends.base import BackendRegistry
 
 FAKE_CODEX_APP_SERVER = r"""#!/usr/bin/env python3
 import json
+import os
 import sys
 
 thread_id = "thr_e2e"
 turn_id = "turn_1"
 approval_mode = "command"
+# Tests can point FAKE_CODEX_TURN_START_LOG at a file to capture every
+# turn/start payload as JSONL for later assertions.
+turn_start_log = os.environ.get("FAKE_CODEX_TURN_START_LOG")
 
 
 def log(message):
     print(message, file=sys.stderr, flush=True)
+
+
+def record_turn_start(params):
+    if not turn_start_log:
+        return
+    try:
+        with open(turn_start_log, "a", encoding="utf-8") as fp:
+            fp.write(json.dumps(params, sort_keys=True) + "\n")
+    except OSError:
+        pass
 
 
 def send(payload):
@@ -55,6 +69,7 @@ for raw in sys.stdin:
         send({"id": msg_id, "result": {"thread": {"id": params.get("threadId", thread_id)}}})
         continue
     if method == "turn/start":
+        record_turn_start(params)
         input_items = params.get("input") or []
         prompt = ""
         if input_items and isinstance(input_items[0], dict):
@@ -395,6 +410,44 @@ def test_codex_accept_edits_auto_accepts_file_change_e2e(tmp_path):
     body = response.json()
     assert body["status"] == "completed"
     assert body["output"][0]["content"][0]["text"] == "Codex e2e approved."
+
+
+def test_codex_request_body_model_params_flow_through_to_turn_start_e2e(tmp_path):
+    """temperature / max_output_tokens from the body reach Codex turn/start params.
+
+    The fake codex app-server logs every received turn/start payload to a file
+    pointed to by FAKE_CODEX_TURN_START_LOG. The test then reads the file and
+    confirms the gateway forwarded the sampling overrides under the expected
+    Codex keys.
+    """
+    fake_bin = _write_fake_codex(tmp_path)
+    turn_log = tmp_path / "turn-start.jsonl"
+
+    with codex_client_context(
+        fake_bin, extra_env={"FAKE_CODEX_TURN_START_LOG": str(turn_log)}
+    ) as client:
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": "codex/gpt-5.5",
+                "input": "request file change approval",
+                "stream": False,
+                "temperature": 0.25,
+                "max_output_tokens": 64,
+                # acceptEdits lets the fake's fileChange branch run to
+                # completion so the e2e finishes cleanly.
+                "permission_mode": "acceptEdits",
+            },
+        )
+
+    assert response.status_code == 200
+
+    assert turn_log.exists(), "fake codex did not record any turn/start params"
+    lines = [json.loads(line) for line in turn_log.read_text().splitlines() if line.strip()]
+    assert lines, "turn/start log is empty"
+    first = lines[0]
+    assert first.get("temperature") == 0.25
+    assert first.get("maxOutputTokens") == 64
 
 
 def test_codex_continuation_request_switches_permission_mode_to_accept_edits(tmp_path):

--- a/tests/integration/test_codex_e2e.py
+++ b/tests/integration/test_codex_e2e.py
@@ -372,6 +372,91 @@ def test_codex_request_body_disallowed_tools_blocks_command_approval_e2e(tmp_pat
     assert body["output"][0]["content"][0]["text"] == "Codex stopped: approval was declined."
 
 
+def test_codex_accept_edits_auto_accepts_file_change_e2e(tmp_path):
+    """permission_mode='acceptEdits' on the Responses body auto-accepts fileChange.
+
+    With acceptEdits, the fake's fileChange approval flow runs to completion
+    without surfacing a requires_action response.
+    """
+    fake_bin = _write_fake_codex(tmp_path)
+
+    with codex_client_context(fake_bin) as client:
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": "codex/gpt-5.5",
+                "input": "request file change approval",
+                "stream": False,
+                "permission_mode": "acceptEdits",
+            },
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "completed"
+    assert body["output"][0]["content"][0]["text"] == "Codex e2e approved."
+
+
+def test_codex_continuation_request_switches_permission_mode_to_accept_edits(tmp_path):
+    """A continuation request can flip permission_mode to acceptEdits and have the next turn auto-accept fileChange.
+
+    Scenario:
+      1. First request: permission_mode default-equivalent (bypass) -> fake codex emits a command
+         approval -> requires_action.
+      2. Second request: function_call_output 'accept' to advance the first turn ->
+         turn completes.
+      3. Third request: same session, ``permission_mode='acceptEdits'`` + prompt that
+         routes the fake to fileChange approval. The route's update_request_policy
+         must propagate the new mode so the gateway auto-accepts fileChange
+         without surfacing a requires_action response.
+    """
+    fake_bin = _write_fake_codex(tmp_path)
+
+    with codex_client_context(fake_bin) as client:
+        first = client.post(
+            "/v1/responses",
+            json={"model": "codex/gpt-5.5", "input": "run a command", "stream": False},
+        )
+        assert first.status_code == 200
+        assert first.json()["status"] == "requires_action"
+        first_body = first.json()
+
+        second = client.post(
+            "/v1/responses",
+            json={
+                "model": "codex/gpt-5.5",
+                "previous_response_id": first_body["id"],
+                "input": [
+                    {
+                        "type": "function_call_output",
+                        "call_id": "approval_1",
+                        "output": "accept",
+                    }
+                ],
+                "stream": False,
+            },
+        )
+        assert second.status_code == 200
+        assert second.json()["status"] == "completed"
+
+        third = client.post(
+            "/v1/responses",
+            json={
+                "model": "codex/gpt-5.5",
+                "previous_response_id": second.json()["id"],
+                "input": "request file change approval",
+                "stream": False,
+                "permission_mode": "acceptEdits",
+            },
+        )
+
+    assert third.status_code == 200
+    third_body = third.json()
+    assert third_body["status"] == "completed"
+    # The fake's "approved" branch fires when our auto-accept reaches it.
+    assert third_body["output"][0]["content"][0]["text"] == "Codex e2e approved."
+
+
 def test_codex_continuation_request_refreshes_disallowed_tools(tmp_path):
     """A continuation request's disallowed_tools applies even when the session client already exists.
 

--- a/tests/test_claude_cli_unit.py
+++ b/tests/test_claude_cli_unit.py
@@ -1048,3 +1048,77 @@ class TestCreateClientSessionId:
 
         assert captured["session_id"] is None
         assert captured["resume"] == gateway_session.session_id
+
+
+# ---------------------------------------------------------------------------
+# Group: update_request_policy (mid-session policy refresh — Codex parity)
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateRequestPolicy:
+    """Mirror Codex Step 1: continuation requests must refresh policy mid-session.
+
+    The Claude SDK only exposes ``set_permission_mode`` for mid-session
+    changes; the other tool-policy fields are baked into ``ClaudeAgentOptions``
+    at create_client time and cannot be retro-actively updated by the SDK.
+    """
+
+    @pytest.mark.asyncio
+    async def test_permission_mode_calls_sdk_set_permission_mode(self, cli_instance):
+        from unittest.mock import AsyncMock
+
+        sdk_client = MagicMock()
+        sdk_client.set_permission_mode = AsyncMock()
+
+        await cli_instance.update_request_policy(
+            sdk_client, permission_mode="acceptEdits"
+        )
+
+        sdk_client.set_permission_mode.assert_awaited_once_with("acceptEdits")
+
+    @pytest.mark.asyncio
+    async def test_omitted_permission_mode_does_not_touch_sdk(self, cli_instance):
+        from unittest.mock import AsyncMock
+
+        sdk_client = MagicMock()
+        sdk_client.set_permission_mode = AsyncMock()
+
+        await cli_instance.update_request_policy(sdk_client)
+
+        sdk_client.set_permission_mode.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_set_permission_mode_failure_propagates(self, cli_instance):
+        """SDK rejection of a permission_mode change is *not* swallowed — running
+        the next turn under the old mode could be a silent privilege downgrade,
+        so the exception bubbles up for the route to fail closed.
+        """
+        from unittest.mock import AsyncMock
+
+        sdk_client = MagicMock()
+        sdk_client.set_permission_mode = AsyncMock(
+            side_effect=RuntimeError("not connected")
+        )
+
+        with pytest.raises(RuntimeError, match="not connected"):
+            await cli_instance.update_request_policy(
+                sdk_client, permission_mode="acceptEdits"
+            )
+
+    @pytest.mark.asyncio
+    async def test_tool_list_change_raises_unsupported(self, cli_instance):
+        """Tool list change on a continuation is rejected — the SDK has no
+        runtime API for it, and silently dropping a disallowed_tools hard-block
+        would be a security gap.
+        """
+        from src.backends.claude.client import UnsupportedContinuationPolicy
+
+        sdk_client = MagicMock()
+        with pytest.raises(UnsupportedContinuationPolicy):
+            await cli_instance.update_request_policy(
+                sdk_client, disallowed_tools=["Bash"]
+            )
+        with pytest.raises(UnsupportedContinuationPolicy):
+            await cli_instance.update_request_policy(
+                sdk_client, allowed_tools=["Read"]
+            )

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -570,6 +570,755 @@ def test_codex_client_logs_unrecognized_structured_approval_output(caplog):
     assert "{'foo': 1}" in caplog.text
 
 
+def _command_approval_notifications(*, request_id: str = "approval_1", command: str = "ls"):
+    return [
+        {
+            "id": request_id,
+            "method": "item/commandExecution/requestApproval",
+            "params": {
+                "threadId": "thr_codex",
+                "turnId": "turn_1",
+                "itemId": "cmd_1",
+                "command": command,
+                "availableDecisions": ["accept", "decline"],
+            },
+        },
+        {
+            "method": "turn/completed",
+            "params": {
+                "threadId": "thr_codex",
+                "turnId": "turn_1",
+                "turn": {"id": "turn_1", "status": "completed", "items": []},
+            },
+        },
+    ]
+
+
+def _file_change_approval_notifications(*, request_id: str = "approval_1"):
+    return [
+        {
+            "id": request_id,
+            "method": "item/fileChange/requestApproval",
+            "params": {
+                "threadId": "thr_codex",
+                "turnId": "turn_1",
+                "itemId": "file_1",
+                "grantRoot": "/repo",
+                "availableDecisions": ["accept", "decline"],
+            },
+        },
+        {
+            "method": "turn/completed",
+            "params": {
+                "threadId": "thr_codex",
+                "turnId": "turn_1",
+                "turn": {"id": "turn_1", "status": "completed", "items": []},
+            },
+        },
+    ]
+
+
+def _collect_approval_tool_uses(chunks):
+    return [
+        block
+        for chunk in chunks
+        if chunk.get("type") == "assistant"
+        for block in chunk.get("content", [])
+        if block.get("type") == "tool_use" and block.get("name") == "codex_approval"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_codex_disallowed_tools_blocks_bash_command_approval(monkeypatch):
+    """When ``Bash`` is in disallowed_tools, commandExecution approvals are auto-denied."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = _command_approval_notifications(command="rm -rf /")
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        disallowed_tools=["Bash"],
+    )
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "test", session)]
+
+    assert fake_rpc.respond_calls == [("approval_1", {"decision": "decline"})]
+    assert _collect_approval_tool_uses(chunks) == []
+    assert session.pending_tool_call is None
+
+
+@pytest.mark.asyncio
+async def test_codex_disallowed_tools_accepts_codex_native_command_name(monkeypatch):
+    """``commandExecution`` (Codex-native name) in disallowed_tools auto-denies command approvals."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = _command_approval_notifications()
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        disallowed_tools=["commandExecution"],
+    )
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "test", session)]
+
+    assert fake_rpc.respond_calls == [("approval_1", {"decision": "decline"})]
+    assert _collect_approval_tool_uses(chunks) == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("alias", ["Edit", "Write", "NotebookEdit", "fileChange"])
+async def test_codex_disallowed_tools_blocks_file_change_approval(monkeypatch, alias):
+    """Any of Edit/Write/NotebookEdit (or Codex-native fileChange) auto-denies fileChange approvals."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = _file_change_approval_notifications()
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        disallowed_tools=[alias],
+    )
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "test", session)]
+
+    assert fake_rpc.respond_calls == [("approval_1", {"decision": "decline"})]
+    assert _collect_approval_tool_uses(chunks) == []
+    assert session.pending_tool_call is None
+
+
+@pytest.mark.asyncio
+async def test_codex_disallowed_tools_does_not_affect_permissions_approval(monkeypatch):
+    """Permissions approvals are not gated by tool name lists (they request scope, not tools)."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = [
+        {
+            "id": "approval_1",
+            "method": "item/permissions/requestApproval",
+            "params": {
+                "threadId": "thr_codex",
+                "turnId": "turn_1",
+                "itemId": "perm_1",
+                "permissions": {"fileSystem": {"read": ["/repo"]}},
+            },
+        },
+        {
+            "method": "turn/completed",
+            "params": {
+                "threadId": "thr_codex",
+                "turnId": "turn_1",
+                "turn": {"id": "turn_1", "status": "completed", "items": []},
+            },
+        },
+    ]
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        disallowed_tools=["Bash", "Edit"],
+    )
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "test", session)]
+
+    # Permission approval bubbles to user — no auto-deny via respond_calls
+    assert fake_rpc.respond_calls == []
+    assert len(_collect_approval_tool_uses(chunks)) == 1
+    assert session.pending_tool_call is not None
+
+
+@pytest.mark.asyncio
+async def test_codex_allowed_tools_whitelist_blocks_unlisted_command(monkeypatch):
+    """allowed_tools whitelist mode auto-denies approvals not in the list."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = _command_approval_notifications()
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    # allowed contains only Edit (fileChange) — command should be blocked.
+    client = await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        allowed_tools=["Edit"],
+    )
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "test", session)]
+
+    assert fake_rpc.respond_calls == [("approval_1", {"decision": "decline"})]
+    assert _collect_approval_tool_uses(chunks) == []
+
+
+@pytest.mark.asyncio
+async def test_codex_allowed_tools_whitelist_lets_listed_approval_bubble(monkeypatch):
+    """allowed_tools whitelist mode still lets listed tools surface as user approvals."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = _command_approval_notifications()
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        allowed_tools=["Bash"],
+    )
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "test", session)]
+
+    assert fake_rpc.respond_calls == []
+    assert len(_collect_approval_tool_uses(chunks)) == 1
+    assert session.pending_tool_call is not None
+
+
+@pytest.mark.asyncio
+async def test_codex_permission_mode_bypass_overrides_thread_approval_policy(monkeypatch):
+    """permission_mode='bypassPermissions' sets Codex approvalPolicy='never' at thread start."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = [
+        {
+            "method": "turn/completed",
+            "params": {
+                "threadId": "thr_codex",
+                "turnId": "turn_1",
+                "turn": {"id": "turn_1", "status": "completed", "items": []},
+            },
+        }
+    ]
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+    monkeypatch.setenv("CODEX_APPROVAL_POLICY", "on-request")  # env says ask; permission_mode overrides
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        permission_mode="bypassPermissions",
+    )
+
+    assert fake_rpc.thread_start_calls
+    assert fake_rpc.thread_start_calls[0]["approvalPolicy"] == "never"
+
+
+@pytest.mark.asyncio
+async def test_codex_permission_mode_default_maps_to_on_request(monkeypatch):
+    """permission_mode='default' maps to Codex approvalPolicy='on-request' even if env says 'never'."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = []
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+    monkeypatch.setenv("CODEX_APPROVAL_POLICY", "never")
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        permission_mode="default",
+    )
+
+    assert fake_rpc.thread_start_calls
+    assert fake_rpc.thread_start_calls[0]["approvalPolicy"] == "on-request"
+
+
+@pytest.mark.asyncio
+async def test_codex_permission_mode_propagates_to_turn_params(monkeypatch):
+    """permission_mode affects turn/start approvalPolicy too (per-turn override)."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = [
+        {
+            "method": "turn/completed",
+            "params": {
+                "threadId": "thr_codex",
+                "turnId": "turn_1",
+                "turn": {"id": "turn_1", "status": "completed", "items": []},
+            },
+        }
+    ]
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+    monkeypatch.setenv("CODEX_APPROVAL_POLICY", "on-request")
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        permission_mode="bypassPermissions",
+    )
+    [chunk async for chunk in backend.run_completion_with_client(client, "hi", session)]
+
+    assert fake_rpc.turn_start_calls
+    _, _, turn_params = fake_rpc.turn_start_calls[0]
+    assert turn_params["approvalPolicy"] == "never"
+
+
+@pytest.mark.asyncio
+async def test_codex_disallowed_tools_forces_approval_policy_off_never(monkeypatch):
+    """Setting disallowed_tools must upgrade approvalPolicy=never to on-request so Codex emits approvals."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = []
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+    monkeypatch.delenv("CODEX_APPROVAL_POLICY", raising=False)  # defaults to "never"
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        permission_mode="bypassPermissions",
+        disallowed_tools=["Bash"],
+    )
+
+    assert fake_rpc.thread_start_calls
+    policy = fake_rpc.thread_start_calls[0]["approvalPolicy"]
+    assert policy != "never", (
+        f"approvalPolicy must not be 'never' when disallowed_tools is set "
+        f"(otherwise Codex skips approval emission and enforcement is bypassed); got {policy!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_codex_allowed_tools_forces_approval_policy_off_never(monkeypatch):
+    """allowed_tools whitelist also upgrades approvalPolicy off 'never' so enforcement runs."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = []
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+    monkeypatch.setenv("CODEX_APPROVAL_POLICY", "never")
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        permission_mode="bypassPermissions",
+        allowed_tools=["Edit"],
+    )
+
+    assert fake_rpc.thread_start_calls
+    policy = fake_rpc.thread_start_calls[0]["approvalPolicy"]
+    assert policy != "never", (
+        f"approvalPolicy must not be 'never' when allowed_tools is set; got {policy!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_codex_disallowed_tools_env_forces_approval_policy_off_never(monkeypatch):
+    """Global DISALLOWED_TOOLS env also upgrades approvalPolicy so enforcement runs."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = []
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+    monkeypatch.setenv("CODEX_APPROVAL_POLICY", "never")
+    monkeypatch.setenv("DISALLOWED_TOOLS", "Bash")
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        permission_mode="bypassPermissions",
+    )
+
+    assert fake_rpc.thread_start_calls
+    policy = fake_rpc.thread_start_calls[0]["approvalPolicy"]
+    assert policy != "never", f"got {policy!r}"
+
+
+@pytest.mark.asyncio
+async def test_codex_no_tool_policy_keeps_never_approval_policy(monkeypatch):
+    """Without any tool policy, approvalPolicy still resolves to 'never' (no unsolicited upgrade)."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = []
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+    monkeypatch.setenv("CODEX_APPROVAL_POLICY", "never")
+    monkeypatch.delenv("DISALLOWED_TOOLS", raising=False)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        permission_mode="bypassPermissions",
+    )
+
+    assert fake_rpc.thread_start_calls
+    assert fake_rpc.thread_start_calls[0]["approvalPolicy"] == "never"
+
+
+@pytest.mark.asyncio
+async def test_codex_no_permission_mode_falls_back_to_env(monkeypatch):
+    """When permission_mode is None, approvalPolicy still comes from CODEX_APPROVAL_POLICY env."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = []
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+    monkeypatch.setenv("CODEX_APPROVAL_POLICY", "on-request")
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    await backend.create_client(session=session, model="gpt-5.5")
+
+    assert fake_rpc.thread_start_calls
+    assert fake_rpc.thread_start_calls[0]["approvalPolicy"] == "on-request"
+
+
+@pytest.mark.asyncio
+async def test_codex_global_disallowed_tools_env_blocks_command(monkeypatch):
+    """The DISALLOWED_TOOLS env var hard-blocks approvals even without per-request setting."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = _command_approval_notifications()
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+    monkeypatch.setenv("DISALLOWED_TOOLS", "Bash")
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(session=session, model="gpt-5.5")
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "test", session)]
+
+    assert fake_rpc.respond_calls == [("approval_1", {"decision": "decline"})]
+    assert _collect_approval_tool_uses(chunks) == []
+
+
+@pytest.mark.asyncio
+async def test_codex_global_disallowed_tools_merges_with_per_request(monkeypatch):
+    """env DISALLOWED_TOOLS and per-request disallowed_tools both apply (union semantics)."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = _file_change_approval_notifications()
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+    monkeypatch.setenv("DISALLOWED_TOOLS", "Bash")
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    # Env blocks Bash; per-request blocks Edit. The file change request should be auto-denied
+    # because Edit is listed per-request.
+    client = await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        disallowed_tools=["Edit"],
+    )
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "test", session)]
+
+    assert fake_rpc.respond_calls == [("approval_1", {"decision": "decline"})]
+    assert _collect_approval_tool_uses(chunks) == []
+
+
+def _mcp_tool_call_approval_notifications(*, request_id: str = "approval_1"):
+    return [
+        {
+            "id": request_id,
+            "method": "item/mcpToolCall/requestApproval",
+            "params": {
+                "threadId": "thr_codex",
+                "turnId": "turn_1",
+                "itemId": "mcp_1",
+                "serverLabel": "fs",
+                "toolName": "read_file",
+                "availableDecisions": ["accept", "decline"],
+            },
+        },
+        {
+            "method": "turn/completed",
+            "params": {
+                "threadId": "thr_codex",
+                "turnId": "turn_1",
+                "turn": {"id": "turn_1", "status": "completed", "items": []},
+            },
+        },
+    ]
+
+
+def _dynamic_tool_call_approval_notifications(*, request_id: str = "approval_1"):
+    return [
+        {
+            "id": request_id,
+            "method": "item/dynamicToolCall/requestApproval",
+            "params": {
+                "threadId": "thr_codex",
+                "turnId": "turn_1",
+                "itemId": "dyn_1",
+                "toolName": "search",
+                "availableDecisions": ["accept", "decline"],
+            },
+        },
+        {
+            "method": "turn/completed",
+            "params": {
+                "threadId": "thr_codex",
+                "turnId": "turn_1",
+                "turn": {"id": "turn_1", "status": "completed", "items": []},
+            },
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_codex_disallowed_tools_blocks_mcp_tool_call_approval(monkeypatch):
+    """disallowed_tools containing 'mcpToolCall' auto-denies MCP tool approval requests."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = _mcp_tool_call_approval_notifications()
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        disallowed_tools=["mcpToolCall"],
+    )
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "test", session)]
+
+    assert fake_rpc.respond_calls == [("approval_1", {"decision": "decline"})]
+    assert _collect_approval_tool_uses(chunks) == []
+    assert session.pending_tool_call is None
+
+
+@pytest.mark.asyncio
+async def test_codex_disallowed_tools_blocks_dynamic_tool_call_approval(monkeypatch):
+    """disallowed_tools containing 'dynamicToolCall' auto-denies dynamic tool approvals."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = _dynamic_tool_call_approval_notifications()
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        disallowed_tools=["dynamicToolCall"],
+    )
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "test", session)]
+
+    assert fake_rpc.respond_calls == [("approval_1", {"decision": "decline"})]
+    assert _collect_approval_tool_uses(chunks) == []
+
+
+@pytest.mark.asyncio
+async def test_codex_allowed_tools_whitelist_blocks_mcp_when_not_listed(monkeypatch):
+    """allowed_tools whitelist auto-denies MCP approvals that aren't listed."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = _mcp_tool_call_approval_notifications()
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        allowed_tools=["Bash"],
+    )
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "test", session)]
+
+    assert fake_rpc.respond_calls == [("approval_1", {"decision": "decline"})]
+    assert _collect_approval_tool_uses(chunks) == []
+
+
+@pytest.mark.asyncio
+async def test_codex_empty_allowed_tools_blocks_all_command_approvals(monkeypatch):
+    """allowed_tools=[] is an explicit block-all whitelist (distinct from None / unset)."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = _command_approval_notifications()
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        allowed_tools=[],  # explicit empty list = block everything
+    )
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "test", session)]
+
+    assert fake_rpc.respond_calls == [("approval_1", {"decision": "decline"})]
+    assert _collect_approval_tool_uses(chunks) == []
+
+
+@pytest.mark.asyncio
+async def test_codex_empty_allowed_tools_forces_approval_policy_off_never(monkeypatch):
+    """allowed_tools=[] is a real policy and upgrades approvalPolicy off 'never'."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = []
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+    monkeypatch.setenv("CODEX_APPROVAL_POLICY", "never")
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        permission_mode="bypassPermissions",
+        allowed_tools=[],
+    )
+
+    assert fake_rpc.thread_start_calls
+    assert fake_rpc.thread_start_calls[0]["approvalPolicy"] != "never"
+
+
+@pytest.mark.asyncio
+async def test_codex_update_request_policy_replaces_session_tool_lists(monkeypatch):
+    """update_request_policy() lets continuation requests refresh per-request tool policy."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = []
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session")
+    client = await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        disallowed_tools=["Bash"],
+    )
+    assert client.disallowed_tools == ["Bash"]
+    assert client.allowed_tools is None
+
+    backend.update_request_policy(
+        client,
+        allowed_tools=["Edit"],
+        disallowed_tools=["Write"],
+    )
+    assert client.allowed_tools == ["Edit"]
+    assert client.disallowed_tools == ["Write"]
+
+
+@pytest.mark.asyncio
+async def test_codex_update_request_policy_clears_with_none(monkeypatch):
+    """Passing None explicitly clears a previously-set policy field."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = []
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session")
+    client = await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        disallowed_tools=["Bash"],
+        allowed_tools=["Edit"],
+    )
+
+    backend.update_request_policy(client, allowed_tools=None, disallowed_tools=None)
+    assert client.allowed_tools is None
+    assert client.disallowed_tools is None
+
+
+@pytest.mark.asyncio
+async def test_codex_disallowed_tools_applies_on_approval_resume(monkeypatch):
+    """Auto-deny policy applies to approvals surfaced during approval-resume turns."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = [
+        {
+            "method": "serverRequest/resolved",
+            "params": {"threadId": "thr_codex", "requestId": "approval_0"},
+        },
+        {
+            "id": "approval_1",
+            "method": "item/commandExecution/requestApproval",
+            "params": {
+                "threadId": "thr_codex",
+                "turnId": "turn_1",
+                "itemId": "cmd_2",
+                "command": "rm -rf /",
+                "availableDecisions": ["accept", "decline"],
+            },
+        },
+        {
+            "method": "turn/completed",
+            "params": {
+                "threadId": "thr_codex",
+                "turnId": "turn_1",
+                "turn": {"id": "turn_1", "status": "completed", "items": []},
+            },
+        },
+    ]
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        disallowed_tools=["Bash"],
+    )
+    client.pending_approval_request_id = "approval_0"
+    client.pending_approval_method = "item/commandExecution/requestApproval"
+    client.pending_approval_turn_id = "turn_1"
+    client.pending_approval_params = {"turnId": "turn_1"}
+
+    chunks = [
+        chunk
+        async for chunk in backend.resume_approval_with_client(
+            client, "approval_0", "accept", session
+        )
+    ]
+
+    # First respond is the user's "accept" for approval_0; second is the auto-deny for approval_1.
+    assert fake_rpc.respond_calls == [
+        ("approval_0", {"decision": "accept"}),
+        ("approval_1", {"decision": "decline"}),
+    ]
+    assert _collect_approval_tool_uses(chunks) == []
+    assert session.pending_tool_call is None
+
+
 @pytest.mark.asyncio
 async def test_codex_client_resumes_command_approval_and_continues_turn(monkeypatch):
     """Codex approval continuation responds to app-server and reads remaining events."""
@@ -1065,6 +1814,82 @@ async def test_codex_function_call_output_uses_approval_resume_without_input_eve
     assert session.turn_counter == 2
     assert session.pending_tool_call is None
     assert calls == [(session.client, "approval_1", "accept", session)]
+
+
+@pytest.mark.asyncio
+async def test_codex_function_call_output_refreshes_session_tool_policy(monkeypatch):
+    """A function_call_output body with new disallowed_tools updates the session client policy."""
+    from src.backends import ResolvedModel
+    from src.response_models import ResponseCreateRequest
+    from src.routes.responses import _handle_function_call_output
+    from src.session_manager import Session
+
+    session = Session(session_id="00000000-0000-0000-0000-000000000001", backend="codex")
+    session.client = SimpleNamespace(allowed_tools=None, disallowed_tools=None)
+    session.workspace = "/tmp/ws/test"
+    session.turn_counter = 1
+    session.pending_tool_call = {
+        "call_id": "approval_1",
+        "name": "AskUserQuestion",
+        "arguments": {"question": "Approve?"},
+        "backend": "codex",
+        "codex_resume": "approval",
+    }
+    session.input_event = None
+
+    body = ResponseCreateRequest(
+        model="codex/gpt-5.5",
+        input=[
+            {
+                "type": "function_call_output",
+                "call_id": "approval_1",
+                "output": "accept",
+            }
+        ],
+        previous_response_id="resp_00000000-0000-0000-0000-000000000001_1",
+        stream=False,
+        disallowed_tools=["Bash"],
+    )
+    resolved = ResolvedModel("codex/gpt-5.5", "codex", "gpt-5.5")
+
+    update_calls = []
+
+    class FakeBackend:
+        name = "codex"
+
+        def update_request_policy(self, client, *, allowed_tools=None, disallowed_tools=None):
+            update_calls.append((client, allowed_tools, disallowed_tools))
+            client.allowed_tools = list(allowed_tools) if allowed_tools is not None else None
+            client.disallowed_tools = (
+                list(disallowed_tools) if disallowed_tools is not None else None
+            )
+
+        async def resume_approval_with_client(self, client, call_id, output, sess):
+            yield {"type": "result", "subtype": "success", "result": "approved"}
+
+        def parse_message(self, chunks):
+            return "approved"
+
+        def estimate_token_usage(self, prompt, completion, model=None):
+            return {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+
+    monkeypatch.setattr(
+        "src.routes.responses.usage_logger.log_turn_from_context",
+        AsyncMock(),
+    )
+
+    await _handle_function_call_output(
+        body,
+        resolved,
+        FakeBackend(),
+        session,
+        session.session_id,
+        "/tmp/ws/test",
+        {"call_id": "approval_1", "output": "accept"},
+    )
+
+    assert update_calls == [(session.client, None, ["Bash"])]
+    assert session.client.disallowed_tools == ["Bash"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -1818,7 +1818,12 @@ async def test_codex_client_closes_rpc_when_thread_start_fails(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_codex_client_restarts_shared_rpc_after_turn_error(monkeypatch):
-    """Transport failures close the shared app-server so the next request restarts it."""
+    """If turn/start fails on every attempt, the shared RPC is left closed so the next request restarts it.
+
+    With the conservative in-request retry path, a persistent transport failure
+    burns through both attempts and surfaces an error chunk; the dead shared
+    RPC must still be cleared so a *subsequent* request brings up a fresh one.
+    """
 
     class FailingTurnRpc(FakeRpc):
         def turn_start(self, thread_id, input_items, params):
@@ -1828,7 +1833,7 @@ async def test_codex_client_restarts_shared_rpc_after_turn_error(monkeypatch):
     created = []
 
     def fake_factory(**kwargs):
-        rpc = FailingTurnRpc() if not created else FakeRpc()
+        rpc = FailingTurnRpc()
         created.append(rpc)
         return rpc
 
@@ -1842,13 +1847,412 @@ async def test_codex_client_restarts_shared_rpc_after_turn_error(monkeypatch):
 
     chunks = [chunk async for chunk in backend.run_completion_with_client(client, "hi", session)]
 
-    assert chunks == [{"type": "error", "is_error": True, "error_message": "transport failed"}]
-    assert created[0].closed is True
+    # The user sees a final error chunk after retry exhausts.
+    assert chunks[-1] == {
+        "type": "error",
+        "is_error": True,
+        "error_message": "transport failed",
+    }
+    # Each failing RPC instance was closed.
+    for rpc in created:
+        assert rpc.closed is True
 
+    # A subsequent create_client constructs a fresh RPC (the dead shared one was cleared).
+    fresh_count_before = len(created)
     await backend.create_client(session=SimpleNamespace(session_id="gw-session-2"), model="gpt-5.5")
+    assert len(created) == fresh_count_before + 1
 
-    assert len(created) == 2
-    assert created[1].closed is False
+
+@pytest.mark.asyncio
+async def test_codex_client_retries_turn_start_once_after_rpc_transport_error_before_turn_is_accepted(
+    monkeypatch,
+):
+    """A transport error on turn/start (before any output is yielded) triggers exactly one retry.
+
+    Scenario:
+      1. First RPC accepts thread_start during create_client.
+      2. turn_start raises a transport error.
+      3. The first RPC is closed; a fresh RPC is started.
+      4. The new RPC restores the same thread via thread_resume, then turn_start
+         succeeds and the turn completes normally — the user sees a successful
+         result, not an error chunk.
+    """
+    from src.backends.codex.client import CodexAppServerError, CodexClient
+
+    rpcs = []
+
+    class FailingTurnStartRpc(FakeRpc):
+        def turn_start(self, thread_id, input_items, params):
+            self.turn_start_calls.append((thread_id, input_items, params))
+            raise CodexAppServerError("transport failed during turn/start")
+
+    def factory(**kwargs):
+        if not rpcs:
+            rpc = FailingTurnStartRpc()
+        else:
+            rpc = FakeRpc()
+            rpc.notifications = [
+                {
+                    "method": "turn/completed",
+                    "params": {
+                        "threadId": "thr_codex",
+                        "turnId": "turn_1",
+                        "turn": {"id": "turn_1", "status": "completed", "items": []},
+                    },
+                },
+            ]
+        rpcs.append(rpc)
+        return rpc
+
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", factory)
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(session=session, model="gpt-5.5")
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "hi", session)]
+
+    # Two RPCs were created total (initial + retry).
+    assert len(rpcs) == 2
+    # First RPC was closed when its turn_start failed.
+    assert rpcs[0].closed is True
+    # Second RPC re-established the same thread before retrying turn_start.
+    assert rpcs[1].thread_resume_calls
+    assert rpcs[1].thread_resume_calls[0][0] == "thr_codex"
+    assert len(rpcs[1].turn_start_calls) == 1
+    # The user-visible output is a normal result, not an error chunk.
+    assert not any(c.get("is_error") for c in chunks)
+    assert chunks[-1]["type"] == "result"
+
+
+@pytest.mark.asyncio
+async def test_codex_client_does_not_retry_after_partial_output(monkeypatch):
+    """Once any chunk has been yielded for a turn, errors no longer trigger a retry.
+
+    The first RPC accepts turn_start and emits one delta; the next read raises
+    a transport error. Because output was already sent to the user, the gateway
+    must surface an error chunk rather than silently re-running the turn (which
+    would risk duplicate side effects on the app-server side).
+    """
+    from src.backends.codex.client import CodexAppServerError, CodexClient
+
+    rpcs = []
+    consume_count = [0]
+
+    class FailingMidStreamRpc(FakeRpc):
+        def next_notification(self):
+            consume_count[0] += 1
+            if consume_count[0] == 1:
+                return {
+                    "method": "item/agentMessage/delta",
+                    "params": {
+                        "threadId": "thr_codex",
+                        "turnId": "turn_1",
+                        "itemId": "item_1",
+                        "delta": "partial",
+                    },
+                }
+            raise CodexAppServerError("transport failed mid-stream")
+
+    def factory(**kwargs):
+        if not rpcs:
+            rpc = FailingMidStreamRpc()
+        else:
+            # If we did retry, the second RPC would be used here.
+            rpc = FakeRpc()
+        rpcs.append(rpc)
+        return rpc
+
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", factory)
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(session=session, model="gpt-5.5")
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "hi", session)]
+
+    # No retry: only one RPC was ever created.
+    assert len(rpcs) == 1
+    # The partial delta was delivered, then an error chunk closes the turn.
+    assert any(c.get("type") == "stream_event" for c in chunks)
+    assert chunks[-1] == {
+        "type": "error",
+        "is_error": True,
+        "error_message": "transport failed mid-stream",
+    }
+
+
+@pytest.mark.asyncio
+async def test_codex_client_does_not_retry_when_turn_start_queued_notifications_before_failing(
+    monkeypatch,
+):
+    """If the app-server queued a notification for this turn before the transport
+    error, treat the turn as possibly accepted and skip retry to avoid duplicate
+    side effects on the app-server side.
+    """
+    from src.backends.codex.client import CodexAppServerError, CodexClient
+
+    rpcs = []
+
+    class QueuesThenFailsRpc(FakeRpc):
+        def __init__(self):
+            super().__init__()
+            self._pending_notifications: list = []
+
+        def turn_start(self, thread_id, input_items, params):
+            self.turn_start_calls.append((thread_id, input_items, params))
+            # Simulate the JSON-RPC client having buffered an inbound notification
+            # for this turn before the transport went down.
+            self._pending_notifications.append(
+                {
+                    "method": "item/started",
+                    "params": {
+                        "threadId": "thr_codex",
+                        "turnId": "turn_1",
+                        "item": {"type": "commandExecution", "id": "cmd_1"},
+                    },
+                }
+            )
+            raise CodexAppServerError("transport failed after queuing notification")
+
+    def factory(**kwargs):
+        rpc = QueuesThenFailsRpc()
+        rpcs.append(rpc)
+        return rpc
+
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", factory)
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(session=session, model="gpt-5.5")
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "hi", session)]
+
+    # Only the original RPC was used — no retry, because queuing implies the
+    # app-server may have already started executing the turn.
+    assert len(rpcs) == 1
+    assert chunks[-1]["type"] == "error"
+    assert chunks[-1]["is_error"] is True
+
+
+@pytest.mark.asyncio
+async def test_codex_client_thread_resume_failure_on_retry_surfaces_error(monkeypatch):
+    """thread_resume failing on the retry attempt is treated as the retry failure."""
+    from src.backends.codex.client import CodexAppServerError, CodexClient
+
+    rpcs = []
+
+    class FailingRpc(FakeRpc):
+        def __init__(self, fail_turn_start=False, fail_resume=False):
+            super().__init__()
+            self._fail_turn_start = fail_turn_start
+            self._fail_resume = fail_resume
+
+        def turn_start(self, thread_id, input_items, params):
+            self.turn_start_calls.append((thread_id, input_items, params))
+            if self._fail_turn_start:
+                raise CodexAppServerError("turn/start transport failed")
+            return {"turn": {"id": "turn_1", "status": "inProgress"}}
+
+        def thread_resume(self, thread_id, params):
+            self.thread_resume_calls.append((thread_id, params))
+            if self._fail_resume:
+                raise CodexAppServerError("thread/resume transport failed")
+            return {"thread": {"id": thread_id}}
+
+    def factory(**kwargs):
+        if not rpcs:
+            # initial RPC: thread_start fine (FakeRpc default), turn/start blows up.
+            rpc = FailingRpc(fail_turn_start=True)
+        else:
+            # retry RPC: thread/resume also blows up before we even reach turn/start.
+            rpc = FailingRpc(fail_resume=True)
+        rpcs.append(rpc)
+        return rpc
+
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", factory)
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(session=session, model="gpt-5.5")
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "hi", session)]
+
+    assert len(rpcs) == 2
+    assert rpcs[1].thread_resume_calls  # we tried to recover, but resume blew up
+    assert chunks[-1]["type"] == "error"
+    assert "thread/resume transport failed" in chunks[-1]["error_message"]
+
+
+@pytest.mark.asyncio
+async def test_codex_client_session_rpc_field_is_refreshed_after_successful_retry(monkeypatch):
+    """``CodexSessionClient.rpc`` points at the live RPC after retry recovery."""
+    from src.backends.codex.client import CodexAppServerError, CodexClient
+
+    rpcs = []
+
+    class FailingFirstTurnRpc(FakeRpc):
+        def turn_start(self, thread_id, input_items, params):
+            self.turn_start_calls.append((thread_id, input_items, params))
+            raise CodexAppServerError("first attempt failed")
+
+    def factory(**kwargs):
+        if not rpcs:
+            rpc = FailingFirstTurnRpc()
+        else:
+            rpc = FakeRpc()
+            rpc.notifications = [
+                {
+                    "method": "turn/completed",
+                    "params": {
+                        "threadId": "thr_codex",
+                        "turnId": "turn_1",
+                        "turn": {"id": "turn_1", "status": "completed", "items": []},
+                    },
+                }
+            ]
+        rpcs.append(rpc)
+        return rpc
+
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", factory)
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(session=session, model="gpt-5.5")
+    assert client.rpc is rpcs[0]
+
+    [chunk async for chunk in backend.run_completion_with_client(client, "hi", session)]
+
+    # After successful retry, the session client should track the live RPC.
+    assert client.rpc is rpcs[1]
+
+
+@pytest.mark.asyncio
+async def test_codex_resume_approval_fails_fast_through_full_approval_flow(monkeypatch):
+    """End-to-end variant: the pending RPC field is populated by the real
+    ``_store_pending_approval`` path (not test-set), then a transport reset
+    swaps the shared RPC. resume_approval must surface a transport-lost error.
+    """
+    from src.backends.codex.client import CodexClient
+
+    rpcs = []
+
+    def factory(**kwargs):
+        rpc = FakeRpc()
+        rpcs.append(rpc)
+        return rpc
+
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", factory)
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(session=session, model="gpt-5.5")
+
+    # Run a turn whose only notification is a command approval; this exercises
+    # the real _store_pending_approval path (including pending_approval_rpc).
+    rpcs[0].notifications = _command_approval_notifications()
+    [chunk async for chunk in backend.run_completion_with_client(client, "test", session)]
+    assert client.pending_approval_rpc is rpcs[0]
+    assert session.pending_tool_call is not None
+
+    # Simulate a transport reset between approval and user response.
+    await backend._close_rpc_locked()
+
+    chunks = [
+        chunk
+        async for chunk in backend.resume_approval_with_client(
+            client, "approval_1", "accept", session
+        )
+    ]
+
+    assert chunks
+    assert chunks[-1]["type"] == "error"
+    assert chunks[-1]["is_error"] is True
+    assert "transport" in chunks[-1]["error_message"].lower()
+    # Pending state is cleared so subsequent operations don't see stale data.
+    assert client.pending_approval_rpc is None
+    assert client.pending_approval_request_id is None
+
+
+@pytest.mark.asyncio
+async def test_codex_resume_approval_fails_fast_when_pending_rpc_is_gone(monkeypatch):
+    """If the RPC that received the approval request is gone, fail fast with a clear error.
+
+    A transport-level reset between an approval being surfaced and the user's
+    response means the new RPC has no record of the pending approval; trying
+    to ``rpc.respond`` would either silently drop the message or hit a server
+    that has no idea what we're talking about.
+    """
+    from src.backends.codex.client import CodexClient
+
+    fake_rpc_a = FakeRpc()
+    fake_rpc_b = FakeRpc()
+    rpcs = [fake_rpc_a, fake_rpc_b]
+
+    def factory(**kwargs):
+        # Pop in order: A for create_client, B for the post-failure recovery.
+        if rpcs:
+            return rpcs.pop(0)
+        return FakeRpc()
+
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", factory)
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(session=session, model="gpt-5.5")
+    # Pretend an approval was surfaced on the original RPC.
+    client.pending_approval_request_id = "approval_1"
+    client.pending_approval_method = "item/commandExecution/requestApproval"
+    client.pending_approval_turn_id = "turn_1"
+    client.pending_approval_params = {"turnId": "turn_1"}
+    client.pending_approval_rpc = fake_rpc_a
+
+    # Simulate transport reset between approval and user response: shared RPC
+    # was closed and replaced by ``fake_rpc_b``.
+    await backend._close_rpc_locked()
+
+    chunks = [
+        chunk
+        async for chunk in backend.resume_approval_with_client(
+            client, "approval_1", "accept", session
+        )
+    ]
+
+    assert chunks
+    assert chunks[-1]["type"] == "error"
+    assert chunks[-1]["is_error"] is True
+    assert "transport" in chunks[-1]["error_message"].lower() or "lost" in chunks[-1]["error_message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_codex_client_does_not_retry_when_retry_also_fails(monkeypatch):
+    """If the retry also raises, the gateway gives up and surfaces an error."""
+    from src.backends.codex.client import CodexAppServerError, CodexClient
+
+    rpcs = []
+
+    class FailingTurnStartRpc(FakeRpc):
+        def turn_start(self, thread_id, input_items, params):
+            self.turn_start_calls.append((thread_id, input_items, params))
+            raise CodexAppServerError("transport failed again")
+
+    def factory(**kwargs):
+        rpc = FailingTurnStartRpc()
+        rpcs.append(rpc)
+        return rpc
+
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", factory)
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(session=session, model="gpt-5.5")
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "hi", session)]
+
+    # Initial RPC + one retry attempt = 2 RPCs created.
+    assert len(rpcs) == 2
+    assert chunks[-1]["type"] == "error"
+    assert chunks[-1]["is_error"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -228,7 +228,8 @@ async def test_codex_client_starts_thread_and_converts_completed_turn(monkeypatc
         },
     }
     assert chunks[-2]["content"] == [{"type": "text", "text": "Hello from Codex"}]
-    assert chunks[-2]["usage"] == {"input_tokens": 3, "output_tokens": 4}
+    # outputTokens=4 + reasoningOutputTokens=1; reasoning tokens are rolled into output.
+    assert chunks[-2]["usage"] == {"input_tokens": 3, "output_tokens": 5}
     assert chunks[-1]["type"] == "result"
     assert chunks[-1]["result"] == "Hello from Codex"
     assert backend.parse_message(chunks) == "Hello from Codex"
@@ -2248,6 +2249,51 @@ def test_codex_tool_result_from_item_returns_none_for_invalid_inputs():
     assert client._tool_result_from_item({"type": "agentMessage", "id": "x"}) is None
     assert client._tool_result_from_item({"type": "commandExecution"}) is None
     assert client._tool_result_from_item({"type": "commandExecution", "id": 123}) is None
+
+
+def test_codex_extract_usage_includes_reasoning_output_tokens():
+    """Reasoning output tokens are part of the model's output and must be reported."""
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    usage = backend._extract_usage(
+        {
+            "last": {
+                "inputTokens": 10,
+                "cachedInputTokens": 2,
+                "outputTokens": 5,
+                "reasoningOutputTokens": 7,
+            }
+        }
+    )
+    assert usage == {"input_tokens": 12, "output_tokens": 12}
+
+
+def test_codex_extract_usage_handles_missing_reasoning_tokens():
+    """Notifications without reasoningOutputTokens fall back to outputTokens only."""
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    usage = backend._extract_usage(
+        {"last": {"inputTokens": 3, "outputTokens": 4}}
+    )
+    assert usage == {"input_tokens": 3, "output_tokens": 4}
+
+
+def test_codex_extract_usage_total_matches_total_tokens():
+    """Reported (input + output) equals notification totalTokens, so totals reconcile."""
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    last = {
+        "inputTokens": 6,
+        "cachedInputTokens": 4,
+        "outputTokens": 8,
+        "reasoningOutputTokens": 3,
+        "totalTokens": 21,
+    }
+    usage = backend._extract_usage({"last": last})
+    assert usage["input_tokens"] + usage["output_tokens"] == last["totalTokens"]
 
 
 def test_codex_extract_usage_returns_none_for_invalid_inputs():

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -794,6 +794,30 @@ async def test_codex_allowed_tools_whitelist_lets_listed_approval_bubble(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_codex_allowed_tools_global_glob_does_not_bypass_whitelist(monkeypatch):
+    """Only MCP policy names support glob matching; '*' must not allow every tool."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = _command_approval_notifications()
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        allowed_tools=["*"],
+    )
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "test", session)]
+
+    assert fake_rpc.respond_calls == [("approval_1", {"decision": "decline"})]
+    assert _collect_approval_tool_uses(chunks) == []
+    assert session.pending_tool_call is None
+
+
+@pytest.mark.asyncio
 async def test_codex_permission_mode_bypass_overrides_thread_approval_policy(monkeypatch):
     """permission_mode='bypassPermissions' sets Codex approvalPolicy='never' at thread start."""
     fake_rpc = FakeRpc()
@@ -808,7 +832,9 @@ async def test_codex_permission_mode_bypass_overrides_thread_approval_policy(mon
         }
     ]
     monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
-    monkeypatch.setenv("CODEX_APPROVAL_POLICY", "on-request")  # env says ask; permission_mode overrides
+    monkeypatch.setenv(
+        "CODEX_APPROVAL_POLICY", "on-request"
+    )  # env says ask; permission_mode overrides
 
     from src.backends.codex.client import CodexClient
 
@@ -1160,7 +1186,12 @@ async def test_codex_global_disallowed_tools_merges_with_per_request(monkeypatch
     assert _collect_approval_tool_uses(chunks) == []
 
 
-def _mcp_tool_call_approval_notifications(*, request_id: str = "approval_1"):
+def _mcp_tool_call_approval_notifications(
+    *,
+    request_id: str = "approval_1",
+    server_label: str = "fs",
+    tool_name: str = "read_file",
+):
     return [
         {
             "id": request_id,
@@ -1169,8 +1200,8 @@ def _mcp_tool_call_approval_notifications(*, request_id: str = "approval_1"):
                 "threadId": "thr_codex",
                 "turnId": "turn_1",
                 "itemId": "mcp_1",
-                "serverLabel": "fs",
-                "toolName": "read_file",
+                "serverLabel": server_label,
+                "toolName": tool_name,
                 "availableDecisions": ["accept", "decline"],
             },
         },
@@ -1234,6 +1265,30 @@ async def test_codex_disallowed_tools_blocks_mcp_tool_call_approval(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_codex_disallowed_tools_blocks_mcp_exact_tool_pattern(monkeypatch):
+    """Claude-style MCP tool names must block matching Codex MCP approvals."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = _mcp_tool_call_approval_notifications()
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        disallowed_tools=["mcp__fs__read_file"],
+    )
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "test", session)]
+
+    assert fake_rpc.respond_calls == [("approval_1", {"decision": "decline"})]
+    assert _collect_approval_tool_uses(chunks) == []
+    assert session.pending_tool_call is None
+
+
+@pytest.mark.asyncio
 async def test_codex_disallowed_tools_blocks_dynamic_tool_call_approval(monkeypatch):
     """disallowed_tools containing 'dynamicToolCall' auto-denies dynamic tool approvals."""
     fake_rpc = FakeRpc()
@@ -1277,6 +1332,53 @@ async def test_codex_allowed_tools_whitelist_blocks_mcp_when_not_listed(monkeypa
 
     assert fake_rpc.respond_calls == [("approval_1", {"decision": "decline"})]
     assert _collect_approval_tool_uses(chunks) == []
+
+
+@pytest.mark.asyncio
+async def test_codex_allowed_tools_mcp_server_pattern_allows_matching_approval(monkeypatch):
+    """Claude-style MCP server wildcards should allow matching Codex MCP approvals."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = _mcp_tool_call_approval_notifications()
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        allowed_tools=["mcp__fs__*"],
+    )
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "test", session)]
+
+    assert fake_rpc.respond_calls == []
+    assert len(_collect_approval_tool_uses(chunks)) == 1
+    assert session.pending_tool_call is not None
+
+
+@pytest.mark.asyncio
+async def test_codex_allowed_tools_mcp_pattern_normalizes_hyphenated_server(monkeypatch):
+    """MCP patterns use Claude's hyphen-to-underscore server-name convention."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = _mcp_tool_call_approval_notifications(server_label="my-server")
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        allowed_tools=["mcp__my_server__*"],
+    )
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "test", session)]
+
+    assert fake_rpc.respond_calls == []
+    assert len(_collect_approval_tool_uses(chunks)) == 1
 
 
 @pytest.mark.asyncio
@@ -2221,7 +2323,10 @@ async def test_codex_resume_approval_fails_fast_when_pending_rpc_is_gone(monkeyp
     assert chunks
     assert chunks[-1]["type"] == "error"
     assert chunks[-1]["is_error"] is True
-    assert "transport" in chunks[-1]["error_message"].lower() or "lost" in chunks[-1]["error_message"].lower()
+    assert (
+        "transport" in chunks[-1]["error_message"].lower()
+        or "lost" in chunks[-1]["error_message"].lower()
+    )
 
 
 @pytest.mark.asyncio
@@ -3021,9 +3126,7 @@ def test_codex_approval_question_covers_all_kinds():
     assert client._approval_question("command", {"command": "ls"}) == (
         "Codex requests approval to run command: ls"
     )
-    assert client._approval_question("command", {}) == (
-        "Codex requests approval to run a command."
-    )
+    assert client._approval_question("command", {}) == ("Codex requests approval to run a command.")
     assert client._approval_question("command", {"command": ""}) == (
         "Codex requests approval to run a command."
     )
@@ -3061,8 +3164,7 @@ def test_codex_approval_decision_label_handles_dict_decisions():
         }
     }
     assert (
-        client._approval_decision_label(full)
-        == "applyNetworkPolicyAmendment:allow:api.example.com"
+        client._approval_decision_label(full) == "applyNetworkPolicyAmendment:allow:api.example.com"
     )
 
     # applyNetworkPolicyAmendment missing host falls back to bare name.
@@ -3261,9 +3363,7 @@ def test_codex_extract_usage_handles_missing_reasoning_tokens():
     from src.backends.codex.client import CodexClient
 
     backend = CodexClient()
-    usage = backend._extract_usage(
-        {"last": {"inputTokens": 3, "outputTokens": 4}}
-    )
+    usage = backend._extract_usage({"last": {"inputTokens": 3, "outputTokens": 4}})
     assert usage == {"input_tokens": 3, "output_tokens": 4}
 
 
@@ -3421,9 +3521,7 @@ def test_codex_metadata_env_filters_by_allowlist(monkeypatch):
     from src import constants as constants_module
     from src.backends.codex.client import CodexClient
 
-    monkeypatch.setattr(
-        constants_module, "METADATA_ENV_ALLOWLIST", frozenset({"ALLOWED_KEY"})
-    )
+    monkeypatch.setattr(constants_module, "METADATA_ENV_ALLOWLIST", frozenset({"ALLOWED_KEY"}))
 
     client = CodexClient()
 
@@ -3726,9 +3824,7 @@ async def test_codex_run_completion_yields_error_when_turn_id_missing(monkeypatc
     session = SimpleNamespace(session_id="gw")
     client = await backend.create_client(session=session)
 
-    chunks = [
-        chunk async for chunk in backend.run_completion_with_client(client, "hi", session)
-    ]
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "hi", session)]
 
     assert len(chunks) == 1
     assert chunks[0]["type"] == "error"

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -980,6 +980,123 @@ async def test_codex_no_tool_policy_keeps_never_approval_policy(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_codex_accept_edits_auto_accepts_file_change_approval(monkeypatch):
+    """permission_mode='acceptEdits' auto-accepts fileChange approvals (Claude parity)."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = _file_change_approval_notifications()
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        permission_mode="acceptEdits",
+    )
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "test", session)]
+
+    assert fake_rpc.respond_calls == [("approval_1", {"decision": "accept"})]
+    assert _collect_approval_tool_uses(chunks) == []
+    assert session.pending_tool_call is None
+
+
+@pytest.mark.asyncio
+async def test_codex_accept_edits_still_bubbles_command_approval(monkeypatch):
+    """acceptEdits only auto-accepts fileChange; commandExecution still asks the user."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = _command_approval_notifications()
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        permission_mode="acceptEdits",
+    )
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "test", session)]
+
+    # No auto-respond; the command approval bubbles to the user as a tool_use.
+    assert fake_rpc.respond_calls == []
+    approvals = _collect_approval_tool_uses(chunks)
+    assert len(approvals) == 1
+    assert session.pending_tool_call is not None
+
+
+@pytest.mark.asyncio
+async def test_codex_accept_edits_respects_disallowed_file_change(monkeypatch):
+    """Disallowing fileChange takes precedence over acceptEdits (deny > accept)."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = _file_change_approval_notifications()
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        permission_mode="acceptEdits",
+        disallowed_tools=["fileChange"],
+    )
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "test", session)]
+
+    # Disallowed wins; reject even though acceptEdits would normally accept.
+    assert fake_rpc.respond_calls == [("approval_1", {"decision": "decline"})]
+    assert _collect_approval_tool_uses(chunks) == []
+
+
+@pytest.mark.asyncio
+async def test_codex_accept_edits_does_not_accept_permissions_approval(monkeypatch):
+    """acceptEdits is fileChange-specific; permissions approvals still bubble."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = [
+        {
+            "id": "approval_1",
+            "method": "item/permissions/requestApproval",
+            "params": {
+                "threadId": "thr_codex",
+                "turnId": "turn_1",
+                "itemId": "perm_1",
+                "permissions": {"fileSystem": {"read": ["/repo"]}},
+            },
+        },
+        {
+            "method": "turn/completed",
+            "params": {
+                "threadId": "thr_codex",
+                "turnId": "turn_1",
+                "turn": {"id": "turn_1", "status": "completed", "items": []},
+            },
+        },
+    ]
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        permission_mode="acceptEdits",
+    )
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "test", session)]
+
+    assert fake_rpc.respond_calls == []
+    assert len(_collect_approval_tool_uses(chunks)) == 1
+
+
+@pytest.mark.asyncio
 async def test_codex_no_permission_mode_falls_back_to_env(monkeypatch):
     """When permission_mode is None, approvalPolicy still comes from CODEX_APPROVAL_POLICY env."""
     fake_rpc = FakeRpc()
@@ -1206,6 +1323,142 @@ async def test_codex_empty_allowed_tools_forces_approval_policy_off_never(monkey
 
     assert fake_rpc.thread_start_calls
     assert fake_rpc.thread_start_calls[0]["approvalPolicy"] != "never"
+
+
+@pytest.mark.asyncio
+async def test_codex_permission_mode_update_takes_effect_on_next_turn(monkeypatch):
+    """Updating permission_mode mid-session changes the next turn's approval semantics."""
+    fake_rpc = FakeRpc()
+    # First call: no notifications needed (we just construct the client).
+    # Second call: fileChange approval that should be auto-accepted after switch.
+    fake_rpc.notifications = _file_change_approval_notifications()
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        permission_mode="default",  # initially: bubble approvals
+    )
+
+    backend.update_request_policy(client, permission_mode="acceptEdits")
+    assert client.permission_mode == "acceptEdits"
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "test", session)]
+
+    assert fake_rpc.respond_calls == [("approval_1", {"decision": "accept"})]
+    assert _collect_approval_tool_uses(chunks) == []
+
+
+@pytest.mark.asyncio
+async def test_codex_update_request_policy_replaces_permission_mode(monkeypatch):
+    """update_request_policy refreshes permission_mode so continuation requests can change it."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = []
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session")
+    client = await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        permission_mode="default",
+    )
+    assert client.permission_mode == "default"
+
+    backend.update_request_policy(client, permission_mode="acceptEdits")
+    assert client.permission_mode == "acceptEdits"
+
+
+@pytest.mark.asyncio
+async def test_codex_update_request_policy_preserves_permission_mode_when_omitted(monkeypatch):
+    """Omitting permission_mode in update_request_policy keeps the existing value."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = []
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session")
+    client = await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        permission_mode="acceptEdits",
+    )
+
+    backend.update_request_policy(client, disallowed_tools=["Bash"])
+    assert client.permission_mode == "acceptEdits"
+
+
+@pytest.mark.asyncio
+async def test_codex_unknown_permission_mode_uses_safe_on_request(monkeypatch, caplog):
+    """Unknown permission_mode strings fall back to a safe ``on-request``, not env=never.
+
+    Falling back to env=never would let a typo silently disable approval-time
+    enforcement. Use a safe explicit default instead, and warn so operators see
+    the malformed input.
+    """
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = []
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+    monkeypatch.setenv("CODEX_APPROVAL_POLICY", "never")  # operator default
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    with caplog.at_level("WARNING", logger="src.backends.codex.client"):
+        await backend.create_client(
+            session=session,
+            model="gpt-5.5",
+            permission_mode="definitely-invalid-mode",
+        )
+
+    assert fake_rpc.thread_start_calls
+    assert fake_rpc.thread_start_calls[0]["approvalPolicy"] == "on-request"
+    assert "unknown permission_mode" in caplog.text.lower()
+    assert "definitely-invalid-mode" in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("expected_method", "notifications_fn"),
+    [
+        ("item/mcpToolCall/requestApproval", _mcp_tool_call_approval_notifications),
+        ("item/dynamicToolCall/requestApproval", _dynamic_tool_call_approval_notifications),
+    ],
+)
+async def test_codex_accept_edits_does_not_accept_non_file_tool_calls(
+    monkeypatch, expected_method, notifications_fn
+):
+    """acceptEdits is fileChange-only; mcpToolCall and dynamicToolCall still bubble."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = notifications_fn()
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        permission_mode="acceptEdits",
+    )
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, "test", session)]
+
+    assert fake_rpc.respond_calls == []
+    approvals = _collect_approval_tool_uses(chunks)
+    assert len(approvals) == 1
+    # Anchor the regression: the bubbled tool_use must come from the expected method.
+    assert approvals[0]["metadata"]["codex_approval_method"] == expected_method
 
 
 @pytest.mark.asyncio
@@ -1858,12 +2111,21 @@ async def test_codex_function_call_output_refreshes_session_tool_policy(monkeypa
     class FakeBackend:
         name = "codex"
 
-        def update_request_policy(self, client, *, allowed_tools=None, disallowed_tools=None):
-            update_calls.append((client, allowed_tools, disallowed_tools))
+        def update_request_policy(
+            self,
+            client,
+            *,
+            allowed_tools=None,
+            disallowed_tools=None,
+            permission_mode=None,
+        ):
+            update_calls.append((client, allowed_tools, disallowed_tools, permission_mode))
             client.allowed_tools = list(allowed_tools) if allowed_tools is not None else None
             client.disallowed_tools = (
                 list(disallowed_tools) if disallowed_tools is not None else None
             )
+            if permission_mode is not None:
+                client.permission_mode = permission_mode
 
         async def resume_approval_with_client(self, client, call_id, output, sess):
             yield {"type": "result", "subtype": "success", "result": "approved"}
@@ -1889,7 +2151,7 @@ async def test_codex_function_call_output_refreshes_session_tool_policy(monkeypa
         {"call_id": "approval_1", "output": "accept"},
     )
 
-    assert update_calls == [(session.client, None, ["Bash"])]
+    assert update_calls == [(session.client, None, ["Bash"], None)]
     assert session.client.disallowed_tools == ["Bash"]
 
 

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -2464,6 +2464,115 @@ async def test_codex_thread_resume_includes_mcp_servers(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_codex_turn_preserves_multimodal_items(monkeypatch):
+    """Codex turn/start carries a multi-item payload (text + image) verbatim."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = [
+        {
+            "method": "turn/completed",
+            "params": {
+                "threadId": "thr_codex",
+                "turnId": "turn_1",
+                "turn": {"id": "turn_1", "status": "completed", "items": []},
+            },
+        }
+    ]
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(session=session, model="gpt-5.5")
+
+    items = [
+        {"type": "text", "text": "look at this"},
+        {"type": "image", "url": "https://example.com/foo.png"},
+        {"type": "text", "text": "any thoughts?"},
+    ]
+
+    [chunk async for chunk in backend.run_completion_with_client(client, items, session)]
+
+    assert fake_rpc.turn_start_calls
+    _, sent_items, _ = fake_rpc.turn_start_calls[0]
+    assert sent_items == items
+
+
+@pytest.mark.asyncio
+async def test_codex_turn_wraps_string_prompt_into_text_item(monkeypatch):
+    """Plain-string prompts stay compatible: they're wrapped into a single text item."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = [
+        {
+            "method": "turn/completed",
+            "params": {
+                "threadId": "thr_codex",
+                "turnId": "turn_1",
+                "turn": {"id": "turn_1", "status": "completed", "items": []},
+            },
+        }
+    ]
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(session=session, model="gpt-5.5")
+
+    [chunk async for chunk in backend.run_completion_with_client(client, "hello there", session)]
+
+    _, sent_items, _ = fake_rpc.turn_start_calls[0]
+    assert sent_items == [{"type": "text", "text": "hello there"}]
+
+
+@pytest.mark.asyncio
+async def test_codex_turn_rejects_empty_input_list(monkeypatch):
+    """Empty input list is rejected — Codex won't accept a turn with no content."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = []
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(session=session, model="gpt-5.5")
+
+    chunks = [chunk async for chunk in backend.run_completion_with_client(client, [], session)]
+    assert fake_rpc.turn_start_calls == []
+    assert chunks[-1]["type"] == "error"
+    assert chunks[-1]["is_error"] is True
+
+
+@pytest.mark.asyncio
+async def test_codex_turn_rejects_invalid_input_item_shape(monkeypatch):
+    """Non-text/non-dict items in the input list surface a clear error."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = []
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(session=session, model="gpt-5.5")
+
+    bad_items = [
+        {"type": "text", "text": "ok"},
+        "this should be a dict, not a string",
+    ]
+    chunks = [
+        chunk async for chunk in backend.run_completion_with_client(client, bad_items, session)
+    ]
+    # No turn/start was reached for an invalid payload.
+    assert fake_rpc.turn_start_calls == []
+    assert chunks
+    assert chunks[-1]["type"] == "error"
+    assert chunks[-1]["is_error"] is True
+
+
+@pytest.mark.asyncio
 async def test_codex_client_filters_metadata_env(monkeypatch):
     """Only allowlisted metadata keys are passed to the Codex subprocess env."""
     fake_rpc = FakeRpc()

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -2256,6 +2256,131 @@ async def test_codex_client_does_not_retry_when_retry_also_fails(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_codex_client_forwards_response_model_params_to_turn_start(monkeypatch):
+    """temperature and max_output_tokens flow into the Codex turn/start payload."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = [
+        {
+            "method": "turn/completed",
+            "params": {
+                "threadId": "thr_codex",
+                "turnId": "turn_1",
+                "turn": {"id": "turn_1", "status": "completed", "items": []},
+            },
+        }
+    ]
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        model_params={"temperature": 0.3, "max_output_tokens": 1024},
+    )
+
+    [chunk async for chunk in backend.run_completion_with_client(client, "hi", session)]
+
+    assert fake_rpc.turn_start_calls
+    _, _, turn_params = fake_rpc.turn_start_calls[0]
+    assert turn_params.get("temperature") == 0.3
+    assert turn_params.get("maxOutputTokens") == 1024
+
+
+@pytest.mark.asyncio
+async def test_codex_client_omits_model_params_when_unset(monkeypatch):
+    """When no model_params are provided, turn/start payload stays minimal (no defaults injected)."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = [
+        {
+            "method": "turn/completed",
+            "params": {
+                "threadId": "thr_codex",
+                "turnId": "turn_1",
+                "turn": {"id": "turn_1", "status": "completed", "items": []},
+            },
+        }
+    ]
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(session=session, model="gpt-5.5")
+    [chunk async for chunk in backend.run_completion_with_client(client, "hi", session)]
+
+    _, _, turn_params = fake_rpc.turn_start_calls[0]
+    assert "temperature" not in turn_params
+    assert "maxOutputTokens" not in turn_params
+
+
+@pytest.mark.asyncio
+async def test_codex_client_translates_legacy_max_tokens_alias(monkeypatch):
+    """The OpenAI 'max_tokens' alias maps to Codex maxOutputTokens for compatibility."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = [
+        {
+            "method": "turn/completed",
+            "params": {
+                "threadId": "thr_codex",
+                "turnId": "turn_1",
+                "turn": {"id": "turn_1", "status": "completed", "items": []},
+            },
+        }
+    ]
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        model_params={"max_tokens": 512},
+    )
+    [chunk async for chunk in backend.run_completion_with_client(client, "hi", session)]
+
+    _, _, turn_params = fake_rpc.turn_start_calls[0]
+    assert turn_params.get("maxOutputTokens") == 512
+
+
+@pytest.mark.asyncio
+async def test_codex_client_drops_none_model_param_values(monkeypatch):
+    """None values in model_params are skipped (so Responses bodies with unset fields are safe)."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = [
+        {
+            "method": "turn/completed",
+            "params": {
+                "threadId": "thr_codex",
+                "turnId": "turn_1",
+                "turn": {"id": "turn_1", "status": "completed", "items": []},
+            },
+        }
+    ]
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    client = await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        model_params={"temperature": None, "max_output_tokens": 100},
+    )
+    [chunk async for chunk in backend.run_completion_with_client(client, "hi", session)]
+
+    _, _, turn_params = fake_rpc.turn_start_calls[0]
+    assert "temperature" not in turn_params
+    assert turn_params.get("maxOutputTokens") == 100
+
+
+@pytest.mark.asyncio
 async def test_codex_client_filters_metadata_env(monkeypatch):
     """Only allowlisted metadata keys are passed to the Codex subprocess env."""
     fake_rpc = FakeRpc()
@@ -2522,12 +2647,16 @@ async def test_codex_function_call_output_refreshes_session_tool_policy(monkeypa
             allowed_tools=None,
             disallowed_tools=None,
             permission_mode=None,
+            model_params=None,
         ):
-            update_calls.append((client, allowed_tools, disallowed_tools, permission_mode))
+            update_calls.append(
+                (client, allowed_tools, disallowed_tools, permission_mode, model_params)
+            )
             client.allowed_tools = list(allowed_tools) if allowed_tools is not None else None
             client.disallowed_tools = (
                 list(disallowed_tools) if disallowed_tools is not None else None
             )
+            client.model_params = dict(model_params) if model_params else None
             if permission_mode is not None:
                 client.permission_mode = permission_mode
 
@@ -2555,7 +2684,7 @@ async def test_codex_function_call_output_refreshes_session_tool_policy(monkeypa
         {"call_id": "approval_1", "output": "accept"},
     )
 
-    assert update_calls == [(session.client, None, ["Bash"], None)]
+    assert update_calls == [(session.client, None, ["Bash"], None, None)]
     assert session.client.disallowed_tools == ["Bash"]
 
 

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -2381,6 +2381,89 @@ async def test_codex_client_drops_none_model_param_values(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_codex_create_client_forwards_mcp_servers_to_thread_params(monkeypatch):
+    """mcp_servers passed to create_client lands in the Codex thread/start payload."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = []
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    mcp = {
+        "fs": {"type": "stdio", "command": "fs-server", "args": []},
+        "web": {"type": "http", "url": "http://localhost:9000"},
+    }
+    await backend.create_client(
+        session=session,
+        model="gpt-5.5",
+        mcp_servers=mcp,
+    )
+
+    assert fake_rpc.thread_start_calls
+    sent_params = fake_rpc.thread_start_calls[0]
+    assert sent_params.get("mcpServers") == mcp
+
+
+@pytest.mark.asyncio
+async def test_codex_create_client_omits_mcp_servers_when_unset(monkeypatch):
+    """No mcp_servers -> no mcpServers key in the payload (backend defaults stand)."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = []
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    await backend.create_client(session=session, model="gpt-5.5")
+
+    assert fake_rpc.thread_start_calls
+    assert "mcpServers" not in fake_rpc.thread_start_calls[0]
+
+
+@pytest.mark.asyncio
+async def test_codex_create_client_omits_mcp_servers_when_empty_dict(monkeypatch):
+    """An empty dict is treated as "no servers" and the key is omitted."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = []
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(session_id="gw-session", pending_tool_call=None)
+    await backend.create_client(session=session, model="gpt-5.5", mcp_servers={})
+
+    assert fake_rpc.thread_start_calls
+    assert "mcpServers" not in fake_rpc.thread_start_calls[0]
+
+
+@pytest.mark.asyncio
+async def test_codex_thread_resume_includes_mcp_servers(monkeypatch):
+    """Resuming a thread also re-asserts the mcp_servers config (so reconnects don't lose it)."""
+    fake_rpc = FakeRpc()
+    fake_rpc.notifications = []
+    monkeypatch.setattr("src.backends.codex.client.CodexJsonRpcClient", lambda **kwargs: fake_rpc)
+
+    from src.backends.codex.client import CodexClient
+
+    backend = CodexClient()
+    session = SimpleNamespace(
+        session_id="gw-session",
+        pending_tool_call=None,
+        codex_thread_id="thr_existing",
+    )
+    mcp = {"fs": {"type": "stdio", "command": "fs-server"}}
+    await backend.create_client(session=session, model="gpt-5.5", mcp_servers=mcp)
+
+    assert fake_rpc.thread_resume_calls
+    _, resume_params = fake_rpc.thread_resume_calls[0]
+    assert resume_params.get("mcpServers") == mcp
+
+
+@pytest.mark.asyncio
 async def test_codex_client_filters_metadata_env(monkeypatch):
     """Only allowlisted metadata keys are passed to the Codex subprocess env."""
     fake_rpc = FakeRpc()

--- a/tests/test_main_api_unit.py
+++ b/tests/test_main_api_unit.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
+import pytest
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
@@ -1042,6 +1043,315 @@ def test_opencode_function_call_output_rejects_unknown_resume_kind(isolated_sess
 
     assert response.status_code == 400
     assert "Unsupported OpenCode resume kind" in response.json()["error"]["message"]
+
+
+def test_claude_previous_response_id_refreshes_permission_mode(isolated_session_manager):
+    """A Claude continuation with new permission_mode applies via update_request_policy."""
+    session_id = str(uuid.uuid4())
+    session = isolated_session_manager.get_or_create_session(session_id)
+    session.backend = "claude"
+    session.turn_counter = 1
+    session.client = object()
+
+    update_calls = []
+
+    async def fake_update_request_policy(
+        client,
+        *,
+        allowed_tools=None,
+        disallowed_tools=None,
+        permission_mode=None,
+        model_params=None,
+    ):
+        update_calls.append(
+            {
+                "client": client,
+                "allowed_tools": allowed_tools,
+                "disallowed_tools": disallowed_tools,
+                "permission_mode": permission_mode,
+                "model_params": model_params,
+            }
+        )
+
+    async def fake_run_with_client(client, prompt, session):
+        yield {"subtype": "success", "result": "continued"}
+
+    with (
+        client_context() as (client, mock_cli),
+        patch.object(main, "get_mcp_servers", return_value={}),
+        patch.object(responses_module, "get_mcp_servers", return_value={}),
+    ):
+        mock_cli.update_request_policy = fake_update_request_policy
+        mock_cli.run_completion_with_client = fake_run_with_client
+        mock_cli.parse_message.return_value = "continued"
+
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": DEFAULT_MODEL,
+                "input": "follow up",
+                "previous_response_id": responses_module._make_response_id(session_id, 1),
+                "permission_mode": "acceptEdits",
+            },
+        )
+
+    assert response.status_code == 200
+    assert update_calls
+    call = update_calls[0]
+    assert call["client"] is session.client
+    assert call["permission_mode"] == "acceptEdits"
+    # No tool list change requested -> backend sees None and is happy.
+    assert call["allowed_tools"] is None
+    assert call["disallowed_tools"] is None
+
+
+def test_claude_continuation_rejects_tool_list_change_with_400(isolated_session_manager):
+    """Claude can't apply mid-session tool list changes; reject with 400 (no silent drop)."""
+    from src.backends.claude.client import UnsupportedContinuationPolicy
+
+    session_id = str(uuid.uuid4())
+    session = isolated_session_manager.get_or_create_session(session_id)
+    session.backend = "claude"
+    session.turn_counter = 1
+    session.client = object()
+
+    async def reject_tool_list(client, *, allowed_tools=None, disallowed_tools=None, **_):
+        if allowed_tools is not None or disallowed_tools is not None:
+            raise UnsupportedContinuationPolicy("tool list change not supported mid-session")
+
+    with (
+        client_context() as (client, mock_cli),
+        patch.object(main, "get_mcp_servers", return_value={}),
+        patch.object(responses_module, "get_mcp_servers", return_value={}),
+    ):
+        mock_cli.update_request_policy = reject_tool_list
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": DEFAULT_MODEL,
+                "input": "follow up",
+                "previous_response_id": responses_module._make_response_id(session_id, 1),
+                "disallowed_tools": ["Bash"],
+            },
+        )
+
+    assert response.status_code == 400
+    body = response.json()
+    payload_text = json.dumps(body)
+    assert "tool" in payload_text.lower()
+
+
+def test_claude_continuation_rejects_allowed_tools_change_with_400(isolated_session_manager):
+    """Same rejection applies to allowed_tools, not just disallowed_tools."""
+    from src.backends.claude.client import UnsupportedContinuationPolicy
+
+    session_id = str(uuid.uuid4())
+    session = isolated_session_manager.get_or_create_session(session_id)
+    session.backend = "claude"
+    session.turn_counter = 1
+    session.client = object()
+
+    async def reject_tool_list(client, *, allowed_tools=None, disallowed_tools=None, **_):
+        if allowed_tools is not None or disallowed_tools is not None:
+            raise UnsupportedContinuationPolicy("tool list change not supported mid-session")
+
+    with (
+        client_context() as (client, mock_cli),
+        patch.object(main, "get_mcp_servers", return_value={}),
+        patch.object(responses_module, "get_mcp_servers", return_value={}),
+    ):
+        mock_cli.update_request_policy = reject_tool_list
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": DEFAULT_MODEL,
+                "input": "follow up",
+                "previous_response_id": responses_module._make_response_id(session_id, 1),
+                "allowed_tools": ["Read"],
+            },
+        )
+
+    assert response.status_code == 400
+
+
+def test_claude_function_call_output_rejects_tool_list_change_with_400(isolated_session_manager):
+    """function_call_output continuation rejects tool-list changes with 400.
+
+    Verifies the policy-rejection path actually fires (the helper validates
+    successfully, update_request_policy raises, the route surfaces 400, and
+    the SDK is NOT woken up — pending_tool_call remains set and the lock is
+    released so the session isn't wedged).
+    """
+    from src.backends.claude.client import UnsupportedContinuationPolicy
+
+    session_id = str(uuid.uuid4())
+    session = isolated_session_manager.get_or_create_session(session_id)
+    session.backend = "claude"
+    session.turn_counter = 1
+    session.client = object()
+    session.input_event = asyncio.Event()
+    session.pending_tool_call = {
+        "call_id": "q1",
+        "name": "AskUserQuestion",
+        "arguments": {"question": "Continue?"},
+        "backend": "claude",
+    }
+
+    update_calls = []
+
+    async def reject_tool_list(client, *, allowed_tools=None, disallowed_tools=None, **_):
+        update_calls.append((allowed_tools, disallowed_tools))
+        if allowed_tools is not None or disallowed_tools is not None:
+            raise UnsupportedContinuationPolicy("tool list change not supported mid-session")
+
+    with (
+        client_context() as (client, mock_cli),
+        patch.object(main, "get_mcp_servers", return_value={}),
+        patch.object(responses_module, "get_mcp_servers", return_value={}),
+    ):
+        mock_cli.update_request_policy = reject_tool_list
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": DEFAULT_MODEL,
+                "previous_response_id": responses_module._make_response_id(session_id, 1),
+                "input": [{"type": "function_call_output", "call_id": "q1", "output": "yes"}],
+                "disallowed_tools": ["Bash"],
+            },
+        )
+
+    assert response.status_code == 400
+    body = response.json()
+    assert "tool" in json.dumps(body).lower()
+    # The policy update was actually invoked (not short-circuited by an
+    # earlier 400 such as "no pending input event").
+    assert update_calls, "update_request_policy was never called"
+    # The lock must be released so subsequent requests on this session work.
+    assert not session.lock.locked(), "session lock leaked after policy rejection"
+    # SDK must NOT have been woken with the rejected request.
+    assert not session.input_event.is_set(), "SDK was resumed despite rejected policy"
+    # Pending tool call should still be set — the continuation was aborted.
+    assert session.pending_tool_call is not None
+
+
+def test_claude_function_call_output_unrelated_exception_releases_lock(isolated_session_manager):
+    """A non-UnsupportedContinuationPolicy raise still releases the session lock and is not 400.
+
+    The Starlette TestClient re-raises uncaught exceptions out of ``client.post``,
+    so we wrap the call to confirm: the exception propagates (i.e. NOT
+    swallowed as 400) and the session lock + input_event are clean afterward.
+    """
+    session_id = str(uuid.uuid4())
+    session = isolated_session_manager.get_or_create_session(session_id)
+    session.backend = "claude"
+    session.turn_counter = 1
+    session.client = object()
+    session.input_event = asyncio.Event()
+    session.pending_tool_call = {
+        "call_id": "q1",
+        "name": "AskUserQuestion",
+        "arguments": {"question": "Continue?"},
+        "backend": "claude",
+    }
+
+    async def boom(client, **kwargs):
+        raise RuntimeError("transient SDK failure")
+
+    with (
+        client_context() as (client, mock_cli),
+        patch.object(main, "get_mcp_servers", return_value={}),
+        patch.object(responses_module, "get_mcp_servers", return_value={}),
+    ):
+        mock_cli.update_request_policy = boom
+        with pytest.raises(RuntimeError, match="transient SDK failure"):
+            client.post(
+                "/v1/responses",
+                json={
+                    "model": DEFAULT_MODEL,
+                    "previous_response_id": responses_module._make_response_id(session_id, 1),
+                    "input": [{"type": "function_call_output", "call_id": "q1", "output": "yes"}],
+                    "permission_mode": "acceptEdits",
+                },
+            )
+
+    assert not session.lock.locked(), "session lock leaked after SDK failure"
+    assert not session.input_event.is_set()
+
+
+def test_claude_continuation_sdk_value_error_is_not_misclassified_as_400(isolated_session_manager):
+    """An unrelated ValueError from the SDK propagates as 5xx, not a 400 misclassification."""
+    session_id = str(uuid.uuid4())
+    session = isolated_session_manager.get_or_create_session(session_id)
+    session.backend = "claude"
+    session.turn_counter = 1
+    session.client = object()
+
+    async def sdk_value_error(client, **kwargs):
+        # Some unrelated ValueError from deeper in the SDK — must NOT be
+        # mistaken for an "unsupported policy" client error.
+        raise ValueError("internal SDK invariant violated")
+
+    with (
+        client_context() as (client, mock_cli),
+        patch.object(main, "get_mcp_servers", return_value={}),
+        patch.object(responses_module, "get_mcp_servers", return_value={}),
+    ):
+        mock_cli.update_request_policy = sdk_value_error
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": DEFAULT_MODEL,
+                "input": "follow up",
+                "previous_response_id": responses_module._make_response_id(session_id, 1),
+                "permission_mode": "acceptEdits",
+            },
+        )
+
+    # Not a client-side limitation; should surface as a server error, not 400.
+    assert response.status_code >= 500
+    assert response.status_code != 400
+
+
+def test_claude_continuation_permission_mode_sdk_failure_fails_closed(isolated_session_manager):
+    """When the Claude SDK rejects a permission_mode update, the request fails closed (400/503),
+    not silently runs with the old (potentially weaker) mode.
+    """
+    session_id = str(uuid.uuid4())
+    session = isolated_session_manager.get_or_create_session(session_id)
+    session.backend = "claude"
+    session.turn_counter = 1
+    session.client = object()
+
+    async def failing_update_request_policy(client, **kwargs):
+        # Simulate Claude SDK rejecting the mid-session update.
+        raise RuntimeError("Claude SDK refused permission_mode change")
+
+    async def fake_run_with_client(client, prompt, session):
+        # Should never run if update fails closed.
+        yield {"subtype": "success", "result": "should-not-appear"}
+
+    with (
+        client_context() as (client, mock_cli),
+        patch.object(main, "get_mcp_servers", return_value={}),
+        patch.object(responses_module, "get_mcp_servers", return_value={}),
+    ):
+        mock_cli.update_request_policy = failing_update_request_policy
+        mock_cli.run_completion_with_client = fake_run_with_client
+        mock_cli.parse_message.return_value = "should-not-appear"
+
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": DEFAULT_MODEL,
+                "input": "follow up",
+                "previous_response_id": responses_module._make_response_id(session_id, 1),
+                "permission_mode": "acceptEdits",
+            },
+        )
+
+    # Either 400 (client-facing limitation) or 5xx (backend error) is fine —
+    # what matters is it does NOT return 200 with stale-mode output.
+    assert response.status_code >= 400
 
 
 def test_opencode_permission_arguments_describe_empty_patterns_and_always():

--- a/tests/test_main_api_unit.py
+++ b/tests/test_main_api_unit.py
@@ -1045,6 +1045,383 @@ def test_opencode_function_call_output_rejects_unknown_resume_kind(isolated_sess
     assert "Unsupported OpenCode resume kind" in response.json()["error"]["message"]
 
 
+def test_codex_responses_input_image_passes_multimodal_items_to_backend(
+    isolated_session_manager,
+):
+    """Codex requests with input_image must hand a multimodal items list to the backend,
+    not a single collapsed-string prompt.
+    """
+    calls = {}
+
+    def resolve(model):
+        if model == "codex/gpt-5.5":
+            return ResolvedModel(model, "codex", "gpt-5.5")
+        return None
+
+    async def create_client(**kwargs):
+        calls["create_client"] = kwargs
+        return object()
+
+    async def run_completion_with_client(client, prompt, session):
+        calls["prompt"] = prompt
+        yield {"subtype": "success", "result": "ok"}
+
+    backend = MagicMock()
+    backend.name = "codex"
+    backend.create_client = create_client
+    backend.run_completion_with_client = run_completion_with_client
+    backend.parse_message.return_value = "ok"
+    backend.estimate_token_usage.return_value = {
+        "prompt_tokens": 1,
+        "completion_tokens": 1,
+        "total_tokens": 2,
+    }
+    BackendRegistry.register_descriptor(
+        BackendDescriptor(
+            name="codex",
+            owned_by="openai",
+            models=["codex/gpt-5.5"],
+            resolve_fn=resolve,
+        )
+    )
+    BackendRegistry.register("codex", backend)
+
+    with client_context() as (client, _mock_cli):
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": "codex/gpt-5.5",
+                "input": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "input_text", "text": "look at this"},
+                            {
+                                "type": "input_image",
+                                "image_url": "https://example.com/foo.png",
+                            },
+                            {"type": "input_text", "text": "any thoughts?"},
+                        ],
+                    }
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    prompt = calls.get("prompt")
+    assert isinstance(prompt, list), f"Codex should receive a list, got {type(prompt).__name__}"
+    # Order must be preserved (text, image, text).
+    assert prompt[0]["type"] == "text"
+    assert prompt[0]["text"] == "look at this"
+    assert prompt[1]["type"] in {"image", "input_image"}
+    assert prompt[1].get("image_url") == "https://example.com/foo.png" or prompt[1].get("url") == "https://example.com/foo.png"
+    assert prompt[2]["type"] == "text"
+    assert prompt[2]["text"] == "any thoughts?"
+
+
+def test_codex_responses_input_image_uses_image_url_codex_item_shape(
+    isolated_session_manager,
+):
+    """Locked-in schema: route emits ``{type: image, url: ...}`` for Codex."""
+    calls = {}
+
+    def resolve(model):
+        if model == "codex/gpt-5.5":
+            return ResolvedModel(model, "codex", "gpt-5.5")
+        return None
+
+    async def create_client(**kwargs):
+        return object()
+
+    async def run_completion_with_client(client, prompt, session):
+        calls["prompt"] = prompt
+        yield {"subtype": "success", "result": "ok"}
+
+    backend = MagicMock()
+    backend.name = "codex"
+    backend.create_client = create_client
+    backend.run_completion_with_client = run_completion_with_client
+    backend.parse_message.return_value = "ok"
+    backend.estimate_token_usage.return_value = {
+        "prompt_tokens": 1,
+        "completion_tokens": 1,
+        "total_tokens": 2,
+    }
+    BackendRegistry.register_descriptor(
+        BackendDescriptor(
+            name="codex",
+            owned_by="openai",
+            models=["codex/gpt-5.5"],
+            resolve_fn=resolve,
+        )
+    )
+    BackendRegistry.register("codex", backend)
+
+    with client_context() as (client, _mock_cli):
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": "codex/gpt-5.5",
+                "input": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "input_text", "text": "see"},
+                            {
+                                "type": "input_image",
+                                "image_url": "https://example.com/x.png",
+                            },
+                        ],
+                    }
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    prompt = calls["prompt"]
+    # Codex-native shape — matches the in-tree fixture in test_codex_backend.py.
+    image_items = [item for item in prompt if item["type"] == "image"]
+    assert image_items, f"no image item in {prompt!r}"
+    assert image_items[0]["url"] == "https://example.com/x.png"
+
+
+def test_codex_responses_unknown_only_input_part_does_not_take_multimodal_path(
+    isolated_session_manager,
+):
+    """If the only non-text part is an unknown type, fall back to the string path
+    (so we don't end up routing nothing to the backend).
+    """
+    calls = {}
+
+    def resolve(model):
+        if model == "codex/gpt-5.5":
+            return ResolvedModel(model, "codex", "gpt-5.5")
+        return None
+
+    async def create_client(**kwargs):
+        return object()
+
+    async def run_completion_with_client(client, prompt, session):
+        calls["prompt"] = prompt
+        yield {"subtype": "success", "result": "ok"}
+
+    backend = MagicMock()
+    backend.name = "codex"
+    backend.create_client = create_client
+    backend.run_completion_with_client = run_completion_with_client
+    backend.parse_message.return_value = "ok"
+    backend.estimate_token_usage.return_value = {
+        "prompt_tokens": 1,
+        "completion_tokens": 1,
+        "total_tokens": 2,
+    }
+    BackendRegistry.register_descriptor(
+        BackendDescriptor(
+            name="codex",
+            owned_by="openai",
+            models=["codex/gpt-5.5"],
+            resolve_fn=resolve,
+        )
+    )
+    BackendRegistry.register("codex", backend)
+
+    with client_context() as (client, _mock_cli):
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": "codex/gpt-5.5",
+                "input": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "input_text", "text": "hello"},
+                            {"type": "input_file", "file_id": "file_xyz"},
+                        ],
+                    }
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    # No input_image part → fell back to string path.
+    assert isinstance(calls["prompt"], str)
+
+
+def test_codex_responses_empty_image_url_returns_400(isolated_session_manager):
+    """Multimodal request whose image_url is empty produces no items → 400 from the route.
+
+    Also locks in: the backend is never reached (no create_client / run call)
+    and the response message names the problem.
+    """
+
+    def resolve(model):
+        if model == "codex/gpt-5.5":
+            return ResolvedModel(model, "codex", "gpt-5.5")
+        return None
+
+    create_calls: list = []
+    run_calls: list = []
+
+    async def create_client(**kwargs):
+        create_calls.append(kwargs)
+        return object()
+
+    async def run_completion_with_client(client, prompt, session):
+        run_calls.append(prompt)
+        yield {"subtype": "success", "result": "ok"}
+
+    backend = MagicMock()
+    backend.name = "codex"
+    backend.create_client = create_client
+    backend.run_completion_with_client = run_completion_with_client
+    BackendRegistry.register_descriptor(
+        BackendDescriptor(
+            name="codex",
+            owned_by="openai",
+            models=["codex/gpt-5.5"],
+            resolve_fn=resolve,
+        )
+    )
+    BackendRegistry.register("codex", backend)
+
+    with client_context() as (client, _mock_cli):
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": "codex/gpt-5.5",
+                "input": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "input_image", "image_url": ""},
+                        ],
+                    }
+                ],
+            },
+        )
+
+    assert response.status_code == 400
+    body = response.json()
+    assert "Codex multimodal input produced no usable items" in json.dumps(body)
+    assert not run_calls, "backend.run_completion_with_client was called for a 400 request"
+
+
+def test_codex_responses_input_file_only_falls_back_to_string_prompt(
+    isolated_session_manager,
+):
+    """A request whose only non-text part is unknown (e.g. input_file) takes the string path.
+
+    Regression guard for Bug #1: ``_has_multimodal_input`` must not return
+    True for unknown types, otherwise the request would go through the
+    Codex item branch and then be rejected as "no usable items".
+    """
+    calls = {}
+
+    def resolve(model):
+        if model == "codex/gpt-5.5":
+            return ResolvedModel(model, "codex", "gpt-5.5")
+        return None
+
+    async def create_client(**kwargs):
+        return object()
+
+    async def run_completion_with_client(client, prompt, session):
+        calls["prompt"] = prompt
+        yield {"subtype": "success", "result": "ok"}
+
+    backend = MagicMock()
+    backend.name = "codex"
+    backend.create_client = create_client
+    backend.run_completion_with_client = run_completion_with_client
+    backend.parse_message.return_value = "ok"
+    backend.estimate_token_usage.return_value = {
+        "prompt_tokens": 1,
+        "completion_tokens": 1,
+        "total_tokens": 2,
+    }
+    BackendRegistry.register_descriptor(
+        BackendDescriptor(
+            name="codex",
+            owned_by="openai",
+            models=["codex/gpt-5.5"],
+            resolve_fn=resolve,
+        )
+    )
+    BackendRegistry.register("codex", backend)
+
+    with client_context() as (client, _mock_cli):
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": "codex/gpt-5.5",
+                "input": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "input_file", "file_id": "file_xyz"},
+                        ],
+                    }
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    assert isinstance(calls["prompt"], str)
+
+
+def test_codex_responses_text_only_input_still_passes_string_prompt(
+    isolated_session_manager,
+):
+    """Codex text-only requests can stay as a string — no forced multimodal upgrade."""
+    calls = {}
+
+    def resolve(model):
+        if model == "codex/gpt-5.5":
+            return ResolvedModel(model, "codex", "gpt-5.5")
+        return None
+
+    async def create_client(**kwargs):
+        calls["create_client"] = kwargs
+        return object()
+
+    async def run_completion_with_client(client, prompt, session):
+        calls["prompt"] = prompt
+        yield {"subtype": "success", "result": "ok"}
+
+    backend = MagicMock()
+    backend.name = "codex"
+    backend.create_client = create_client
+    backend.run_completion_with_client = run_completion_with_client
+    backend.parse_message.return_value = "ok"
+    backend.estimate_token_usage.return_value = {
+        "prompt_tokens": 1,
+        "completion_tokens": 1,
+        "total_tokens": 2,
+    }
+    BackendRegistry.register_descriptor(
+        BackendDescriptor(
+            name="codex",
+            owned_by="openai",
+            models=["codex/gpt-5.5"],
+            resolve_fn=resolve,
+        )
+    )
+    BackendRegistry.register("codex", backend)
+
+    with client_context() as (client, _mock_cli):
+        response = client.post(
+            "/v1/responses",
+            json={"model": "codex/gpt-5.5", "input": "hi"},
+        )
+
+    assert response.status_code == 200
+    prompt = calls.get("prompt")
+    # Plain string input → backend still receives the original string. Codex's
+    # backend layer wraps it into a single text item internally.
+    assert isinstance(prompt, str)
+    assert prompt == "hi"
+
+
 def test_claude_previous_response_id_refreshes_permission_mode(isolated_session_manager):
     """A Claude continuation with new permission_mode applies via update_request_policy."""
     session_id = str(uuid.uuid4())

--- a/tests/test_main_api_unit.py
+++ b/tests/test_main_api_unit.py
@@ -1114,7 +1114,10 @@ def test_codex_responses_input_image_passes_multimodal_items_to_backend(
     assert prompt[0]["type"] == "text"
     assert prompt[0]["text"] == "look at this"
     assert prompt[1]["type"] in {"image", "input_image"}
-    assert prompt[1].get("image_url") == "https://example.com/foo.png" or prompt[1].get("url") == "https://example.com/foo.png"
+    assert (
+        prompt[1].get("image_url") == "https://example.com/foo.png"
+        or prompt[1].get("url") == "https://example.com/foo.png"
+    )
     assert prompt[2]["type"] == "text"
     assert prompt[2]["text"] == "any thoughts?"
 
@@ -1247,8 +1250,18 @@ def test_codex_responses_unknown_only_input_part_does_not_take_multimodal_path(
     assert isinstance(calls["prompt"], str)
 
 
-def test_codex_responses_empty_image_url_returns_400(isolated_session_manager):
-    """Multimodal request whose image_url is empty produces no items → 400 from the route.
+@pytest.mark.parametrize(
+    "content",
+    [
+        [{"type": "input_image", "image_url": ""}],
+        [
+            {"type": "input_text", "text": "look"},
+            {"type": "input_image", "image_url": ""},
+        ],
+    ],
+)
+def test_codex_responses_empty_image_url_returns_400(isolated_session_manager, content):
+    """Multimodal request whose image_url is empty returns 400 from the route.
 
     Also locks in: the backend is never reached (no create_client / run call)
     and the response message names the problem.
@@ -1292,9 +1305,7 @@ def test_codex_responses_empty_image_url_returns_400(isolated_session_manager):
                 "input": [
                     {
                         "role": "user",
-                        "content": [
-                            {"type": "input_image", "image_url": ""},
-                        ],
+                        "content": content,
                     }
                 ],
             },
@@ -1302,7 +1313,7 @@ def test_codex_responses_empty_image_url_returns_400(isolated_session_manager):
 
     assert response.status_code == 400
     body = response.json()
-    assert "Codex multimodal input produced no usable items" in json.dumps(body)
+    assert "empty image_url" in json.dumps(body)
     assert not run_calls, "backend.run_completion_with_client was called for a 400 request"
 
 

--- a/tests/test_main_api_unit.py
+++ b/tests/test_main_api_unit.py
@@ -1775,6 +1775,72 @@ def test_responses_create_client_forwards_allowed_tools(isolated_session_manager
     assert create_calls[0]["allowed_tools"] == ["Read"]
 
 
+def test_responses_create_client_forwards_model_params(isolated_session_manager):
+    """temperature and max_output_tokens from the request body land in model_params."""
+    create_calls = []
+
+    async def fake_create_client(**kwargs):
+        create_calls.append(kwargs)
+        return object()
+
+    async def fake_run_with_client(client, prompt, session):
+        yield {"subtype": "success", "result": "ok"}
+
+    with (
+        client_context() as (client, mock_cli),
+        patch.object(main, "get_mcp_servers", return_value={}),
+        patch.object(responses_module, "get_mcp_servers", return_value={}),
+    ):
+        mock_cli.create_client = fake_create_client
+        mock_cli.run_completion_with_client = fake_run_with_client
+        mock_cli.parse_message.return_value = "ok"
+
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": DEFAULT_MODEL,
+                "input": "Hello",
+                "temperature": 0.42,
+                "max_output_tokens": 256,
+            },
+        )
+
+    assert response.status_code == 200
+    assert create_calls[0]["model_params"] == {
+        "temperature": 0.42,
+        "max_output_tokens": 256,
+    }
+
+
+def test_responses_create_client_omits_model_params_when_unset(isolated_session_manager):
+    """Bodies without sampling overrides pass model_params=None (backend defaults stand)."""
+    create_calls = []
+
+    async def fake_create_client(**kwargs):
+        create_calls.append(kwargs)
+        return object()
+
+    async def fake_run_with_client(client, prompt, session):
+        yield {"subtype": "success", "result": "ok"}
+
+    with (
+        client_context() as (client, mock_cli),
+        patch.object(main, "get_mcp_servers", return_value={}),
+        patch.object(responses_module, "get_mcp_servers", return_value={}),
+    ):
+        mock_cli.create_client = fake_create_client
+        mock_cli.run_completion_with_client = fake_run_with_client
+        mock_cli.parse_message.return_value = "ok"
+
+        response = client.post(
+            "/v1/responses",
+            json={"model": DEFAULT_MODEL, "input": "Hello"},
+        )
+
+    assert response.status_code == 200
+    assert create_calls[0]["model_params"] is None
+
+
 def test_responses_create_client_forwards_disallowed_tools(isolated_session_manager):
     """disallowed_tools from the request body flows through to create_client."""
     create_calls = []

--- a/tests/test_main_api_unit.py
+++ b/tests/test_main_api_unit.py
@@ -1775,6 +1775,39 @@ def test_responses_create_client_forwards_allowed_tools(isolated_session_manager
     assert create_calls[0]["allowed_tools"] == ["Read"]
 
 
+def test_responses_create_client_forwards_disallowed_tools(isolated_session_manager):
+    """disallowed_tools from the request body flows through to create_client."""
+    create_calls = []
+
+    async def fake_create_client(**kwargs):
+        create_calls.append(kwargs)
+        return object()
+
+    async def fake_run_with_client(client, prompt, session):
+        yield {"subtype": "success", "result": "ok"}
+
+    with (
+        client_context() as (client, mock_cli),
+        patch.object(main, "get_mcp_servers", return_value={}),
+        patch.object(responses_module, "get_mcp_servers", return_value={}),
+    ):
+        mock_cli.create_client = fake_create_client
+        mock_cli.run_completion_with_client = fake_run_with_client
+        mock_cli.parse_message.return_value = "ok"
+
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": DEFAULT_MODEL,
+                "input": "Hello",
+                "disallowed_tools": ["Bash"],
+            },
+        )
+
+    assert response.status_code == 200
+    assert create_calls[0]["disallowed_tools"] == ["Bash"]
+
+
 def test_responses_streaming_error_disconnects_persistent_client(isolated_session_manager):
     """Streaming failures discard the session SDK client."""
     sdk_client = AsyncMock()

--- a/tests/test_main_api_unit.py
+++ b/tests/test_main_api_unit.py
@@ -249,8 +249,60 @@ def test_responses_dispatches_to_codex_backend_without_mcp():
 
     assert response.status_code == 200
     assert calls["create_client"]["model"] == "gpt-5.5"
-    assert calls["create_client"]["mcp_servers"] is None
+    # Codex now also receives the gateway MCP config; with no MCP_CONFIG env,
+    # the helper returns an empty dict (no servers configured).
+    assert calls["create_client"]["mcp_servers"] == {}
     assert calls["prompt"] == "hi"
+
+
+def test_responses_dispatches_to_codex_backend_with_configured_mcp_servers():
+    """A non-empty server MCP config is forwarded to the Codex backend."""
+    calls = {}
+
+    def resolve(model):
+        if model == "codex/gpt-5.5":
+            return ResolvedModel(model, "codex", "gpt-5.5")
+        return None
+
+    async def create_client(**kwargs):
+        calls["create_client"] = kwargs
+        return object()
+
+    async def run_completion_with_client(client, prompt, session):
+        yield {"type": "result", "subtype": "success", "result": "ok"}
+
+    backend = MagicMock()
+    backend.name = "codex"
+    backend.create_client = create_client
+    backend.run_completion_with_client = run_completion_with_client
+    backend.parse_message.return_value = "ok"
+    backend.estimate_token_usage.return_value = {
+        "prompt_tokens": 1,
+        "completion_tokens": 1,
+        "total_tokens": 2,
+    }
+    BackendRegistry.register_descriptor(
+        BackendDescriptor(
+            name="codex",
+            owned_by="openai",
+            models=["codex/gpt-5.5"],
+            resolve_fn=resolve,
+        )
+    )
+    BackendRegistry.register("codex", backend)
+
+    configured = {"fs": {"type": "stdio", "command": "fs-server"}}
+    with (
+        client_context() as (client, _mock_cli),
+        patch.object(responses_module, "get_mcp_servers", return_value=configured),
+    ):
+        response = client.post(
+            "/v1/responses",
+            json={"model": "codex/gpt-5.5", "input": "hi"},
+        )
+
+    assert response.status_code == 200
+    assert calls["create_client"]["mcp_servers"] == configured
 
 
 def test_responses_streaming_enables_opencode_event_streaming():

--- a/tests/test_response_models.py
+++ b/tests/test_response_models.py
@@ -102,6 +102,19 @@ def test_response_create_request_rejects_non_string_input_image_url():
         )
 
 
+def test_response_create_request_accepts_valid_permission_modes():
+    """All four documented permission_mode values must be accepted."""
+    for mode in ("default", "acceptEdits", "bypassPermissions", "plan"):
+        req = ResponseCreateRequest(model="sonnet", input="hi", permission_mode=mode)
+        assert req.permission_mode == mode
+
+
+def test_response_create_request_rejects_invalid_permission_mode():
+    """Typos / unknown permission_mode strings are rejected at the API boundary."""
+    with pytest.raises(ValidationError):
+        ResponseCreateRequest(model="sonnet", input="hi", permission_mode="definitely-invalid")
+
+
 def test_response_create_request_accepts_unknown_part_type_as_dict():
     """Forward-compat: unknown part types (e.g., input_file) are kept as dicts."""
     req = ResponseCreateRequest(


### PR DESCRIPTION
## Summary

Brings the Codex backend up to feature parity with the Claude backend. Closes the policy/usage/multimodal/retry gaps that previously made Codex sessions silently drop request fields. Each step was reviewed and LGTM'd by Codex before moving on; all 11 commits stack cleanly.

**Stats:** 11 commits · 13 files changed · +4,089 / -289 · 1,539 tests pass (no regressions).

## What changed (per commit)

| Commit | Area | Highlights |
|---|---|---|
| `6ee53e4` | Step 1 — policy enforcement | `allowed_tools`/`disallowed_tools`/`permission_mode` now applied. Approval-time auto-deny for `command/file_change/mcpToolCall/dynamicToolCall`. `approvalPolicy` auto-upgraded off `never` when a tool policy is active. Shared `DISALLOWED_TOOLS` env honored. `allowed_tools=[]` treated as explicit block-all. |
| `5c858bc` | Step 2a — reasoning tokens | `last.reasoningOutputTokens` is rolled into `output_tokens` so totals reconcile with notification `totalTokens`. |
| `4123c30` | Step 2b — acceptEdits | `permission_mode="acceptEdits"` auto-accepts `fileChange` approvals; `commandExecution`/`mcpToolCall`/`dynamicToolCall` still bubble. Disallow always wins. `permission_mode` exposed as a `Literal`-validated request body field. Unknown modes safely fall back to `on-request`. |
| `b2241e2` | Step 3 — retry / recovery | One conservative retry of `turn/start` on transport error. Skipped if any notification was queued (turn possibly accepted) or any chunk was already yielded. `client.rpc` refreshed after retry. Approval resume fails fast if the originating RPC is gone. |
| `8ef0485` | Step 4 — model params | `temperature` / `max_output_tokens` (and `max_tokens` alias) flow through to `turn/start` with Codex-style camelCase. Continuation refreshes clear stale overrides. Fake Codex e2e captures payloads to assert they reach the wire. |
| `30206b3` | Step 5 — MCP servers | `get_mcp_servers()` is forwarded to Codex (was Claude-only). Stored on the session client, included in `thread/start` and the retry-path `thread/resume`. |
| `745ffcf` | Step 6 — Claude continuation gap | Claude gains `update_request_policy` (mid-session `set_permission_mode`). Tool-list changes on continuation raise `UnsupportedContinuationPolicy` → 400 (no silent drop). `_unblock_pending_tool_call` split so the SDK is only woken **after** policy refresh succeeds; lock released on any failure. |
| `f83bb7f` | Step 7 — backend multimodal | `run_completion_with_client(prompt=...)` accepts either a string or a list of Codex input items. Empty/non-dict items rejected before `turn/start` fires. |
| `ddf0a98` | Step 8 — route multimodal | Codex requests with `input_image` build a Codex item list (`{type:image, url}`) instead of collapsing into a single text prompt. Unknown part types stay on the string path; empty image items return 400 without ever touching the backend. |
| `9883c7b` | Step 9 — cleanup | Drops the unused `CodexSessionClient.stream_events` field; OpenCode's analogous field stays. |
| `c44e5e1` | Step 10 — polish | `BackendClient.run_completion_with_client` typed as `prompt: Union[str, List[Dict]]`. Inline doc comparing Claude (MCP filtered at create time) vs Codex (filtered at approval time). |

## Out of scope (deliberate)

- **No Docker/deploy changes** per the user goal.
- **Codex JSON-RPC spec verification.** Camel-cased field names (`maxOutputTokens`, `topP`, `mcpServers`, `image`/`url`) are educated guesses based on in-tree fixtures and the conventions of other Codex RPC fields. They're internally consistent but not verified against an external spec.
- **Tracked for follow-up** via memory notes:
  - OpenCode has the same reasoning-token undercount Codex did before `5c858bc`.
  - A route-level e2e for continuation `temperature/max_output_tokens` refresh.

## Test plan

- [x] `uv run pytest` — 1539 passed, 2 skipped, 4 deselected; no regressions vs `main`.
- [x] Codex backend unit tests (`tests/test_codex_backend.py`): 130+ tests covering enforcement, aliases, retry guards, fast-fail, multimodal items, model params, MCP forwarding.
- [x] Codex e2e (`tests/integration/test_codex_e2e.py`): fake Codex app-server exercises real `/v1/responses` flows for command/file/permissions approvals, body-level `disallowed_tools`, continuation policy refresh, model-param wire capture, etc.
- [x] Route unit (`tests/test_main_api_unit.py`): forwarding of new body fields, Claude continuation 400s, multimodal items shape lock-in, unknown-only fallback, empty `image_url` 400.
- [x] Claude unit (`tests/test_claude_cli_unit.py`): `update_request_policy` propagates SDK errors, raises `UnsupportedContinuationPolicy` for tool-list change attempts.
- [x] `ResponseCreateRequest` schema (`tests/test_response_models.py`): valid `permission_mode` values accepted, invalid rejected at the API boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)