### PR TITLE
chore(deps): upgrade claude-agent-sdk 0.1.57 → 0.2.82

### DIFF
--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -28,7 +28,7 @@ To force the previous behavior (block on MCP connect), set `MCP_CONNECTION_NONBL
 
 ### New block types may appear in assistant content
 
-The SDK now emits `server_tool_use` and `advisor_tool_result` blocks (previously silently dropped). These pass through to clients unchanged. Clients that exhaustively switch on block `type` should add cases for these (or use a default fallback).
+The SDK now emits `server_tool_use` and `advisor_tool_result` blocks (previously silently dropped). Streaming responses expose these as `response.server_tool_use` and `response.advisor_tool_result` SSE events with the original content block under `block`. Clients that exhaustively switch on `block.type` should add cases for these (or use a default fallback).
 
 ### `api_error_status` field available on error results
 

--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -13,7 +13,7 @@ Schemas observed in this SDK version (from CLI tool definitions and a smoke-test
 
 | Tool | Input fields | id source |
 |---|---|---|
-| `TaskCreate` | `subject`, `description`, `activeForm?` (status is auto-`pending`) | returned in the `tool_result` `content` (e.g. `"Task #1 created successfully: ..."`), not in the `input` |
+| `TaskCreate` | `subject`, `description`, `activeForm?` (status is auto-`pending`) | returned in the matching `tool_result.content` as the created task record (for example, `{ "task": { "id": "...", "subject": "..." } }`), not in the `input` |
 | `TaskUpdate` | `taskId`, plus any of `status`, `subject`, `description`, `activeForm`, `owner`, `addBlocks`, `addBlockedBy`, `metadata` | n/a (caller supplies `taskId`) |
 | `TaskGet` | `taskId` | n/a |
 | `TaskList` | (no required input) | n/a |

--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -2,23 +2,23 @@
 
 ## 2026-05-16 — Claude Agent SDK 0.2.82 upgrade
 
-### Tool name changes in `response.tool_use` events
+### Task tools are now available (opt-in)
 
-The Claude backend now emits the following tool names in `response.tool_use` SSE events instead of `TodoWrite`:
+claude-agent-sdk 0.2.82 ships a new task-tracking tool family (`TaskCreate` / `TaskUpdate` / `TaskGet` / `TaskList`) alongside the legacy `TodoWrite`. The bundled Claude CLI gates these behind the `CLAUDE_CODE_ENABLE_TASKS` env var:
 
-- `TaskCreate` — create a task (input: `{title, description, status}`)
-- `TaskUpdate` — update task status (input: `{task_id, status, ...}`)
-- `TaskGet` — fetch a single task by id
-- `TaskList` — list all tasks
+- **Env unset (default)** — `TodoWrite` remains the only task-tracking tool emitted. No `response.tool_use` payload changes for existing clients.
+- **`CLAUDE_CODE_ENABLE_TASKS=1`** — the SDK emits `TaskCreate` / `TaskUpdate` / `TaskGet` / `TaskList` instead. The gateway does not set this env automatically; operators choose per deployment.
 
-**Required client changes:**
+Schemas observed in this SDK version (from CLI tool definitions and a smoke-test run):
 
-1. **Recognize the new tool names.** Clients that previously branched on `tool_use.name == "TodoWrite"` must also handle `TaskCreate` / `TaskUpdate` / `TaskGet` / `TaskList`.
-2. **Switch from snapshot-replace to per-id accumulation.** `TodoWrite` emitted a full snapshot of all todos on every call; the new events are deltas keyed by task id. Maintain a `Map<task_id, task>` and apply each event:
-   - `TaskCreate`: insert
-   - `TaskUpdate`: update by id
-   - (others: as semantically appropriate)
-3. **`TodoWrite` may still appear from older sessions or back-compat paths.** Treat it as a snapshot for legacy data.
+| Tool | Input fields | id source |
+|---|---|---|
+| `TaskCreate` | `subject`, `description`, `activeForm?` (status is auto-`pending`) | returned in the `tool_result` `content` (e.g. `"Task #1 created successfully: ..."`), not in the `input` |
+| `TaskUpdate` | `taskId`, plus any of `status`, `subject`, `description`, `activeForm`, `owner`, `addBlocks`, `addBlockedBy`, `metadata` | n/a (caller supplies `taskId`) |
+| `TaskGet` | `taskId` | n/a |
+| `TaskList` | (no required input) | n/a |
+
+`Task*` events are per-id deltas (the CLI maintains task state on disk); `TodoWrite` events are full snapshots. Clients that want to render Task* should accumulate by `taskId`. Clients that only handle `TodoWrite` keep working as long as `CLAUDE_CODE_ENABLE_TASKS` stays unset.
 
 ### MCP server `init` may include pending servers
 

--- a/docs/api/breaking-changes.md
+++ b/docs/api/breaking-changes.md
@@ -1,0 +1,47 @@
+# Breaking Changes for API Consumers
+
+## 2026-05-16 — Claude Agent SDK 0.2.82 upgrade
+
+### Tool name changes in `response.tool_use` events
+
+The Claude backend now emits the following tool names in `response.tool_use` SSE events instead of `TodoWrite`:
+
+- `TaskCreate` — create a task (input: `{title, description, status}`)
+- `TaskUpdate` — update task status (input: `{task_id, status, ...}`)
+- `TaskGet` — fetch a single task by id
+- `TaskList` — list all tasks
+
+**Required client changes:**
+
+1. **Recognize the new tool names.** Clients that previously branched on `tool_use.name == "TodoWrite"` must also handle `TaskCreate` / `TaskUpdate` / `TaskGet` / `TaskList`.
+2. **Switch from snapshot-replace to per-id accumulation.** `TodoWrite` emitted a full snapshot of all todos on every call; the new events are deltas keyed by task id. Maintain a `Map<task_id, task>` and apply each event:
+   - `TaskCreate`: insert
+   - `TaskUpdate`: update by id
+   - (others: as semantically appropriate)
+3. **`TodoWrite` may still appear from older sessions or back-compat paths.** Treat it as a snapshot for legacy data.
+
+### MCP server `init` may include pending servers
+
+Sessions now start before MCP servers finish connecting. The `init` system message may list servers with `status: "pending"`. Clients that surface MCP server state should reflect this transitional state rather than treating non-`"ready"` as an error.
+
+To force the previous behavior (block on MCP connect), set `MCP_CONNECTION_NONBLOCKING=0` in the gateway environment, or mark individual servers `alwaysLoad: true` in your MCP config.
+
+### New block types may appear in assistant content
+
+The SDK now emits `server_tool_use` and `advisor_tool_result` blocks (previously silently dropped). These pass through to clients unchanged. Clients that exhaustively switch on block `type` should add cases for these (or use a default fallback).
+
+### `api_error_status` field available on error results
+
+The underlying `ResultMessage` exposes an `api_error_status: int | None` field surfacing the HTTP status (429, 500, 529) when the API call failed. The gateway does not yet propagate this to its downstream payload, but a follow-up may do so; clients planning to distinguish rate-limit from server errors should request it.
+
+---
+
+## Why the gateway propagates these changes
+
+This gateway is intentionally a thin pass-through over `claude-agent-sdk`. We do not insert a compatibility shim because:
+
+- Shims hide useful new fields (e.g., `pending` MCP status).
+- Each shim adds maintenance cost that scales with upstream changes.
+- Downstream consumers tend to want the latest SDK semantics.
+
+If you need a compatibility layer in your own client, build it client-side.

--- a/docs/streaming-events.md
+++ b/docs/streaming-events.md
@@ -122,6 +122,49 @@ reconcile their buffered content.
 If the tool call/result comes from a subagent, the event includes
 `parent_tool_use_id`.
 
+### Server-side tool events
+
+claude-agent-sdk 0.2.82+ surfaces tools that the Anthropic API executes
+server-side (e.g. `web_search`, `web_fetch`, `code_execution`, `advisor`).
+These were silently dropped before 0.2.82.
+
+`response.server_tool_use` is emitted when the model invokes a server-side
+tool. The full SDK content block (preserving its `type` discriminator) is
+passed through under `block`:
+
+```json
+{
+  "type": "response.server_tool_use",
+  "block": {
+    "type": "server_tool_use",
+    "id": "srv_01ABC",
+    "name": "web_search",
+    "input": { "query": "claude agent sdk release notes" }
+  },
+  "sequence_number": 9
+}
+```
+
+`response.advisor_tool_result` is emitted when the API returns the result
+for a server-side tool call. `block.content` is the raw dict from the API
+— callers that care about a specific server tool's result schema inspect
+`block.content["type"]`:
+
+```json
+{
+  "type": "response.advisor_tool_result",
+  "block": {
+    "type": "advisor_tool_result",
+    "tool_use_id": "srv_01ABC",
+    "content": { "type": "web_search_result", "results": [...] }
+  },
+  "sequence_number": 10
+}
+```
+
+Clients are not expected to return anything for server-side tool calls —
+the API executes them itself and delivers the result in the same stream.
+
 ## Subagent Events
 
 Subagent task system messages are forwarded as structured progress events:

--- a/docs/superpowers/plans/2026-05-16-claude-agent-sdk-upgrade.md
+++ b/docs/superpowers/plans/2026-05-16-claude-agent-sdk-upgrade.md
@@ -1,0 +1,749 @@
+# Claude Agent SDK 0.1.57 → 0.2.82 Upgrade Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Upgrade `claude-agent-sdk` from 0.1.57 to 0.2.82 with adjustments to tool allow-lists, MCP connection behavior, and Skill option migration, while preserving the gateway's pass-through philosophy and documenting breaking changes for downstream API consumers.
+
+**Architecture:** Adopt **Option A (pass-through)** — no compatibility adapters added to the gateway. Update `src/backends/claude/constants.py` tool catalog for the new Task tools, leave `chunk_processing.py` / `sse_builders.py` untouched (generic fallback handles new block types), migrate from deprecated `"Skill"` allowed_tools entry to the new `skills` option on `ClaudeAgentOptions`, and surface new SDK features incrementally. Downstream breaking changes are documented for API consumers to handle.
+
+**Tech Stack:** Python 3.x, `uv` for dependency management, `pytest` (asyncio_mode=auto), `claude-agent-sdk`, FastAPI, SSE.
+
+---
+
+## Release Highlights (0.1.58 → 0.2.82)
+
+**Breaking changes (0.2.82):**
+- MCP servers connect in background by default (was: blocking up to 5s). Override: `MCP_CONNECTION_NONBLOCKING=0` env or per-server `alwaysLoad: true`.
+- Headless/SDK sessions emit `TaskCreate` / `TaskUpdate` / `TaskGet` / `TaskList` instead of `TodoWrite`.
+
+**API additions worth using (chronological):**
+- `0.1.62`: `skills` option on `ClaudeAgentOptions` (replaces `"Skill"` in `allowed_tools`)
+- `0.1.65`: `ThinkingConfig.display` field; `ServerToolUseBlock` / `AdvisorToolResultBlock` now emitted (previously dropped)
+- `0.1.71`: `SandboxNetworkConfig` domain allowlist fields
+- `0.1.73`: `session_store_flush` (`"batched"` / `"eager"`)
+- `0.1.74`: `include_hook_events`, `"defer"` hook decision, `strict_mcp_config`, `xhigh` effort level, atexit subprocess cleanup
+- `0.1.76`: `ResultMessage.api_error_status: int | None` (429/500/529)
+- `0.1.77`: Actionable error messages on `Command failed exit 1`; `"Skill"` allowed_tools deprecated
+- `0.2.82`: `EffortLevel` type export
+
+**Deprecations:**
+- `"Skill"` in `allowed_tools` → use `skills=` option (0.1.77)
+
+**Bug fixes inherited (no action):**
+- Trio compat restored (0.1.67), trio nursery corruption (0.1.70), ResourceWarning on disconnect (0.1.74), stderr callback isolation (0.2.82)
+
+**Dependency floor:**
+- `mcp>=1.23.0` required (0.2.82, CVE-2025-66416). **Already satisfied** — our `uv.lock` pins `mcp==1.26.0`.
+
+---
+
+## File Structure
+
+**Modified files:**
+- `pyproject.toml` — bump SDK pin
+- `uv.lock` — regenerate via `uv lock`
+- `src/backends/claude/constants.py` — update `CLAUDE_TOOLS` and `DEFAULT_ALLOWED_TOOLS`, add `Skill` option migration toggle
+- `src/backends/claude/client.py` — migrate `"Skill"` allowed_tools to `skills=` option in `_build_options`
+- `src/backends/claude/client.py` — (optional) wire `api_error_status` into error responses, expose `xhigh` for Opus 4.7
+- `tests/test_sdk_migration.py` — add tests for new Task tool catalog entries and `skills` option migration
+- `CHANGELOG.md` (create or update) — document downstream-breaking changes
+- `docs/api/breaking-changes.md` (create) — downstream consumer migration guide
+
+**Unchanged (intentional pass-through):**
+- `src/chunk_processing.py` — generic `hasattr(tb, "type")` fallback already handles new block types
+- `src/sse_builders.py` — pure pass-through
+
+**Environment toggle (deployment decision, not code):**
+- `MCP_CONNECTION_NONBLOCKING=0` if first-turn MCP tools are required
+
+---
+
+## Pre-Flight Checks
+
+Before starting, verify:
+
+- [ ] Working directory clean: `git status` shows no uncommitted changes
+- [ ] On `main` (or branch off `main`): `git branch --show-current`
+- [ ] Tests currently pass on 0.1.57: `uv run pytest -x -q tests/test_sdk_migration.py tests/test_claude_cli_unit.py`
+- [ ] Downstream inventory documented: who consumes this gateway's SSE API? (sync with team; this drives Task 9 urgency)
+
+If any check fails, resolve before proceeding.
+
+---
+
+## Task 1: Create feature branch and confirm baseline
+
+**Files:**
+- N/A (git only)
+
+- [ ] **Step 1: Create branch**
+
+Run:
+```bash
+git checkout -b chore/claude-agent-sdk-0.2.82
+```
+
+- [ ] **Step 2: Verify baseline tests pass on 0.1.57**
+
+Run:
+```bash
+uv run pytest -x -q
+```
+
+Expected: All tests pass. Note the count for comparison after upgrade.
+
+- [ ] **Step 3: Commit branch marker (no-op)**
+
+No-op step — branch already created in Step 1, nothing to commit yet. Proceed to Task 2.
+
+---
+
+## Task 2: Bump SDK pin and refresh lockfile
+
+**Files:**
+- Modify: `pyproject.toml` (find line with `"claude-agent-sdk==0.1.57"`)
+- Modify: `uv.lock` (regenerated)
+
+- [ ] **Step 1: Update pin**
+
+Edit `pyproject.toml`:
+- Find: `"claude-agent-sdk==0.1.57",`
+- Replace with: `"claude-agent-sdk==0.2.82",`
+
+- [ ] **Step 2: Regenerate lockfile**
+
+Run:
+```bash
+uv lock
+```
+
+Expected: `uv.lock` updated with `claude-agent-sdk==0.2.82` entry. No errors.
+
+- [ ] **Step 3: Sync environment**
+
+Run:
+```bash
+uv sync
+```
+
+Expected: New SDK installed. Verify:
+```bash
+uv run python -c "import claude_agent_sdk; print(claude_agent_sdk.__version__)"
+```
+Should print `0.2.82`.
+
+- [ ] **Step 4: Run baseline tests (expect some failures)**
+
+Run:
+```bash
+uv run pytest -x -q tests/test_sdk_migration.py tests/test_claude_cli_unit.py 2>&1 | tail -30
+```
+
+Expected: Most tests pass. Any failures here indicate import or API signature changes — note them, do NOT fix yet (we'll address systematically).
+
+- [ ] **Step 5: Commit pin bump**
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "chore(deps): bump claude-agent-sdk to 0.2.82"
+```
+
+---
+
+## Task 3: Add Task tools to allow-list (TDD)
+
+**Files:**
+- Test: `tests/test_sdk_migration.py` (add test class)
+- Modify: `src/backends/claude/constants.py:15-31` (`CLAUDE_TOOLS`) and `:35-44` (`DEFAULT_ALLOWED_TOOLS`)
+
+**Why:** From 0.2.82, the SDK emits `TaskCreate` / `TaskUpdate` / `TaskGet` / `TaskList` for task tracking. If these are not in `allowed_tools`, the model's task tracking is silently filtered out.
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_sdk_migration.py`:
+
+```python
+class TestTaskToolCatalog:
+    """Task tools must be present in tool catalog after 0.2.82 upgrade."""
+
+    def test_claude_tools_contains_task_tools(self):
+        from src.backends.claude.constants import CLAUDE_TOOLS
+
+        for tool in ("TaskCreate", "TaskUpdate", "TaskGet", "TaskList"):
+            assert tool in CLAUDE_TOOLS, f"{tool} missing from CLAUDE_TOOLS"
+
+    def test_default_allowed_tools_contains_task_tools(self):
+        from src.backends.claude.constants import DEFAULT_ALLOWED_TOOLS
+
+        for tool in ("TaskCreate", "TaskUpdate", "TaskGet", "TaskList"):
+            assert tool in DEFAULT_ALLOWED_TOOLS, f"{tool} missing from DEFAULT_ALLOWED_TOOLS"
+
+    def test_todowrite_retained_for_back_compat(self):
+        """TodoWrite stays in catalog; SDK no longer emits it but no harm leaving it."""
+        from src.backends.claude.constants import CLAUDE_TOOLS
+
+        assert "TodoWrite" in CLAUDE_TOOLS
+```
+
+- [ ] **Step 2: Run tests, confirm failure**
+
+Run:
+```bash
+uv run pytest tests/test_sdk_migration.py::TestTaskToolCatalog -v
+```
+
+Expected: 2 fail (`test_claude_tools_contains_task_tools`, `test_default_allowed_tools_contains_task_tools`), 1 pass (TodoWrite still present).
+
+- [ ] **Step 3: Update CLAUDE_TOOLS**
+
+Edit `src/backends/claude/constants.py:15-31`:
+
+Replace the `CLAUDE_TOOLS` block with:
+```python
+CLAUDE_TOOLS = [
+    "Task",  # Launch agents for complex tasks
+    "TaskCreate",  # Create task for tracking (replaces TodoWrite, 0.2.82+)
+    "TaskUpdate",  # Update task status (0.2.82+)
+    "TaskGet",  # Get task details (0.2.82+)
+    "TaskList",  # List tasks (0.2.82+)
+    "Bash",  # Execute bash commands
+    "Glob",  # File pattern matching
+    "Grep",  # Search file contents
+    "Read",  # Read files
+    "Edit",  # Edit files
+    "Write",  # Write files
+    "NotebookEdit",  # Edit Jupyter notebooks
+    "WebFetch",  # Fetch web content
+    "TodoWrite",  # Deprecated 0.2.82; retained for back-compat
+    "WebSearch",  # Search the web
+    "BashOutput",  # Get bash output
+    "KillShell",  # Kill bash shells
+    "Skill",  # Execute skills (deprecated 0.1.77 — see skills= option)
+    "SlashCommand",  # Execute slash commands
+]
+```
+
+- [ ] **Step 4: Update DEFAULT_ALLOWED_TOOLS**
+
+Edit `src/backends/claude/constants.py:35-44`:
+
+Replace with:
+```python
+DEFAULT_ALLOWED_TOOLS = [
+    "Read",
+    "Glob",
+    "Grep",
+    "Bash",
+    "Write",
+    "Edit",
+    "Skill",
+    "TaskCreate",
+    "TaskUpdate",
+    "TaskGet",
+    "TaskList",
+    "TodoWrite",  # back-compat; SDK 0.2.82+ does not emit this
+]
+```
+
+- [ ] **Step 5: Run tests, confirm pass**
+
+Run:
+```bash
+uv run pytest tests/test_sdk_migration.py::TestTaskToolCatalog -v
+```
+
+Expected: All 3 pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/backends/claude/constants.py tests/test_sdk_migration.py
+git commit -m "feat(claude): add Task* tools to allow-list for SDK 0.2.82"
+```
+
+---
+
+## Task 4: Decide MCP nonblocking strategy (deployment + docs only)
+
+**Files:**
+- Modify: `src/backends/claude/constants.py` (add doc comment block)
+- (optional) Modify: deployment docs/env example
+
+**Why:** 0.2.82 starts sessions before MCP servers connect. Pending servers report `status: "pending"`. We need an explicit team decision and runtime toggle path. Default: accept new behavior; provide override.
+
+- [ ] **Step 1: Add documentation block to constants.py**
+
+Append to the end of `src/backends/claude/constants.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# MCP Connection Behavior (claude-agent-sdk 0.2.82+)
+# ---------------------------------------------------------------------------
+# By default, MCP servers connect in the background; sessions start
+# immediately and slow servers report ``status: "pending"`` in init.
+#
+# To restore pre-0.2.82 behavior (wait up to 5s before first query), set:
+#     MCP_CONNECTION_NONBLOCKING=0
+#
+# Alternative: mark a specific server with ``alwaysLoad: true`` in the
+# mcp_servers config so the SDK waits for that server in turn 1.
+#
+# We accept the new default; downstream consumers must handle ``pending``
+# server state in init messages. See docs/api/breaking-changes.md.
+```
+
+- [ ] **Step 2: Confirm no MCP config code change needed**
+
+Run:
+```bash
+grep -n "alwaysLoad\|MCP_CONNECTION_NONBLOCKING" /home/jinyoung/oh-my-gateway/src/backends/claude/client.py
+```
+
+Expected: no matches. We pass MCP server dicts through to the SDK as-is, so per-server `alwaysLoad: true` is a config-file decision by consumers, not a code change in the gateway.
+
+- [ ] **Step 3: Commit doc block**
+
+```bash
+git add src/backends/claude/constants.py
+git commit -m "docs(claude): document MCP nonblocking behavior in 0.2.82"
+```
+
+---
+
+## Task 5: Migrate `"Skill"` allow-list to `skills=` option (TDD)
+
+**Files:**
+- Test: `tests/test_sdk_migration.py` (add test)
+- Modify: `src/backends/claude/client.py` — `_build_options` (around line 356-385)
+
+**Why:** 0.1.77 deprecated `"Skill"` in `allowed_tools`. The replacement is `skills="all" | [list of names] | []` on `ClaudeAgentOptions` (0.1.62). Migrating now eliminates a deprecation warning and gives finer-grained control.
+
+- [ ] **Step 1: Read the existing `_build_options` to find insertion point**
+
+Run:
+```bash
+sed -n '340,395p' /home/jinyoung/oh-my-gateway/src/backends/claude/client.py
+```
+
+Note the existing signature and where `options.allowed_tools` is set in `_configure_tools` (around line 195-199).
+
+- [ ] **Step 2: Write failing test**
+
+Append to `tests/test_sdk_migration.py`:
+
+```python
+class TestSkillsOptionMigration:
+    """`Skill` allowed_tools entry should be transformed into `skills="all"`."""
+
+    def test_skill_in_allowed_tools_sets_skills_all(self):
+        from claude_agent_sdk import ClaudeAgentOptions
+        from src.backends.claude.client import ClaudeBackend
+
+        backend = ClaudeBackend.__new__(ClaudeBackend)  # avoid __init__ side effects
+        options = ClaudeAgentOptions(max_turns=1)
+        backend._configure_tools(
+            options,
+            allowed_tools=["Read", "Skill", "Bash"],
+            disallowed_tools=None,
+        )
+
+        assert "Skill" not in (options.allowed_tools or [])
+        assert getattr(options, "skills", None) == "all"
+
+    def test_no_skill_keeps_skills_unset(self):
+        from claude_agent_sdk import ClaudeAgentOptions
+        from src.backends.claude.client import ClaudeBackend
+
+        backend = ClaudeBackend.__new__(ClaudeBackend)
+        options = ClaudeAgentOptions(max_turns=1)
+        backend._configure_tools(
+            options,
+            allowed_tools=["Read", "Bash"],
+            disallowed_tools=None,
+        )
+
+        assert getattr(options, "skills", None) is None
+```
+
+- [ ] **Step 3: Run test, confirm failure**
+
+Run:
+```bash
+uv run pytest tests/test_sdk_migration.py::TestSkillsOptionMigration -v
+```
+
+Expected: Both fail — `Skill` is still in `allowed_tools` and `options.skills` is None.
+
+- [ ] **Step 4: Implement migration in `_configure_tools`**
+
+Edit `src/backends/claude/client.py`, in `_configure_tools` (around line 188-201). Replace the method body with:
+
+```python
+    def _configure_tools(
+        self,
+        options: ClaudeAgentOptions,
+        allowed_tools: Optional[List[str]],
+        disallowed_tools: Optional[List[str]],
+    ) -> None:
+        """Apply tool allow/disallow lists to *options*.
+
+        Translates the deprecated ``"Skill"`` entry in ``allowed_tools`` into
+        the modern ``skills="all"`` option (claude-agent-sdk 0.1.62+).
+        """
+        if allowed_tools:
+            filtered = [t for t in allowed_tools if t not in DISALLOWED_TOOLS]
+            if "Skill" in filtered:
+                filtered = [t for t in filtered if t != "Skill"]
+                options.skills = "all"
+            options.allowed_tools = filtered
+        base_disallowed = list(DISALLOWED_SUBAGENT_TYPES) + list(DISALLOWED_TOOLS)
+        if disallowed_tools:
+            base_disallowed.extend(disallowed_tools)
+        if base_disallowed:
+            seen: set[str] = set()
+            options.disallowed_tools = [t for t in base_disallowed if not (t in seen or seen.add(t))]
+```
+
+- [ ] **Step 5: Run test, confirm pass**
+
+Run:
+```bash
+uv run pytest tests/test_sdk_migration.py::TestSkillsOptionMigration -v
+```
+
+Expected: Both pass.
+
+- [ ] **Step 6: Run full SDK migration test suite for regressions**
+
+Run:
+```bash
+uv run pytest tests/test_sdk_migration.py tests/test_claude_cli_unit.py -v 2>&1 | tail -40
+```
+
+Expected: All pass. Any failure here means `_configure_tools` interactions with other call sites are affected — investigate before continuing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/backends/claude/client.py tests/test_sdk_migration.py
+git commit -m "refactor(claude): migrate Skill allow-list entry to skills= option"
+```
+
+---
+
+## Task 6: Run full test suite and address regressions
+
+**Files:**
+- (depends on what fails)
+
+- [ ] **Step 1: Run full suite, capture output**
+
+Run:
+```bash
+uv run pytest 2>&1 | tee /tmp/sdk-upgrade-pytest.log | tail -80
+```
+
+Expected outcome categories:
+- ✅ All pass → proceed to Task 7
+- ⚠️ Failures in `test_ask_user_question_live.py` requiring live API — skip those (requires API key); confirm they were skipped not errored
+- ❌ Real failures → diagnose individually below
+
+- [ ] **Step 2: For each non-live failure, diagnose**
+
+For each failing test, identify category:
+
+**Category A — SDK API rename/removal:**
+- Find the missing symbol: `uv run python -c "from claude_agent_sdk import <symbol>"`
+- Cross-reference release notes 0.1.58–0.2.82 for the rename
+- Update import and minimal usage in test or source
+
+**Category B — Block type assertion changes:**
+- New block types `ServerToolUseBlock`/`AdvisorToolResultBlock` may now appear where they were silently dropped before. Update assertions to either filter them out or include them as expected types.
+
+**Category C — Behavioral change:**
+- Look up release notes for the area; decide if test should be updated to reflect new behavior or if our code needs a compensating change.
+
+- [ ] **Step 3: Fix one failure at a time with a commit per fix**
+
+For each fix:
+```bash
+# make the fix
+uv run pytest <specific test> -v  # verify
+git add <files>
+git commit -m "fix(claude): <one-line summary of fix>"
+```
+
+- [ ] **Step 4: Re-run full suite**
+
+Run:
+```bash
+uv run pytest 2>&1 | tail -20
+```
+
+Expected: All non-live tests pass.
+
+---
+
+## Task 7: (Optional) Surface `api_error_status` and `xhigh` effort level
+
+**Files:**
+- Modify: `src/backends/claude/client.py` — wherever `ResultMessage` is handled
+- Modify: `src/backends/claude/constants.py` — `CLAUDE_MODELS` or new effort config
+
+**Skip this task** if there is no immediate consumer for the new fields. These are quality-of-life improvements, not migration blockers. If skipping, jump to Task 8.
+
+- [ ] **Step 1: Locate ResultMessage handling**
+
+Run:
+```bash
+grep -rn "ResultMessage\|is_error" /home/jinyoung/oh-my-gateway/src/backends/claude/ | head -20
+```
+
+- [ ] **Step 2: Add `api_error_status` propagation**
+
+In the file where `ResultMessage` is converted to an error response (likely `client.py` or an error-mapping helper), add:
+
+```python
+status = getattr(result_msg, "api_error_status", None)
+if status is not None:
+    error_payload["api_error_status"] = status  # downstream sees 429/500/529 separately
+```
+
+- [ ] **Step 3: Test with mock**
+
+Add to `tests/test_claude_cli_unit.py`:
+
+```python
+def test_api_error_status_propagated(self):
+    from claude_agent_sdk.types import ResultMessage
+
+    msg = ResultMessage.__new__(ResultMessage)
+    msg.is_error = True
+    msg.api_error_status = 429
+    # ... assert your conversion logic surfaces 429 in the output
+```
+
+(Adapt to your actual error-mapping function signature.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/backends/claude/ tests/
+git commit -m "feat(claude): surface api_error_status for downstream error classification"
+```
+
+- [ ] **Step 5: (Optional) Expose `xhigh` effort for Opus 4.7**
+
+Only if you currently expose effort levels through your request schema. Locate where effort is parsed and add `"xhigh"` to the accepted values. Verify SDK accepts it:
+
+```python
+from claude_agent_sdk import ClaudeAgentOptions
+options = ClaudeAgentOptions(max_turns=1)
+options.effort = "xhigh"  # type: ignore  # SDK 0.1.74+
+```
+
+Commit:
+```bash
+git commit -am "feat(claude): accept xhigh effort level (Opus 4.7)"
+```
+
+---
+
+## Task 8: Document breaking changes for downstream API consumers
+
+**Files:**
+- Create: `docs/api/breaking-changes.md`
+- Modify: `CHANGELOG.md` (if exists) or create
+
+**Why:** Option A propagates SDK breaking changes to our API consumers. They need a clear migration guide.
+
+- [ ] **Step 1: Check for existing CHANGELOG**
+
+Run:
+```bash
+ls /home/jinyoung/oh-my-gateway/CHANGELOG.md 2>/dev/null
+ls /home/jinyoung/oh-my-gateway/docs/ 2>/dev/null
+```
+
+If `CHANGELOG.md` exists, append a new section. Otherwise create `docs/api/breaking-changes.md`.
+
+- [ ] **Step 2: Write the breaking-changes document**
+
+Create `docs/api/breaking-changes.md` with the following content:
+
+```markdown
+# Breaking Changes for API Consumers
+
+## 2026-05-XX — Claude Agent SDK 0.2.82 upgrade
+
+### Tool name changes in `response.tool_use` events
+
+The Claude backend now emits the following tool names in `response.tool_use` SSE events instead of `TodoWrite`:
+
+- `TaskCreate` — create a task (input: `{title, description, status}`)
+- `TaskUpdate` — update task status (input: `{task_id, status, ...}`)
+- `TaskGet` — fetch a single task by id
+- `TaskList` — list all tasks
+
+**Required client changes:**
+
+1. **Recognize the new tool names.** Clients that previously branched on `tool_use.name == "TodoWrite"` must also handle `TaskCreate` / `TaskUpdate` / `TaskGet` / `TaskList`.
+2. **Switch from snapshot-replace to per-id accumulation.** `TodoWrite` emitted a full snapshot of all todos on every call; the new events are deltas keyed by task id. Maintain a `Map<task_id, task>` and apply each event:
+   - `TaskCreate`: insert
+   - `TaskUpdate`: update by id
+   - (others: as semantically appropriate)
+3. **`TodoWrite` may still appear from older sessions or back-compat paths.** Treat it as a snapshot for legacy data.
+
+### MCP server `init` may include pending servers
+
+Sessions now start before MCP servers finish connecting. The `init` system message may list servers with `status: "pending"`. Clients that surface MCP server state should reflect this transitional state rather than treating non-`"ready"` as an error.
+
+To force the previous behavior (block on MCP connect), set `MCP_CONNECTION_NONBLOCKING=0` in the gateway environment, or mark individual servers `alwaysLoad: true` in your MCP config.
+
+### New block types may appear in assistant content
+
+The SDK now emits `server_tool_use` and `advisor_tool_result` blocks (previously silently dropped). These pass through to clients unchanged. Clients that exhaustively switch on block `type` should add cases for these (or use a default fallback).
+
+### `api_error_status` on error responses
+
+Error responses now include `api_error_status: 429 | 500 | 529 | null` when the underlying API call failed. Useful for distinguishing rate-limit from server errors.
+
+---
+
+## Why the gateway propagates these changes
+
+This gateway is intentionally a thin pass-through over `claude-agent-sdk`. We do not insert a compatibility shim because:
+- Shims hide useful new fields (e.g., `pending` MCP status).
+- Each shim adds maintenance cost that scales with upstream changes.
+- Downstream consumers tend to want the latest SDK semantics.
+
+If you need a compatibility layer in your own client, build it client-side.
+```
+
+- [ ] **Step 3: Commit doc**
+
+```bash
+git add docs/api/breaking-changes.md
+git commit -m "docs(api): document 0.2.82 downstream breaking changes"
+```
+
+---
+
+## Task 9: Smoke test against a running backend
+
+**Files:** N/A (manual verification)
+
+- [ ] **Step 1: Boot the gateway locally**
+
+Run:
+```bash
+uv run uvicorn src.main:app --reload --port 8000 &
+```
+
+Wait for "Application startup complete".
+
+- [ ] **Step 2: Hit the Claude endpoint with a simple prompt that triggers task tracking**
+
+Run:
+```bash
+curl -N -X POST http://localhost:8000/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "claude-opus-4-7",
+    "input": "Plan and execute these three steps: list files, count them, report the count.",
+    "stream": true
+  }' 2>&1 | head -100
+```
+
+- [ ] **Step 3: Verify the SSE stream contains `TaskCreate` events**
+
+Look for `event: response.tool_use` lines with `"name": "TaskCreate"` (or `TaskUpdate`).
+
+Expected: At least one `TaskCreate` event appears (model self-tracks the 3-step plan).
+
+If only `TodoWrite` appears, the upgrade hasn't activated the new tool names — check the SDK version and `DEFAULT_ALLOWED_TOOLS`.
+
+- [ ] **Step 4: Verify init event shows MCP server states**
+
+If MCP servers are configured, look at the `init` system message. New `status: "pending"` entries are expected for slow-starting servers.
+
+- [ ] **Step 5: Shut down gateway**
+
+```bash
+kill %1
+```
+
+- [ ] **Step 6: If anything anomalous, file an issue / fix**
+
+If smoke test reveals problems, fix and add a regression test to `tests/test_sdk_migration.py`.
+
+---
+
+## Task 10: Open PR and request review
+
+**Files:** N/A (PR creation)
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin chore/claude-agent-sdk-0.2.82
+```
+
+- [ ] **Step 2: Create PR**
+
+```bash
+gh pr create --title "chore(deps): upgrade claude-agent-sdk 0.1.57 → 0.2.82" --body "$(cat <<'EOF'
+## Summary
+- Bumps `claude-agent-sdk` from `0.1.57` to `0.2.82`.
+- Adds new `Task*` tools to allow-list (`TaskCreate` / `TaskUpdate` / `TaskGet` / `TaskList`); SDK 0.2.82 emits these instead of `TodoWrite`.
+- Migrates `"Skill"` allow-list entry to the modern `skills="all"` option on `ClaudeAgentOptions` (was deprecated in 0.1.77).
+- Documents downstream-breaking changes for API consumers (see `docs/api/breaking-changes.md`).
+
+## Pass-through philosophy
+Per [[gateway-passthrough-philosophy]] (project convention), no compatibility adapters are added. SDK breaking changes propagate to our API consumers, who handle them client-side.
+
+## Downstream impact (requires consumer changes)
+- `tool_use.name`: `TodoWrite` → `TaskCreate` / `TaskUpdate` / `TaskGet` / `TaskList`
+- MCP `init` may include `status: "pending"` servers
+- New block types `server_tool_use` / `advisor_tool_result` may appear
+
+## Test plan
+- [x] Unit tests pass: `uv run pytest`
+- [x] Manual smoke test against `claude-opus-4-7` endpoint shows `TaskCreate` events
+- [ ] Reviewer: confirm downstream consumers (list them) are aware of breaking changes
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 2: Verify PR URL returned**
+
+Confirm `gh pr create` outputs a URL. Share with team.
+
+---
+
+## Self-Review (run before handing off)
+
+- [ ] **Spec coverage:** Every breaking change in 0.2.82 → covered? (✅ Task 3 covers TodoWrite→Task; Task 4 covers MCP nonblocking; ServerToolUseBlock/AdvisorToolResultBlock covered by existing generic fallback + documented in Task 8.)
+- [ ] **Deprecations:** `"Skill"` allowed_tools → covered in Task 5.
+- [ ] **mcp version floor:** `>=1.23.0` — already satisfied (1.26.0), noted in Release Highlights.
+- [ ] **Downstream contract:** documented in Task 8.
+- [ ] **Tests:** TDD pattern used in Tasks 3 and 5; full-suite gate in Task 6.
+- [ ] **Placeholders:** none — every code change has exact code and exact commands.
+
+---
+
+## Out of Scope (defer to follow-up)
+
+Features available in 0.1.62–0.2.82 worth considering later, but **not** required for the upgrade:
+
+- `SessionStore` adapter (0.1.64) — for cross-process resume, S3/Redis/Postgres backends
+- `session_store_flush="eager"` (0.1.73) — for live-tailing UIs
+- `include_hook_events` (0.1.74) — for surfacing hook events to clients
+- `"defer"` hook decision + `DeferredToolUse` (0.1.74) — for two-stage permission UX
+- `strict_mcp_config` (0.1.74) — for deterministic test sandboxes
+- `ThinkingConfig.display="summarized"` (0.1.65) — to surface Opus 4.7 thinking text
+- Distributed tracing via OTel (0.1.60) — `pip install claude-agent-sdk[otel]`
+
+Each deserves its own brainstorm + plan.

--- a/docs/superpowers/plans/2026-05-16-claude-agent-sdk-upgrade.md
+++ b/docs/superpowers/plans/2026-05-16-claude-agent-sdk-upgrade.md
@@ -4,7 +4,7 @@
 
 **Goal:** Upgrade `claude-agent-sdk` from 0.1.57 to 0.2.82 with adjustments to tool allow-lists, MCP connection behavior, and Skill option migration, while preserving the gateway's pass-through philosophy and documenting breaking changes for downstream API consumers.
 
-**Architecture:** Adopt **Option A (pass-through)** — no compatibility adapters added to the gateway. Update `src/backends/claude/constants.py` tool catalog for the new Task tools, leave `chunk_processing.py` / `sse_builders.py` untouched (generic fallback handles new block types), migrate from deprecated `"Skill"` allowed_tools entry to the new `skills` option on `ClaudeAgentOptions`, and surface new SDK features incrementally. Downstream breaking changes are documented for API consumers to handle.
+**Architecture:** Adopt **Option A (pass-through)** — no compatibility adapters added to the gateway. Update `src/backends/claude/constants.py` tool catalog for the new Task tools, preserve new server-side tool block types through chunk processing/streaming, migrate from deprecated `"Skill"` allowed_tools entry to the new `skills` option on `ClaudeAgentOptions`, and surface new SDK features incrementally. Downstream breaking changes are documented for API consumers to handle.
 
 **Tech Stack:** Python 3.x, `uv` for dependency management, `pytest` (asyncio_mode=auto), `claude-agent-sdk`, FastAPI, SSE.
 
@@ -12,9 +12,9 @@
 
 ## Release Highlights (0.1.58 → 0.2.82)
 
-**Breaking changes (0.2.82):**
+**Downstream-visible changes (0.2.82):**
 - MCP servers connect in background by default (was: blocking up to 5s). Override: `MCP_CONNECTION_NONBLOCKING=0` env or per-server `alwaysLoad: true`.
-- Headless/SDK sessions emit `TaskCreate` / `TaskUpdate` / `TaskGet` / `TaskList` instead of `TodoWrite`.
+- Headless/SDK sessions still emit `TodoWrite` by default. The new `TaskCreate` / `TaskUpdate` / `TaskGet` / `TaskList` family is available when the CLI subprocess env includes `CLAUDE_CODE_ENABLE_TASKS=1`.
 
 **API additions worth using (chronological):**
 - `0.1.62`: `skills` option on `ClaudeAgentOptions` (replaces `"Skill"` in `allowed_tools`)
@@ -156,7 +156,7 @@ git commit -m "chore(deps): bump claude-agent-sdk to 0.2.82"
 - Test: `tests/test_sdk_migration.py` (add test class)
 - Modify: `src/backends/claude/constants.py:15-31` (`CLAUDE_TOOLS`) and `:35-44` (`DEFAULT_ALLOWED_TOOLS`)
 
-**Why:** From 0.2.82, the SDK emits `TaskCreate` / `TaskUpdate` / `TaskGet` / `TaskList` for task tracking. If these are not in `allowed_tools`, the model's task tracking is silently filtered out.
+**Why:** 0.2.82 includes the opt-in `TaskCreate` / `TaskUpdate` / `TaskGet` / `TaskList` task-tracking tools. If an operator enables them with `CLAUDE_CODE_ENABLE_TASKS=1` and these tools are not in `allowed_tools`, task tracking may be filtered out. `TodoWrite` remains allowed because it is still the SDK/`claude -p` default.
 
 - [ ] **Step 1: Write failing tests**
 
@@ -178,8 +178,8 @@ class TestTaskToolCatalog:
         for tool in ("TaskCreate", "TaskUpdate", "TaskGet", "TaskList"):
             assert tool in DEFAULT_ALLOWED_TOOLS, f"{tool} missing from DEFAULT_ALLOWED_TOOLS"
 
-    def test_todowrite_retained_for_back_compat(self):
-        """TodoWrite stays in catalog; SDK no longer emits it but no harm leaving it."""
+    def test_todowrite_retained_as_default(self):
+        """TodoWrite remains default; Task* require CLAUDE_CODE_ENABLE_TASKS=1."""
         from src.backends.claude.constants import CLAUDE_TOOLS
 
         assert "TodoWrite" in CLAUDE_TOOLS
@@ -202,10 +202,10 @@ Replace the `CLAUDE_TOOLS` block with:
 ```python
 CLAUDE_TOOLS = [
     "Task",  # Launch agents for complex tasks
-    "TaskCreate",  # Create task for tracking (replaces TodoWrite, 0.2.82+)
-    "TaskUpdate",  # Update task status (0.2.82+)
-    "TaskGet",  # Get task details (0.2.82+)
-    "TaskList",  # List tasks (0.2.82+)
+    "TaskCreate",  # Task tracking (0.2.82+, opt-in via CLAUDE_CODE_ENABLE_TASKS=1)
+    "TaskUpdate",  # Task tracking (0.2.82+, opt-in via CLAUDE_CODE_ENABLE_TASKS=1)
+    "TaskGet",  # Task tracking (0.2.82+, opt-in via CLAUDE_CODE_ENABLE_TASKS=1)
+    "TaskList",  # Task tracking (0.2.82+, opt-in via CLAUDE_CODE_ENABLE_TASKS=1)
     "Bash",  # Execute bash commands
     "Glob",  # File pattern matching
     "Grep",  # Search file contents
@@ -214,11 +214,11 @@ CLAUDE_TOOLS = [
     "Write",  # Write files
     "NotebookEdit",  # Edit Jupyter notebooks
     "WebFetch",  # Fetch web content
-    "TodoWrite",  # Deprecated 0.2.82; retained for back-compat
+    "TodoWrite",  # Default task-tracking tool when CLAUDE_CODE_ENABLE_TASKS is unset
     "WebSearch",  # Search the web
     "BashOutput",  # Get bash output
     "KillShell",  # Kill bash shells
-    "Skill",  # Execute skills (deprecated 0.1.77 — see skills= option)
+    "Skill",  # Execute skills (deprecated 0.1.77 — translated to skills= option)
     "SlashCommand",  # Execute slash commands
 ]
 ```
@@ -241,7 +241,7 @@ DEFAULT_ALLOWED_TOOLS = [
     "TaskUpdate",
     "TaskGet",
     "TaskList",
-    "TodoWrite",  # back-compat; SDK 0.2.82+ does not emit this
+    "TodoWrite",
 ]
 ```
 
@@ -576,23 +576,23 @@ Create `docs/api/breaking-changes.md` with the following content:
 
 ## 2026-05-XX — Claude Agent SDK 0.2.82 upgrade
 
-### Tool name changes in `response.tool_use` events
+### Task tools are now available (opt-in)
 
-The Claude backend now emits the following tool names in `response.tool_use` SSE events instead of `TodoWrite`:
+claude-agent-sdk 0.2.82 ships a new task-tracking tool family (`TaskCreate` / `TaskUpdate` / `TaskGet` / `TaskList`) alongside the legacy `TodoWrite`. The bundled Claude CLI gates these behind the `CLAUDE_CODE_ENABLE_TASKS` env var:
 
-- `TaskCreate` — create a task (input: `{title, description, status}`)
-- `TaskUpdate` — update task status (input: `{task_id, status, ...}`)
-- `TaskGet` — fetch a single task by id
-- `TaskList` — list all tasks
+- **Env unset (default)** — `TodoWrite` remains the only task-tracking tool emitted. No `response.tool_use` payload changes for existing clients.
+- **`CLAUDE_CODE_ENABLE_TASKS=1`** — the SDK emits `TaskCreate` / `TaskUpdate` / `TaskGet` / `TaskList` instead. The gateway does not set this env automatically; operators choose per deployment.
 
-**Required client changes:**
+Schemas observed in this SDK version:
 
-1. **Recognize the new tool names.** Clients that previously branched on `tool_use.name == "TodoWrite"` must also handle `TaskCreate` / `TaskUpdate` / `TaskGet` / `TaskList`.
-2. **Switch from snapshot-replace to per-id accumulation.** `TodoWrite` emitted a full snapshot of all todos on every call; the new events are deltas keyed by task id. Maintain a `Map<task_id, task>` and apply each event:
-   - `TaskCreate`: insert
-   - `TaskUpdate`: update by id
-   - (others: as semantically appropriate)
-3. **`TodoWrite` may still appear from older sessions or back-compat paths.** Treat it as a snapshot for legacy data.
+| Tool | Input fields | id source |
+|---|---|---|
+| `TaskCreate` | `subject`, `description`, `activeForm?` (status is auto-`pending`) | returned in the matching `tool_result.content` as the created task record (for example, `{ "task": { "id": "...", "subject": "..." } }`), not in the `input` |
+| `TaskUpdate` | `taskId`, plus any of `status`, `subject`, `description`, `activeForm`, `owner`, `addBlocks`, `addBlockedBy`, `metadata` | n/a (caller supplies `taskId`) |
+| `TaskGet` | `taskId` | n/a |
+| `TaskList` | (no required input) | n/a |
+
+`Task*` events are per-id deltas (the CLI maintains task state on disk); `TodoWrite` events are full snapshots. Clients that want to render Task* should accumulate by `taskId`. Clients that only handle `TodoWrite` keep working as long as `CLAUDE_CODE_ENABLE_TASKS` stays unset.
 
 ### MCP server `init` may include pending servers
 
@@ -606,7 +606,7 @@ The SDK now emits `server_tool_use` and `advisor_tool_result` blocks (previously
 
 ### `api_error_status` on error responses
 
-Error responses now include `api_error_status: 429 | 500 | 529 | null` when the underlying API call failed. Useful for distinguishing rate-limit from server errors.
+The underlying `ResultMessage` exposes an `api_error_status: int | None` field surfacing the HTTP status (429, 500, 529) when the API call failed. The gateway does not yet propagate this to its downstream payload, but a follow-up may do so; clients planning to distinguish rate-limit from server errors should request it.
 
 ---
 
@@ -655,13 +655,13 @@ curl -N -X POST http://localhost:8000/v1/responses \
   }' 2>&1 | head -100
 ```
 
-- [ ] **Step 3: Verify the SSE stream contains `TaskCreate` events**
+- [ ] **Step 3: Optionally verify Task tool SSE events**
 
-Look for `event: response.tool_use` lines with `"name": "TaskCreate"` (or `TaskUpdate`).
+If validating the opt-in Task tool path, start the gateway with `CLAUDE_CODE_ENABLE_TASKS=1` in the CLI subprocess environment and look for `event: response.tool_use` lines with `"name": "TaskCreate"` (or `TaskUpdate`).
 
-Expected: At least one `TaskCreate` event appears (model self-tracks the 3-step plan).
+Expected with the env set: at least one `TaskCreate` event may appear when the model self-tracks the 3-step plan.
 
-If only `TodoWrite` appears, the upgrade hasn't activated the new tool names — check the SDK version and `DEFAULT_ALLOWED_TOOLS`.
+Expected with the env unset: `TodoWrite` remains the default task-tracking event. This is intentional for compatibility.
 
 - [ ] **Step 4: Verify init event shows MCP server states**
 
@@ -695,7 +695,7 @@ git push -u origin chore/claude-agent-sdk-0.2.82
 gh pr create --title "chore(deps): upgrade claude-agent-sdk 0.1.57 → 0.2.82" --body "$(cat <<'EOF'
 ## Summary
 - Bumps `claude-agent-sdk` from `0.1.57` to `0.2.82`.
-- Adds new `Task*` tools to allow-list (`TaskCreate` / `TaskUpdate` / `TaskGet` / `TaskList`); SDK 0.2.82 emits these instead of `TodoWrite`.
+- Adds new `Task*` tools to allow-list (`TaskCreate` / `TaskUpdate` / `TaskGet` / `TaskList`); the bundled CLI emits these only when `CLAUDE_CODE_ENABLE_TASKS=1` is set. Default deployments keep `TodoWrite`.
 - Migrates `"Skill"` allow-list entry to the modern `skills="all"` option on `ClaudeAgentOptions` (was deprecated in 0.1.77).
 - Documents downstream-breaking changes for API consumers (see `docs/api/breaking-changes.md`).
 
@@ -703,13 +703,13 @@ gh pr create --title "chore(deps): upgrade claude-agent-sdk 0.1.57 → 0.2.82" -
 Per [[gateway-passthrough-philosophy]] (project convention), no compatibility adapters are added. SDK breaking changes propagate to our API consumers, who handle them client-side.
 
 ## Downstream impact (requires consumer changes)
-- `tool_use.name`: `TodoWrite` → `TaskCreate` / `TaskUpdate` / `TaskGet` / `TaskList`
+- `Task*` tool events are opt-in via `CLAUDE_CODE_ENABLE_TASKS=1`; default deployments keep emitting `TodoWrite`
 - MCP `init` may include `status: "pending"` servers
 - New block types `server_tool_use` / `advisor_tool_result` may appear
 
 ## Test plan
 - [x] Unit tests pass: `uv run pytest`
-- [x] Manual smoke test against `claude-opus-4-7` endpoint shows `TaskCreate` events
+- [x] Manual smoke test against `claude-opus-4-7` endpoint shows `TaskCreate` events when Task tools are enabled
 - [ ] Reviewer: confirm downstream consumers (list them) are aware of breaking changes
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
@@ -725,7 +725,7 @@ Confirm `gh pr create` outputs a URL. Share with team.
 
 ## Self-Review (run before handing off)
 
-- [ ] **Spec coverage:** Every breaking change in 0.2.82 → covered? (✅ Task 3 covers TodoWrite→Task; Task 4 covers MCP nonblocking; ServerToolUseBlock/AdvisorToolResultBlock covered by existing generic fallback + documented in Task 8.)
+- [ ] **Spec coverage:** Every downstream-visible change in 0.2.82 → covered? (✅ Task 3 covers Task tool opt-in while retaining TodoWrite; Task 4 covers MCP nonblocking; ServerToolUseBlock/AdvisorToolResultBlock covered by streaming preservation + documented in Task 8.)
 - [ ] **Deprecations:** `"Skill"` allowed_tools → covered in Task 5.
 - [ ] **mcp version floor:** `>=1.23.0` — already satisfied (1.26.0), noted in Release Highlights.
 - [ ] **Downstream contract:** documented in Task 8.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "httpx>=0.27.2",
     "sse-starlette>=2.1.3",
     "python-multipart>=0.0.18",
-    "claude-agent-sdk==0.1.57",
+    "claude-agent-sdk==0.2.82",
     "slowapi>=0.1.9",
     "pyyaml>=6.0",
     "sqlalchemy[asyncio]>=2.0.0",

--- a/src/backends/claude/client.py
+++ b/src/backends/claude/client.py
@@ -191,9 +191,17 @@ class ClaudeCodeCLI:
         allowed_tools: Optional[List[str]],
         disallowed_tools: Optional[List[str]],
     ) -> None:
-        """Apply tool allow/disallow lists to *options*."""
+        """Apply tool allow/disallow lists to *options*.
+
+        Translates the deprecated ``"Skill"`` entry in ``allowed_tools`` into
+        the modern ``skills="all"`` option (claude-agent-sdk 0.1.62+).
+        """
         if allowed_tools:
-            options.allowed_tools = [t for t in allowed_tools if t not in DISALLOWED_TOOLS]
+            filtered = [t for t in allowed_tools if t not in DISALLOWED_TOOLS]
+            if "Skill" in filtered:
+                filtered = [t for t in filtered if t != "Skill"]
+                options.skills = "all"
+            options.allowed_tools = filtered
         base_disallowed = list(DISALLOWED_SUBAGENT_TYPES) + list(DISALLOWED_TOOLS)
         if disallowed_tools:
             base_disallowed.extend(disallowed_tools)

--- a/src/backends/claude/client.py
+++ b/src/backends/claude/client.py
@@ -197,17 +197,23 @@ class ClaudeCodeCLI:
         the modern ``skills="all"`` option (claude-agent-sdk 0.1.62+).
         """
         if allowed_tools:
-            filtered = [t for t in allowed_tools if t not in DISALLOWED_TOOLS]
-            if "Skill" in filtered:
-                filtered = [t for t in filtered if t != "Skill"]
-                options.skills = "all"
-            options.allowed_tools = filtered
+            self._set_allowed_tools(options, allowed_tools)
         base_disallowed = list(DISALLOWED_SUBAGENT_TYPES) + list(DISALLOWED_TOOLS)
         if disallowed_tools:
             base_disallowed.extend(disallowed_tools)
         if base_disallowed:
             seen: set[str] = set()
-            options.disallowed_tools = [t for t in base_disallowed if not (t in seen or seen.add(t))]
+            options.disallowed_tools = [
+                t for t in base_disallowed if not (t in seen or seen.add(t))
+            ]
+
+    def _set_allowed_tools(self, options: ClaudeAgentOptions, tools: List[str]) -> None:
+        """Set allowed_tools while translating deprecated Skill access."""
+        filtered = [t for t in tools if t not in DISALLOWED_TOOLS]
+        if "Skill" in filtered:
+            filtered = [t for t in filtered if t != "Skill"]
+            options.skills = "all"
+        options.allowed_tools = filtered
 
     def _configure_sandbox(self, options: ClaudeAgentOptions) -> None:
         """Apply bash sandbox configuration to *options*.
@@ -307,7 +313,7 @@ class ClaudeCodeCLI:
         options.mcp_servers = mcp_servers
         mcp_patterns = get_mcp_tool_patterns(mcp_servers)
         if not options.allowed_tools:
-            options.allowed_tools = list(DEFAULT_ALLOWED_TOOLS)
+            self._set_allowed_tools(options, list(DEFAULT_ALLOWED_TOOLS))
         options.allowed_tools.extend(mcp_patterns)
         logger.debug(f"MCP tools enabled: {mcp_patterns}")
 

--- a/src/backends/claude/constants.py
+++ b/src/backends/claude/constants.py
@@ -165,3 +165,18 @@ CLAUDE_SANDBOX_NETWORK_ALLOW_LOCAL: bool = _parse_sandbox_bool(
 )
 
 CLAUDE_SANDBOX_WEAKER_NESTED: bool = _parse_sandbox_bool("CLAUDE_SANDBOX_WEAKER_NESTED", "false")
+
+# ---------------------------------------------------------------------------
+# MCP Connection Behavior (claude-agent-sdk 0.2.82+)
+# ---------------------------------------------------------------------------
+# By default, MCP servers connect in the background; sessions start
+# immediately and slow servers report ``status: "pending"`` in init.
+#
+# To restore pre-0.2.82 behavior (wait up to 5s before first query), set:
+#     MCP_CONNECTION_NONBLOCKING=0
+#
+# Alternative: mark a specific server with ``alwaysLoad: true`` in the
+# mcp_servers config so the SDK waits for that server in turn 1.
+#
+# We accept the new default; downstream consumers must handle ``pending``
+# server state in init messages. See docs/api/breaking-changes.md.

--- a/src/backends/claude/constants.py
+++ b/src/backends/claude/constants.py
@@ -14,6 +14,10 @@ from src.env_utils import parse_bool_env
 # See: https://docs.anthropic.com/en/docs/claude-code/sdk
 CLAUDE_TOOLS = [
     "Task",  # Launch agents for complex tasks
+    "TaskCreate",  # Create task for tracking (replaces TodoWrite, 0.2.82+)
+    "TaskUpdate",  # Update task status (0.2.82+)
+    "TaskGet",  # Get task details (0.2.82+)
+    "TaskList",  # List tasks (0.2.82+)
     "Bash",  # Execute bash commands
     "Glob",  # File pattern matching
     "Grep",  # Search file contents
@@ -22,11 +26,11 @@ CLAUDE_TOOLS = [
     "Write",  # Write files
     "NotebookEdit",  # Edit Jupyter notebooks
     "WebFetch",  # Fetch web content
-    "TodoWrite",  # Manage todo lists
+    "TodoWrite",  # Deprecated 0.2.82; retained for back-compat
     "WebSearch",  # Search the web
     "BashOutput",  # Get bash output
     "KillShell",  # Kill bash shells
-    "Skill",  # Execute skills
+    "Skill",  # Execute skills (deprecated 0.1.77 — see skills= option)
     "SlashCommand",  # Execute slash commands
 ]
 
@@ -40,7 +44,11 @@ DEFAULT_ALLOWED_TOOLS = [
     "Write",
     "Edit",
     "Skill",
-    "TodoWrite",
+    "TaskCreate",
+    "TaskUpdate",
+    "TaskGet",
+    "TaskList",
+    "TodoWrite",  # back-compat; SDK 0.2.82+ does not emit this
 ]
 
 # Claude Models

--- a/src/backends/claude/constants.py
+++ b/src/backends/claude/constants.py
@@ -14,10 +14,10 @@ from src.env_utils import parse_bool_env
 # See: https://docs.anthropic.com/en/docs/claude-code/sdk
 CLAUDE_TOOLS = [
     "Task",  # Launch agents for complex tasks
-    "TaskCreate",  # Create task for tracking (replaces TodoWrite, 0.2.82+)
-    "TaskUpdate",  # Update task status (0.2.82+)
-    "TaskGet",  # Get task details (0.2.82+)
-    "TaskList",  # List tasks (0.2.82+)
+    "TaskCreate",  # Task tracking (0.2.82+, opt-in via CLAUDE_CODE_ENABLE_TASKS=1)
+    "TaskUpdate",  # Task tracking (0.2.82+, opt-in via CLAUDE_CODE_ENABLE_TASKS=1)
+    "TaskGet",  # Task tracking (0.2.82+, opt-in via CLAUDE_CODE_ENABLE_TASKS=1)
+    "TaskList",  # Task tracking (0.2.82+, opt-in via CLAUDE_CODE_ENABLE_TASKS=1)
     "Bash",  # Execute bash commands
     "Glob",  # File pattern matching
     "Grep",  # Search file contents
@@ -26,16 +26,18 @@ CLAUDE_TOOLS = [
     "Write",  # Write files
     "NotebookEdit",  # Edit Jupyter notebooks
     "WebFetch",  # Fetch web content
-    "TodoWrite",  # Deprecated 0.2.82; retained for back-compat
+    "TodoWrite",  # Default task-tracking tool when CLAUDE_CODE_ENABLE_TASKS is unset
     "WebSearch",  # Search the web
     "BashOutput",  # Get bash output
     "KillShell",  # Kill bash shells
-    "Skill",  # Execute skills (deprecated 0.1.77 — see skills= option)
+    "Skill",  # Execute skills (deprecated 0.1.77 — translated to skills= option)
     "SlashCommand",  # Execute slash commands
 ]
 
 # Default tools to allow when tools are enabled
-# Subset of CLAUDE_TOOLS that are safe and commonly used
+# Subset of CLAUDE_TOOLS that are safe and commonly used.
+# Includes both TodoWrite (default) and Task* (active only when
+# CLAUDE_CODE_ENABLE_TASKS=1 is set on the CLI subprocess env).
 DEFAULT_ALLOWED_TOOLS = [
     "Read",
     "Glob",
@@ -48,7 +50,7 @@ DEFAULT_ALLOWED_TOOLS = [
     "TaskUpdate",
     "TaskGet",
     "TaskList",
-    "TodoWrite",  # back-compat; SDK 0.2.82+ does not emit this
+    "TodoWrite",
 ]
 
 # Claude Models

--- a/src/chunk_processing.py
+++ b/src/chunk_processing.py
@@ -3,7 +3,12 @@
 import json
 from typing import Any, Dict, Optional
 
-from claude_agent_sdk.types import ToolResultBlock, ToolUseBlock
+from claude_agent_sdk.types import (
+    ServerToolResultBlock,
+    ServerToolUseBlock,
+    ToolResultBlock,
+    ToolUseBlock,
+)
 
 from src.collab_filter import strip_collab_json
 from src.constants import (
@@ -11,6 +16,14 @@ from src.constants import (
 )
 from src.message_adapter import MessageAdapter
 from src.sse_builders import _normalize_tool_result
+
+
+_TOOL_CONTENT_BLOCK_TYPES = {
+    "tool_use",
+    "tool_result",
+    "server_tool_use",
+    "advisor_tool_result",
+}
 
 
 def _extract_tool_blocks(content) -> tuple[list, list]:
@@ -25,11 +38,13 @@ def _extract_tool_blocks(content) -> tuple[list, list]:
     tool_blocks: list[Any] = []
     non_tool: list[Any] = []
     for b in content:
-        if isinstance(b, (ToolUseBlock, ToolResultBlock)):
+        if isinstance(
+            b, (ToolUseBlock, ToolResultBlock, ServerToolUseBlock, ServerToolResultBlock)
+        ):
             tool_blocks.append(b)
-        elif isinstance(b, dict) and b.get("type") in ("tool_use", "tool_result"):
+        elif isinstance(b, dict) and b.get("type") in _TOOL_CONTENT_BLOCK_TYPES:
             tool_blocks.append(b)
-        elif hasattr(b, "type") and getattr(b, "type", None) in ("tool_use", "tool_result"):
+        elif hasattr(b, "type") and getattr(b, "type", None) in _TOOL_CONTENT_BLOCK_TYPES:
             tool_blocks.append(b)
         else:
             non_tool.append(b)
@@ -131,6 +146,23 @@ def extract_embedded_tool_blocks(chunk: Dict[str, Any]) -> list:
             )
         elif isinstance(tb, ToolResultBlock):
             normalized.append(_normalize_tool_result(tb))
+        elif isinstance(tb, ServerToolUseBlock):
+            normalized.append(
+                {
+                    "type": "server_tool_use",
+                    "id": getattr(tb, "id", ""),
+                    "name": getattr(tb, "name", ""),
+                    "input": getattr(tb, "input", {}),
+                }
+            )
+        elif isinstance(tb, ServerToolResultBlock):
+            normalized.append(
+                {
+                    "type": "advisor_tool_result",
+                    "tool_use_id": getattr(tb, "tool_use_id", ""),
+                    "content": getattr(tb, "content", ""),
+                }
+            )
         elif hasattr(tb, "type"):
             # Generic SDK object fallback
             d: Dict[str, Any] = {"type": getattr(tb, "type", "")}

--- a/src/message_adapter.py
+++ b/src/message_adapter.py
@@ -3,6 +3,8 @@ import os
 import re
 import json
 
+from claude_agent_sdk.types import ServerToolResultBlock, ServerToolUseBlock
+
 
 class MessageAdapter:
     """Converts between OpenAI message format and Claude Code prompts."""
@@ -34,6 +36,33 @@ class MessageAdapter:
         # ThinkingBlock (dict)
         if isinstance(block, dict) and block.get("type") == "thinking":
             return block
+
+        # ServerToolUseBlock (object)
+        if isinstance(block, ServerToolUseBlock):
+            return {
+                "type": "server_tool_use",
+                "id": getattr(block, "id", ""),
+                "name": block.name,
+                "input": block.input if isinstance(block.input, dict) else str(block.input),
+            }
+
+        # ServerToolUseBlock (dict)
+        if isinstance(block, dict) and block.get("type") == "server_tool_use":
+            return block
+
+        # ServerToolResultBlock / advisor_tool_result (object)
+        if isinstance(block, ServerToolResultBlock):
+            return {
+                "type": "advisor_tool_result",
+                "tool_use_id": block.tool_use_id,
+                "content": MessageAdapter._truncate_tool_content(block.content),
+            }
+
+        # ServerToolResultBlock / advisor_tool_result (dict)
+        if isinstance(block, dict) and block.get("type") == "advisor_tool_result":
+            result = dict(block)
+            result["content"] = MessageAdapter._truncate_tool_content(result.get("content", ""))
+            return result
 
         # ToolUseBlock (object)
         if hasattr(block, "name") and hasattr(block, "input"):

--- a/src/streaming_utils.py
+++ b/src/streaming_utils.py
@@ -461,9 +461,7 @@ def _user_tool_result_events(
     normalized_results = [_normalize_tool_result(tr_block) for tr_block in tool_results]
     visible_results = []
     for tr_block in normalized_results:
-        if _is_synthetic_ask_user_response_result(
-            tr_block, tool_names_by_id, request_context
-        ):
+        if _is_synthetic_ask_user_response_result(tr_block, tool_names_by_id, request_context):
             tr_block["is_error"] = False
             _record_tool_result(tool_stats, tr_block)
             continue
@@ -506,6 +504,11 @@ def _embedded_tool_events(
             if suppress_result:
                 result_block["is_error"] = False
             _record_tool_result(tool_stats, result_block)
+        elif block_type == "server_tool_use":
+            _remember_tool_use(tool_names_by_id, tool_block)
+            _record_tool_use(tool_stats, tool_block)
+        elif block_type == "advisor_tool_result":
+            _record_tool_result(tool_stats, tool_block)
 
         is_subagent_block = tool_block.get("parent_tool_use_id") is not None
         if is_subagent_block and not SUBAGENT_STREAM_TOOL_BLOCKS:
@@ -526,6 +529,14 @@ def _embedded_tool_events(
                     result_block if result_block is not None else tool_block,
                     sequence_number=next_seq(),
                     parent_tool_use_id=tool_block.get("parent_tool_use_id"),
+                )
+            )
+        elif block_type in {"server_tool_use", "advisor_tool_result"}:
+            events.append(
+                make_response_sse(
+                    f"response.{block_type}",
+                    block=tool_block,
+                    sequence_number=next_seq(),
                 )
             )
     return events

--- a/tests/test_message_adapter_unit.py
+++ b/tests/test_message_adapter_unit.py
@@ -8,6 +8,8 @@ These are pure unit tests that don't require a running server.
 
 from types import SimpleNamespace
 
+from claude_agent_sdk.types import ServerToolResultBlock, ServerToolUseBlock
+
 from src.message_adapter import MessageAdapter
 from src.response_models import ResponseInputItem
 
@@ -160,6 +162,22 @@ class TestBlockFormatting:
             "tool_use_id": "tool-1",
             "content": "result",
             "is_error": True,
+        }
+
+    def test_block_to_dict_preserves_server_tool_block_types(self):
+        server_use = ServerToolUseBlock(id="srv-1", name="web_search", input={"query": "x"})
+        advisor_result = ServerToolResultBlock(tool_use_id="srv-1", content="done")
+
+        assert MessageAdapter._block_to_dict(server_use) == {
+            "type": "server_tool_use",
+            "id": "srv-1",
+            "name": "web_search",
+            "input": {"query": "x"},
+        }
+        assert MessageAdapter._block_to_dict(advisor_result) == {
+            "type": "advisor_tool_result",
+            "tool_use_id": "srv-1",
+            "content": "done",
         }
 
     def test_block_to_dict_supports_dict_and_string_variants(self):

--- a/tests/test_sdk_migration.py
+++ b/tests/test_sdk_migration.py
@@ -282,6 +282,28 @@ class TestMessageAdapterFormatBlocks:
         assert result is None
 
 
+class TestTaskToolCatalog:
+    """Task tools must be present in tool catalog after 0.2.82 upgrade."""
+
+    def test_claude_tools_contains_task_tools(self):
+        from src.backends.claude.constants import CLAUDE_TOOLS
+
+        for tool in ("TaskCreate", "TaskUpdate", "TaskGet", "TaskList"):
+            assert tool in CLAUDE_TOOLS, f"{tool} missing from CLAUDE_TOOLS"
+
+    def test_default_allowed_tools_contains_task_tools(self):
+        from src.backends.claude.constants import DEFAULT_ALLOWED_TOOLS
+
+        for tool in ("TaskCreate", "TaskUpdate", "TaskGet", "TaskList"):
+            assert tool in DEFAULT_ALLOWED_TOOLS, f"{tool} missing from DEFAULT_ALLOWED_TOOLS"
+
+    def test_todowrite_retained_for_back_compat(self):
+        """TodoWrite stays in catalog; SDK no longer emits it but no harm leaving it."""
+        from src.backends.claude.constants import CLAUDE_TOOLS
+
+        assert "TodoWrite" in CLAUDE_TOOLS
+
+
 if __name__ == "__main__":
     # Run tests with pytest
     pytest.main([__file__, "-v"])

--- a/tests/test_sdk_migration.py
+++ b/tests/test_sdk_migration.py
@@ -297,8 +297,8 @@ class TestTaskToolCatalog:
         for tool in ("TaskCreate", "TaskUpdate", "TaskGet", "TaskList"):
             assert tool in DEFAULT_ALLOWED_TOOLS, f"{tool} missing from DEFAULT_ALLOWED_TOOLS"
 
-    def test_todowrite_retained_for_back_compat(self):
-        """TodoWrite stays in catalog; SDK no longer emits it but no harm leaving it."""
+    def test_todowrite_retained_as_default(self):
+        """TodoWrite remains the default task-tracking tool; Task* require CLAUDE_CODE_ENABLE_TASKS=1 on the CLI subprocess env."""
         from src.backends.claude.constants import CLAUDE_TOOLS
 
         assert "TodoWrite" in CLAUDE_TOOLS

--- a/tests/test_sdk_migration.py
+++ b/tests/test_sdk_migration.py
@@ -336,6 +336,25 @@ class TestSkillsOptionMigration:
 
         assert getattr(options, "skills", None) is None
 
+    def test_skill_in_disallowed_tools_skips_skills_translation(self, monkeypatch):
+        """DISALLOWED_TOOLS filter must win over the Skill→skills translation."""
+        from claude_agent_sdk import ClaudeAgentOptions
+        from src.backends.claude.client import ClaudeCodeCLI
+
+        # Operator-configured deny-list takes precedence over the Skill translation.
+        monkeypatch.setattr("src.backends.claude.client.DISALLOWED_TOOLS", ["Skill"])
+
+        backend = ClaudeCodeCLI.__new__(ClaudeCodeCLI)
+        options = ClaudeAgentOptions(max_turns=1)
+        backend._configure_tools(
+            options,
+            allowed_tools=["Read", "Skill", "Bash"],
+            disallowed_tools=None,
+        )
+
+        assert "Skill" not in (options.allowed_tools or [])
+        assert getattr(options, "skills", None) is None
+
 
 if __name__ == "__main__":
     # Run tests with pytest

--- a/tests/test_sdk_migration.py
+++ b/tests/test_sdk_migration.py
@@ -355,6 +355,23 @@ class TestSkillsOptionMigration:
         assert "Skill" not in (options.allowed_tools or [])
         assert getattr(options, "skills", None) is None
 
+    def test_mcp_default_allowed_tools_translates_skill(self):
+        """MCP default allow-list path should not reintroduce deprecated Skill."""
+        from claude_agent_sdk import ClaudeAgentOptions
+        from src.backends.claude.client import ClaudeCodeCLI
+
+        backend = ClaudeCodeCLI.__new__(ClaudeCodeCLI)
+        options = ClaudeAgentOptions(max_turns=1)
+        backend._configure_mcp_servers(
+            options,
+            mcp_servers={"fs": {"type": "stdio", "command": "server"}},
+            allowed_tools=None,
+        )
+
+        assert "Skill" not in (options.allowed_tools or [])
+        assert "mcp__fs__*" in (options.allowed_tools or [])
+        assert getattr(options, "skills", None) == "all"
+
 
 if __name__ == "__main__":
     # Run tests with pytest

--- a/tests/test_sdk_migration.py
+++ b/tests/test_sdk_migration.py
@@ -304,6 +304,39 @@ class TestTaskToolCatalog:
         assert "TodoWrite" in CLAUDE_TOOLS
 
 
+class TestSkillsOptionMigration:
+    """`Skill` allowed_tools entry should be transformed into `skills="all"`."""
+
+    def test_skill_in_allowed_tools_sets_skills_all(self):
+        from claude_agent_sdk import ClaudeAgentOptions
+        from src.backends.claude.client import ClaudeCodeCLI
+
+        backend = ClaudeCodeCLI.__new__(ClaudeCodeCLI)  # avoid __init__ side effects
+        options = ClaudeAgentOptions(max_turns=1)
+        backend._configure_tools(
+            options,
+            allowed_tools=["Read", "Skill", "Bash"],
+            disallowed_tools=None,
+        )
+
+        assert "Skill" not in (options.allowed_tools or [])
+        assert getattr(options, "skills", None) == "all"
+
+    def test_no_skill_keeps_skills_unset(self):
+        from claude_agent_sdk import ClaudeAgentOptions
+        from src.backends.claude.client import ClaudeCodeCLI
+
+        backend = ClaudeCodeCLI.__new__(ClaudeCodeCLI)
+        options = ClaudeAgentOptions(max_turns=1)
+        backend._configure_tools(
+            options,
+            allowed_tools=["Read", "Bash"],
+            disallowed_tools=None,
+        )
+
+        assert getattr(options, "skills", None) is None
+
+
 if __name__ == "__main__":
     # Run tests with pytest
     pytest.main([__file__, "-v"])

--- a/tests/test_streaming_coverage_unit.py
+++ b/tests/test_streaming_coverage_unit.py
@@ -12,7 +12,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from claude_agent_sdk.types import ToolResultBlock, ToolUseBlock
+from claude_agent_sdk.types import (
+    ServerToolResultBlock,
+    ServerToolUseBlock,
+    ToolResultBlock,
+    ToolUseBlock,
+)
 from src.streaming_utils import (
     CollabJsonStreamFilter,
     ToolUseAccumulator,
@@ -394,6 +399,27 @@ class TestExtractEmbeddedToolBlocksSDKNormalization:
         assert blocks[0]["type"] == "tool_result"
         assert blocks[0]["tool_use_id"] == "sdk-t1"
         assert blocks[0]["content"] == "file data"
+
+    def test_sdk_server_tool_blocks_preserve_wire_types(self):
+        """Server tool blocks keep their SDK 0.2.82 content block types."""
+        use = ServerToolUseBlock(id="srv-t1", name="web_search", input={"query": "x"})
+        result = ServerToolResultBlock(tool_use_id="srv-t1", content="done")
+        chunk = {"type": "assistant", "content": [use, result]}
+        blocks = extract_embedded_tool_blocks(chunk)
+
+        assert blocks == [
+            {
+                "type": "server_tool_use",
+                "id": "srv-t1",
+                "name": "web_search",
+                "input": {"query": "x"},
+            },
+            {
+                "type": "advisor_tool_result",
+                "tool_use_id": "srv-t1",
+                "content": "done",
+            },
+        ]
 
     def test_generic_sdk_object_with_type_attr_fallback(self):
         """Lines 498-504: generic SDK object with type attribute uses fallback."""

--- a/tests/test_streaming_utils_unit.py
+++ b/tests/test_streaming_utils_unit.py
@@ -8,6 +8,7 @@ import logging
 
 import pytest
 
+from claude_agent_sdk.types import ServerToolResultBlock, ServerToolUseBlock
 from src.response_models import OutputItem, ResponseObject
 from src.streaming_utils import (
     CollabJsonStreamFilter,
@@ -300,6 +301,7 @@ async def test_stream_response_chunks_signals_empty_without_yielding_failed():
     """When no content is produced, signal via stream_result["empty"] rather
     than yielding response.failed directly. The route decides whether to emit
     a failed event or a function_call (AskUserQuestion hook path)."""
+
     async def empty_source():
         yield {"type": "metadata"}
 
@@ -844,6 +846,54 @@ async def test_stream_response_chunks_emits_embedded_tool_blocks_as_structured_s
 
     assert stream_result["success"] is True
     assert parsed[-1][0] == "response.completed"
+
+
+@pytest.mark.asyncio
+async def test_stream_response_chunks_preserves_server_tool_block_types():
+    """SDK server/advisor blocks emit as distinct structured SSE events."""
+
+    async def embedded_server_tool_source():
+        yield {
+            "type": "assistant",
+            "content": [
+                ServerToolUseBlock(id="srv_xyz", name="web_search", input={"query": "docs"}),
+                ServerToolResultBlock(tool_use_id="srv_xyz", content="Found docs"),
+                {"type": "text", "text": "Done."},
+            ],
+        }
+
+    chunks_buffer = []
+    stream_result = {}
+    lines = [
+        line
+        async for line in stream_response_chunks(
+            chunk_source=embedded_server_tool_source(),
+            model="claude-test",
+            response_id="resp-server-tool",
+            output_item_id="msg-server-tool",
+            chunks_buffer=chunks_buffer,
+            logger=logging.getLogger("test-server-tool-blocks"),
+            stream_result=stream_result,
+        )
+    ]
+    parsed = [_parse_response_sse(line) for line in lines]
+
+    server_event = next(p for et, p in parsed if et == "response.server_tool_use")
+    assert server_event["block"] == {
+        "type": "server_tool_use",
+        "id": "srv_xyz",
+        "name": "web_search",
+        "input": {"query": "docs"},
+    }
+
+    result_event = next(p for et, p in parsed if et == "response.advisor_tool_result")
+    assert result_event["block"] == {
+        "type": "advisor_tool_result",
+        "tool_use_id": "srv_xyz",
+        "content": "Found docs",
+    }
+    assert not any(et == "response.tool_use" for et, _ in parsed)
+    assert stream_result["success"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -307,20 +307,21 @@ wheels = [
 
 [[package]]
 name = "claude-agent-sdk"
-version = "0.1.57"
+version = "0.2.82"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "mcp" },
+    { name = "sniffio" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/b9/fdc7fffa8ae39b8482fb05a59ae6d654ac78b163affebc372c11e488e3b3/claude_agent_sdk-0.1.57.tar.gz", hash = "sha256:467a229106b8002cafc780b690ae8d31b349e02302b1ac1cc199d0369fa1e395", size = 122883, upload-time = "2026-04-09T00:21:30.968Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/3d/f75aaecf476c2b2a903dbba6042171b6683eb91c1f97f3ad894784cec270/claude_agent_sdk-0.2.82.tar.gz", hash = "sha256:3e907b7d2bf52a5917d96a3ce336b8aa5546ea31e29ce826a7f346622cf7f4bf", size = 252053, upload-time = "2026-05-15T03:45:34.251Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/e8/04319a2117cf10f9e967a9d6d876c03931db241f101db7dd78d4f7a52ce7/claude_agent_sdk-0.1.57-py3-none-macosx_11_0_arm64.whl", hash = "sha256:36e14792f0a86a1af6358b544651e27fd6bd6e382f6021369239aa23267cb216", size = 58777709, upload-time = "2026-04-09T00:21:34.149Z" },
-    { url = "https://files.pythonhosted.org/packages/77/9e/d24d4b1648d67292d3179eff63f9653fef8f0304baa46eade46b3d037acb/claude_agent_sdk-0.1.57-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:650c4306be9ca353c8682f966b3de6501b926f23add03b5e02650c801af395ea", size = 60607511, upload-time = "2026-04-09T00:21:37.1Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/77/7fb241af17a03622a579c520110c86c941f64bb15d90470b61f09e70615d/claude_agent_sdk-0.1.57-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:e7fc4d7847550bb74aaf5810af8157a6e250a098b2101e4a50120113d2a46887", size = 72053457, upload-time = "2026-04-09T00:21:40.491Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/8c/2aba83f65f2b756382a2bc90d12451845fd85f8d37264e8df8b5b5ca056f/claude_agent_sdk-0.1.57-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:4433887d3655cbae960417267899b7210c2b22f621bd54ffc0696b585b015611", size = 72206927, upload-time = "2026-04-09T00:21:43.594Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/31/e14ebaecc49a856e49e9031fc1e8158d56295b99e66564f377a7b5d6c502/claude_agent_sdk-0.1.57-py3-none-win_amd64.whl", hash = "sha256:7b61a393d043838c98f8ade8de9c62417e5ad3bde9d685636ce0a6a610597e24", size = 74312239, upload-time = "2026-04-09T00:21:46.899Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/27cf3aec2a24f2ed1f60277de795496b808a761d2a7a3fd34602a2fec37d/claude_agent_sdk-0.2.82-py3-none-macosx_11_0_arm64.whl", hash = "sha256:24ad8ccbcee9afe206ae5d621a9e40a5022ca3eb8c2c672b36916d3e70746e42", size = 61473506, upload-time = "2026-05-15T03:45:38.745Z" },
+    { url = "https://files.pythonhosted.org/packages/96/91/95a83f018dbc8c113233eb542bccf17c1a3f5f689448700daf950602bf5e/claude_agent_sdk-0.2.82-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:13e54d5163d9d4f899c4e2a3f14df597f4e050d5afa104618ccf7bb37b372ad1", size = 63541975, upload-time = "2026-05-15T03:45:46.005Z" },
+    { url = "https://files.pythonhosted.org/packages/be/07/9356fe0e30f988bade6b116ecc602b4a9ae4df34fa055305187a835e36e0/claude_agent_sdk-0.2.82-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:3b0a0e3f0927737f1fc91ee4549185172243a4e8f135d4c1e4f1f1eba91373e1", size = 71212904, upload-time = "2026-05-15T03:45:51.121Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/d9/e2920b4b6c75cf79ec87ebfb4cc4447c78a4f26317cb3fed77e79fcc804e/claude_agent_sdk-0.2.82-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:b05873f9df01c5894930b87f6ca9315f0d97f1563bc2e4dc0fafe0d4a1e31997", size = 71381948, upload-time = "2026-05-15T03:45:56.153Z" },
+    { url = "https://files.pythonhosted.org/packages/89/80/c3ec5a89c735a96d35fe12b6262517169b396ff366149a3b9f4387f797c1/claude_agent_sdk-0.2.82-py3-none-win_amd64.whl", hash = "sha256:71e85e4f50d04cd95e687898092f03648e74e1cd2537583de93370d2da1c0586", size = 71990462, upload-time = "2026-05-15T03:46:01.646Z" },
 ]
 
 [[package]]
@@ -1165,7 +1166,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiomysql", specifier = ">=0.2.0" },
-    { name = "claude-agent-sdk", specifier = "==0.1.57" },
+    { name = "claude-agent-sdk", specifier = "==0.2.82" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.27.2" },
     { name = "pydantic", specifier = ">=2.10.0" },
@@ -1938,6 +1939,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a0/99/adfc7f94ca024736f061257d39118e1542bade7a52e86415a4c4ae92d8ff/slowapi-0.1.9.tar.gz", hash = "sha256:639192d0f1ca01b1c6d95bf6c71d794c3a9ee189855337b4821f7f457dddad77", size = 14028, upload-time = "2024-02-05T12:11:52.13Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/bb/f71c4b7d7e7eb3fc1e8c0458a8979b912f40b58002b9fbf37729b8cb464b/slowapi-0.1.9-py3-none-any.whl", hash = "sha256:cfad116cfb84ad9d763ee155c1e5c5cbf00b0d47399a769b227865f5df576e36", size = 14670, upload-time = "2024-02-05T12:11:50.898Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps `claude-agent-sdk` from `0.1.57` to `0.2.82`.
- Adds new `Task*` tools (`TaskCreate` / `TaskUpdate` / `TaskGet` / `TaskList`) to the allow-list. The bundled CLI gates these behind `CLAUDE_CODE_ENABLE_TASKS=1`; with the env unset the SDK continues to emit `TodoWrite` as the default task-tracking tool.
- Migrates the deprecated `"Skill"` allow-list entry to the modern `skills="all"` option on `ClaudeAgentOptions` (both explicit and MCP-default code paths).
- Preserves `ServerToolUseBlock` / `ServerToolResultBlock` wire types end-to-end (extraction, normalization, adapter) and exposes them as new structured SSE events `response.server_tool_use` and `response.advisor_tool_result` (carrying the original SDK content block under `block`).
- Documents the changes in `docs/api/breaking-changes.md` and `docs/streaming-events.md`.

## Pass-through philosophy
Per established convention, no compatibility adapters are added to the gateway. SDK behavior surfaces directly to downstream API consumers; consumers handle any new event/tool names client-side.

## Downstream-visible changes
- New SSE events: `response.server_tool_use` and `response.advisor_tool_result` (server-side tools like `web_search`, `web_fetch`, `advisor`, etc., which the API executes itself). Previously these blocks were silently dropped by the SDK parser.
- MCP `init` may include servers with `status: "pending"` (0.2.82 default; override with `MCP_CONNECTION_NONBLOCKING=0` or per-server `alwaysLoad: true`).
- `Task*` tool events are **opt-in** — they only appear when the operator sets `CLAUDE_CODE_ENABLE_TASKS=1` on the CLI subprocess env. Default deployments keep emitting `TodoWrite`.

See `docs/api/breaking-changes.md` for schema details (corrected `TaskCreate` input is `{subject, description, activeForm?}`, `TaskUpdate` is `{taskId, ...}`, and the created task id comes back in the `tool_result` content).

## Test plan
- [x] Unit tests pass: `uv run pytest` → 1553 passed, 3 skipped, 4 deselected
- [x] Manual smoke test against gateway emitted `TaskCreate` events with real `tool_result` ("Task #1 created successfully: ...") — note this run had Task tools enabled via the inherited host env, so it does not by itself prove Task* are default
- [ ] Reviewer: confirm `CLAUDE_CODE_ENABLE_TASKS` is intentionally not set in the gateway env (current behavior keeps `TodoWrite` as default)
- [ ] (Optional follow-up) Surface `ResultMessage.api_error_status` (429/500/529) to downstream error payload; expose `xhigh` effort level for Opus 4.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
