### PR TITLE
feat(sanitizer): opt-in /v1/messages stream sanitizer for LiteLLM

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,14 @@
 # ANTHROPIC_DEFAULT_SONNET_MODEL=claude-sonnet-4-5-20250929
 # ANTHROPIC_DEFAULT_HAIKU_MODEL=claude-haiku-4-5-20251001
 
+# Optional Anthropic Messages stream sanitizer.
+# Keep ANTHROPIC_BASE_URL pointed at the real Anthropic-compatible upstream
+# (for example LiteLLM in Docker Compose: http://litellm:4000). When enabled,
+# the gateway rewrites only the Claude SDK subprocess env so Claude calls the
+# local sanitizer route first, and the sanitizer forwards to ANTHROPIC_BASE_URL.
+# SANITIZER_ENABLED=false
+# SANITIZER_REQUEST_TIMEOUT=0
+
 
 # API Configuration
 # If API_KEY is not set, server will prompt for interactive API key protection on startup

--- a/src/backends/claude/client.py
+++ b/src/backends/claude/client.py
@@ -348,7 +348,18 @@ class ClaudeCodeCLI:
 
         env_map = {k: v for k, v in extra_env.items() if k in METADATA_ENV_ALLOWLIST}
         if env_map:
-            options.env = env_map
+            options.env.update(env_map)
+
+    def _configure_sdk_env(self, options: ClaudeAgentOptions) -> None:
+        sdk_env = dict(self.claude_env_vars or {})
+
+        from src.sanitizer.config import get_gateway_base_url, is_enabled as sanitizer_enabled
+
+        if sanitizer_enabled():
+            sdk_env["ANTHROPIC_BASE_URL"] = get_gateway_base_url()
+
+        if sdk_env:
+            options.env.update(sdk_env)
 
     def _build_sdk_options(
         self,
@@ -405,6 +416,7 @@ class ClaudeCodeCLI:
         self._configure_session_identity(options, session_id, resume)
         self._configure_task_budget(options, task_budget)
         self._configure_metadata_env(options, extra_env)
+        self._configure_sdk_env(options)
 
         return options
 
@@ -473,16 +485,6 @@ class ClaudeCodeCLI:
                 original[key] = os.environ.get(key)
                 os.environ[key] = value
 
-            # Keep the process-level ANTHROPIC_BASE_URL as the real upstream
-            # for the sanitizer, but point the Claude SDK subprocess at the
-            # gateway's local /v1/messages route when the sanitizer is enabled.
-            from src.sanitizer.config import get_gateway_base_url, is_enabled as sanitizer_enabled
-
-            if sanitizer_enabled():
-                key = "ANTHROPIC_BASE_URL"
-                original[key] = os.environ.get(key)
-                os.environ[key] = get_gateway_base_url()
-
             # Remove other backends' credentials (cross-isolation)
             for key in self._ISOLATION_VARS:
                 if key in os.environ:
@@ -510,14 +512,11 @@ class ClaudeCodeCLI:
         try:
             logger.info("Testing Claude Agent SDK...")
 
+            options = self._build_sdk_options(max_turns=1)
             messages = []
             async for message in query(
                 prompt="Hello",
-                options=ClaudeAgentOptions(
-                    max_turns=1,
-                    cwd=self.cwd,
-                    system_prompt={"type": "preset", "preset": "claude_code"},
-                ),
+                options=options,
             ):
                 messages.append(message)
                 msg_type = getattr(message, "type", None) or (

--- a/src/backends/claude/client.py
+++ b/src/backends/claude/client.py
@@ -473,6 +473,16 @@ class ClaudeCodeCLI:
                 original[key] = os.environ.get(key)
                 os.environ[key] = value
 
+            # Keep the process-level ANTHROPIC_BASE_URL as the real upstream
+            # for the sanitizer, but point the Claude SDK subprocess at the
+            # gateway's local /v1/messages route when the sanitizer is enabled.
+            from src.sanitizer.config import get_gateway_base_url, is_enabled as sanitizer_enabled
+
+            if sanitizer_enabled():
+                key = "ANTHROPIC_BASE_URL"
+                original[key] = os.environ.get(key)
+                os.environ[key] = get_gateway_base_url()
+
             # Remove other backends' credentials (cross-isolation)
             for key in self._ISOLATION_VARS:
                 if key in os.environ:

--- a/src/main.py
+++ b/src/main.py
@@ -568,15 +568,13 @@ app.include_router(sessions_router)
 app.include_router(general_router)
 app.include_router(admin_router)
 
-# Optional: Anthropic Messages SSE sanitizer for upstream LiteLLM-like proxies
-# that emit non-spec-conforming streams (LiteLLM #21128). Opt-in via
-# SANITIZER_ENABLED=true.
-from src.sanitizer.config import is_enabled as _sanitizer_enabled  # noqa: E402
+# Anthropic Messages SSE sanitizer for upstream LiteLLM-like proxies that emit
+# non-spec-conforming streams (LiteLLM #21128). The route is always mounted so
+# the admin panel can flip it on/off at runtime; the handler short-circuits to
+# 503 when disabled. The boot-time default is SANITIZER_ENABLED.
+from src.sanitizer.routes import router as sanitizer_router  # noqa: E402
 
-if _sanitizer_enabled():
-    from src.sanitizer.routes import router as sanitizer_router  # noqa: E402
-
-    app.include_router(sanitizer_router)
+app.include_router(sanitizer_router)
 
 
 # ==================== Backward-compat re-exports ====================

--- a/src/main.py
+++ b/src/main.py
@@ -568,6 +568,16 @@ app.include_router(sessions_router)
 app.include_router(general_router)
 app.include_router(admin_router)
 
+# Optional: Anthropic Messages SSE sanitizer for upstream LiteLLM-like proxies
+# that emit non-spec-conforming streams (LiteLLM #21128). Opt-in via
+# SANITIZER_ENABLED=true.
+from src.sanitizer.config import is_enabled as _sanitizer_enabled  # noqa: E402
+
+if _sanitizer_enabled():
+    from src.sanitizer.routes import router as sanitizer_router  # noqa: E402
+
+    app.include_router(sanitizer_router)
+
 
 # ==================== Backward-compat re-exports ====================
 # Tests call these functions directly as main.X() — re-exports are required.

--- a/src/main.py
+++ b/src/main.py
@@ -571,7 +571,7 @@ app.include_router(admin_router)
 # Anthropic Messages SSE sanitizer for upstream LiteLLM-like proxies that emit
 # non-spec-conforming streams (LiteLLM #21128). The route is always mounted so
 # the admin panel can flip it on/off at runtime; the handler short-circuits to
-# 503 when disabled. The boot-time default is SANITIZER_ENABLED.
+# 404 when disabled. The boot-time default is SANITIZER_ENABLED.
 from src.sanitizer.routes import router as sanitizer_router  # noqa: E402
 
 app.include_router(sanitizer_router)

--- a/src/request_logger.py
+++ b/src/request_logger.py
@@ -90,6 +90,9 @@ DEFAULT_EXCLUDE_PREFIXES: Tuple[str, ...] = (
     "/docs",
     "/openapi.json",
     "/favicon.ico",
+    # The sanitizer proxy is a pure pass-through for Claude Code ↔ LiteLLM; its
+    # requests belong to the upstream model traffic, not gateway observability.
+    "/v1/messages",
 )
 
 

--- a/src/runtime_config.py
+++ b/src/runtime_config.py
@@ -54,7 +54,7 @@ EDITABLE_KEYS: Dict[str, Dict[str, Any]] = {
     "sanitizer_enabled": {
         "label": "Sanitizer (/v1/messages)",
         "type": "bool",
-        "description": "Anthropic SSE sanitizer in front of localhost LiteLLM",
+        "description": "Anthropic SSE sanitizer in front of ANTHROPIC_BASE_URL",
     },
 }
 

--- a/src/runtime_config.py
+++ b/src/runtime_config.py
@@ -51,6 +51,11 @@ EDITABLE_KEYS: Dict[str, Dict[str, Any]] = {
         "type": "bool",
         "description": "Stream individual tokens vs batched chunks",
     },
+    "sanitizer_enabled": {
+        "label": "Sanitizer (/v1/messages)",
+        "type": "bool",
+        "description": "Anthropic SSE sanitizer in front of localhost LiteLLM",
+    },
 }
 
 
@@ -134,12 +139,17 @@ class RuntimeConfig:
             TOKEN_STREAMING,
         )
 
+        # Lazy import to avoid a circular dependency: sanitizer.config imports
+        # back from runtime_config to honor admin overrides.
+        from src.sanitizer.config import _env_enabled as _sanitizer_env_enabled
+
         _map = {
             "default_model": DEFAULT_MODEL,
             "default_max_turns": DEFAULT_MAX_TURNS,
             "session_max_age_minutes": SESSION_MAX_AGE_MINUTES,
             "thinking_mode": THINKING_MODE,
             "token_streaming": TOKEN_STREAMING,
+            "sanitizer_enabled": _sanitizer_env_enabled(),
         }
         return _map.get(key)
 

--- a/src/sanitizer/__init__.py
+++ b/src/sanitizer/__init__.py
@@ -1,0 +1,13 @@
+"""Anthropic Messages SSE sanitizer.
+
+Sits as ``POST /v1/messages`` in front of an upstream LiteLLM (or similar) proxy
+that emits non-conforming streams (notably LiteLLM #21128, where the first
+content block is hardcoded as ``type=text`` regardless of whether the model is
+actually thinking). Rewrites the event stream so that ``content_block_start.type``
+matches the ``delta.type`` of every contained ``content_block_delta``, which the
+Anthropic SDK / Claude Code enforce strictly.
+
+Intentionally isolated from the rest of the gateway: no shared state, no auth,
+no session/rate-limit dependencies — it is a pure pass-through proxy that
+happens to share the FastAPI app for deployment convenience.
+"""

--- a/src/sanitizer/config.py
+++ b/src/sanitizer/config.py
@@ -1,32 +1,34 @@
 """Configuration for the Anthropic Messages sanitizer proxy.
 
-The upstream is intentionally locked to ``127.0.0.1`` — the sanitizer is meant
-to sit in front of a co-located LiteLLM (or similar) instance, not to proxy
-to arbitrary remote endpoints. This keeps the security model simple: same
-trust boundary, no leaked credentials, no SSRF surface from the gateway.
+``ANTHROPIC_BASE_URL`` keeps its normal meaning: the Anthropic-compatible
+upstream Claude Code would have called directly. When the sanitizer is enabled,
+the Claude SDK environment is rewritten to call this gateway's local
+``/v1/messages`` route instead, and the route forwards to the original
+``ANTHROPIC_BASE_URL`` value.
 """
 
 from __future__ import annotations
 
+import os
+
 from src.env_utils import parse_bool_env, parse_int_env
 
 
-# Host portion of the upstream URL — fixed by design.
-UPSTREAM_HOST = "127.0.0.1"
-
-
-def get_upstream_port() -> int:
-    """TCP port of the upstream Anthropic Messages service on localhost.
-
-    Defaults to a high port (54000) since the upstream LiteLLM is expected to
-    be bound to loopback only — it is not a service users hit directly.
-    """
-    return parse_int_env("SANITIZER_UPSTREAM_PORT", 54000)
-
-
 def get_upstream_url() -> str:
-    """Full upstream base URL (``http://127.0.0.1:<port>``)."""
-    return f"http://{UPSTREAM_HOST}:{get_upstream_port()}"
+    """Original Anthropic-compatible upstream base URL.
+
+    This intentionally reads ``ANTHROPIC_BASE_URL`` rather than a sanitizer-
+    specific env var. Operators keep configuring Claude Code's real upstream
+    in the usual place; the gateway only overrides Claude's view of that env
+    var while launching the SDK subprocess.
+    """
+    return os.getenv("ANTHROPIC_BASE_URL", "https://api.anthropic.com").rstrip("/")
+
+
+def get_gateway_base_url() -> str:
+    """Local base URL Claude SDK should call when the sanitizer is enabled."""
+    port = parse_int_env("PORT", 8000)
+    return f"http://127.0.0.1:{port}"
 
 
 def get_request_timeout_seconds() -> float | None:

--- a/src/sanitizer/config.py
+++ b/src/sanitizer/config.py
@@ -34,3 +34,16 @@ def is_enabled() -> bool:
     Disabled by default so operators must opt in via ``SANITIZER_ENABLED=true``.
     """
     return parse_bool_env("SANITIZER_ENABLED", "false")
+
+
+def get_upstream_api_key() -> str | None:
+    """Bearer token to present to the upstream service, if any.
+
+    The client's ``Authorization`` header authenticates against the gateway and
+    is **not** forwarded — upstream lives in a different trust boundary and
+    typically has its own credential. Operators set ``SANITIZER_UPSTREAM_API_KEY``
+    to inject the upstream bearer; if unset, the upstream request goes out
+    without an ``Authorization`` header.
+    """
+    raw = os.getenv("SANITIZER_UPSTREAM_API_KEY")
+    return raw if raw else None

--- a/src/sanitizer/config.py
+++ b/src/sanitizer/config.py
@@ -1,20 +1,32 @@
-"""Configuration for the Anthropic Messages sanitizer proxy."""
+"""Configuration for the Anthropic Messages sanitizer proxy.
+
+The upstream is intentionally locked to ``127.0.0.1`` — the sanitizer is meant
+to sit in front of a co-located LiteLLM (or similar) instance, not to proxy
+to arbitrary remote endpoints. This keeps the security model simple: same
+trust boundary, no leaked credentials, no SSRF surface from the gateway.
+"""
 
 from __future__ import annotations
-
-import os
 
 from src.env_utils import parse_bool_env, parse_int_env
 
 
-def get_upstream_url() -> str:
-    """URL of the upstream service that speaks Anthropic Messages API.
+# Host portion of the upstream URL — fixed by design.
+UPSTREAM_HOST = "127.0.0.1"
 
-    Typically a LiteLLM ``--port 4000`` instance. The sanitizer forwards
-    ``POST /v1/messages`` to ``{upstream}/v1/messages`` verbatim and post-
-    processes the SSE stream.
+
+def get_upstream_port() -> int:
+    """TCP port of the upstream Anthropic Messages service on localhost.
+
+    Defaults to a high port (54000) since the upstream LiteLLM is expected to
+    be bound to loopback only — it is not a service users hit directly.
     """
-    return os.getenv("SANITIZER_UPSTREAM_URL", "http://localhost:4000").rstrip("/")
+    return parse_int_env("SANITIZER_UPSTREAM_PORT", 54000)
+
+
+def get_upstream_url() -> str:
+    """Full upstream base URL (``http://127.0.0.1:<port>``)."""
+    return f"http://{UPSTREAM_HOST}:{get_upstream_port()}"
 
 
 def get_request_timeout_seconds() -> float | None:
@@ -28,22 +40,20 @@ def get_request_timeout_seconds() -> float | None:
     return None if raw <= 0 else float(raw)
 
 
-def is_enabled() -> bool:
-    """Whether the sanitizer route should be mounted on the gateway.
-
-    Disabled by default so operators must opt in via ``SANITIZER_ENABLED=true``.
-    """
+def _env_enabled() -> bool:
+    """Boot-time default from ``SANITIZER_ENABLED``."""
     return parse_bool_env("SANITIZER_ENABLED", "false")
 
 
-def get_upstream_api_key() -> str | None:
-    """Bearer token to present to the upstream service, if any.
+def is_enabled() -> bool:
+    """Whether the sanitizer should accept requests right now.
 
-    The client's ``Authorization`` header authenticates against the gateway and
-    is **not** forwarded — upstream lives in a different trust boundary and
-    typically has its own credential. Operators set ``SANITIZER_UPSTREAM_API_KEY``
-    to inject the upstream bearer; if unset, the upstream request goes out
-    without an ``Authorization`` header.
+    The admin panel may override the boot-time env value at runtime via
+    ``runtime_config.set("sanitizer_enabled", ...)``. Restarting reverts to
+    the ``SANITIZER_ENABLED`` env value.
     """
-    raw = os.getenv("SANITIZER_UPSTREAM_API_KEY")
-    return raw if raw else None
+    # Local import avoids a circular dependency: ``runtime_config._get_original``
+    # imports from this module to resolve the boot default.
+    from src.runtime_config import runtime_config
+
+    return bool(runtime_config.get("sanitizer_enabled"))

--- a/src/sanitizer/config.py
+++ b/src/sanitizer/config.py
@@ -1,0 +1,36 @@
+"""Configuration for the Anthropic Messages sanitizer proxy."""
+
+from __future__ import annotations
+
+import os
+
+from src.env_utils import parse_bool_env, parse_int_env
+
+
+def get_upstream_url() -> str:
+    """URL of the upstream service that speaks Anthropic Messages API.
+
+    Typically a LiteLLM ``--port 4000`` instance. The sanitizer forwards
+    ``POST /v1/messages`` to ``{upstream}/v1/messages`` verbatim and post-
+    processes the SSE stream.
+    """
+    return os.getenv("SANITIZER_UPSTREAM_URL", "http://localhost:4000").rstrip("/")
+
+
+def get_request_timeout_seconds() -> float | None:
+    """Per-request timeout in seconds, or ``None`` to disable.
+
+    Streaming responses can be long-lived, so the default disables the timeout.
+    Override via ``SANITIZER_REQUEST_TIMEOUT`` (integer seconds; ``0`` = no
+    timeout).
+    """
+    raw = parse_int_env("SANITIZER_REQUEST_TIMEOUT", 0)
+    return None if raw <= 0 else float(raw)
+
+
+def is_enabled() -> bool:
+    """Whether the sanitizer route should be mounted on the gateway.
+
+    Disabled by default so operators must opt in via ``SANITIZER_ENABLED=true``.
+    """
+    return parse_bool_env("SANITIZER_ENABLED", "false")

--- a/src/sanitizer/routes.py
+++ b/src/sanitizer/routes.py
@@ -1,21 +1,23 @@
 """FastAPI route that proxies ``POST /v1/messages`` to an upstream LiteLLM-like
 service and sanitizes the SSE response stream.
 
-This module is intentionally self-contained: it does **not** import from the
-rest of the gateway (auth, sessions, rate limiter, logging adapters) so it can
-be excised into its own service later without untangling dependencies.
+The module only takes one gateway-side dependency — ``verify_api_key`` — so the
+endpoint participates in the same ``API_KEY`` protection as the rest of the
+``/v1/*`` surface. All sanitizer-specific logic stays self-contained.
 """
 
 from __future__ import annotations
 
 import json
 import logging
-from typing import Any, AsyncIterator, Dict
+from typing import Any, AsyncIterator, Dict, Optional
 
 import httpx
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import Response, StreamingResponse
+from fastapi.security import HTTPAuthorizationCredentials
 
+from src.auth import security, verify_api_key
 from src.sanitizer.config import get_request_timeout_seconds, get_upstream_url
 from src.sanitizer.stream_sanitizer import sanitize_events
 
@@ -105,8 +107,13 @@ def _format_sse(evt: Dict[str, Any]) -> bytes:
 
 
 @router.post("/v1/messages")
-async def sanitize_messages(request: Request) -> Response:
+async def sanitize_messages(
+    request: Request,
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+) -> Response:
     """Proxy ``/v1/messages`` to the upstream and rewrite the SSE stream."""
+    await verify_api_key(request, credentials)
+
     body = await request.body()
     fwd_headers = _filter_headers(request.headers.items())
 
@@ -146,6 +153,25 @@ async def sanitize_messages(request: Request) -> Response:
             await client.aclose()
 
     upstream = await client.send(upstream_req, stream=True)
+
+    # The sanitizer only knows how to rewrite Anthropic-style SSE. If upstream
+    # returned a JSON/HTML error (or anything else), passing it through the
+    # SSE parser would silently drop the body and leave the client with an
+    # empty event stream — so we forward non-SSE responses verbatim.
+    upstream_ctype = upstream.headers.get("content-type", "")
+    if not upstream_ctype.lower().startswith("text/event-stream"):
+        try:
+            content = await upstream.aread()
+            resp_headers = _filter_headers(upstream.headers.items())
+            return Response(
+                content=content,
+                status_code=upstream.status_code,
+                headers=resp_headers,
+                media_type=upstream_ctype or None,
+            )
+        finally:
+            await upstream.aclose()
+            await client.aclose()
 
     async def body_iter() -> AsyncIterator[bytes]:
         try:

--- a/src/sanitizer/routes.py
+++ b/src/sanitizer/routes.py
@@ -51,13 +51,12 @@ _HOP_BY_HOP = frozenset(
     }
 )
 
-# Stripped from the request before forwarding to upstream:
-# - ``authorization``: the gateway has its own API key; we don't want it
-#   leaking onto the loopback port as a de-facto upstream credential.
+# Stripped from requests before forwarding to upstream:
 # - ``accept-encoding``: httpx negotiates and auto-decompresses internally; if
 #   we forwarded the client's value, upstream would compress and we'd decode
 #   anyway — wasted upstream CPU.
-_DROP_FROM_REQUEST = _HOP_BY_HOP | frozenset({"authorization", "accept-encoding"})
+_DROP_FROM_REQUEST = _HOP_BY_HOP | frozenset({"accept-encoding"})
+_DROP_FROM_EXTERNAL_REQUEST = _DROP_FROM_REQUEST | frozenset({"authorization"})
 
 # Stripped from the upstream response before returning to the client:
 # - ``content-encoding``: httpx returns decoded bytes from .content/.aread()/
@@ -69,6 +68,12 @@ _DROP_FROM_RESPONSE = _HOP_BY_HOP | frozenset({"content-encoding"})
 
 def _filter_headers(items, drop: frozenset) -> Dict[str, str]:
     return {k: v for k, v in items if k.lower() not in drop}
+
+
+def _is_loopback_request(request: Request) -> bool:
+    """Return True for SDK self-calls from the same host/container."""
+    host = request.client.host if request.client else ""
+    return host in {"127.0.0.1", "::1", "localhost"}
 
 
 async def _iter_sse_events(
@@ -143,10 +148,13 @@ async def sanitize_messages(
             media_type="application/json",
         )
 
-    await verify_api_key(request, credentials)
+    is_loopback = _is_loopback_request(request)
+    if not is_loopback:
+        await verify_api_key(request, credentials)
 
     body = await request.body()
-    fwd_headers = _filter_headers(request.headers.items(), _DROP_FROM_REQUEST)
+    drop_headers = _DROP_FROM_REQUEST if is_loopback else _DROP_FROM_EXTERNAL_REQUEST
+    fwd_headers = _filter_headers(request.headers.items(), drop_headers)
 
     # Decide stream vs non-stream from the request body, falling back to
     # non-stream on parse failure (matches Anthropic API behavior).

--- a/src/sanitizer/routes.py
+++ b/src/sanitizer/routes.py
@@ -1,0 +1,168 @@
+"""FastAPI route that proxies ``POST /v1/messages`` to an upstream LiteLLM-like
+service and sanitizes the SSE response stream.
+
+This module is intentionally self-contained: it does **not** import from the
+rest of the gateway (auth, sessions, rate limiter, logging adapters) so it can
+be excised into its own service later without untangling dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, AsyncIterator, Dict
+
+import httpx
+from fastapi import APIRouter, Request
+from fastapi.responses import Response, StreamingResponse
+
+from src.sanitizer.config import get_request_timeout_seconds, get_upstream_url
+from src.sanitizer.stream_sanitizer import sanitize_events
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _make_client(timeout: float | None) -> httpx.AsyncClient:
+    """AsyncClient factory; tests monkeypatch this to inject a MockTransport."""
+    return httpx.AsyncClient(timeout=timeout)
+
+# Headers that must not be forwarded upstream or back to the client because
+# they describe the *transport* (length, encoding, host) rather than the
+# request/response itself. ``httpx`` and ``Starlette`` set them automatically.
+_HOP_BY_HOP = frozenset(
+    {
+        "host",
+        "content-length",
+        "transfer-encoding",
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailers",
+        "upgrade",
+    }
+)
+
+
+def _filter_headers(items) -> Dict[str, str]:
+    return {k: v for k, v in items if k.lower() not in _HOP_BY_HOP}
+
+
+async def _iter_sse_events(
+    response: httpx.Response,
+) -> AsyncIterator[Dict[str, Any]]:
+    """Yield parsed event dicts from an Anthropic-style SSE response.
+
+    Anthropic SSE frames have the form:
+
+        event: <type>
+        data: <json>
+        <blank line>
+
+    The ``event:`` line is informational — the canonical type lives in the
+    JSON payload's ``type`` field, which is what we operate on.
+    """
+    data_lines: list[str] = []
+    async for raw_line in response.aiter_lines():
+        line = raw_line.rstrip("\r")
+        if line == "":
+            if not data_lines:
+                continue
+            payload = "\n".join(data_lines)
+            data_lines = []
+            try:
+                evt = json.loads(payload)
+            except json.JSONDecodeError:
+                logger.warning("sanitizer: skipping non-JSON SSE payload: %r", payload[:200])
+                continue
+            if isinstance(evt, dict):
+                yield evt
+            continue
+        if line.startswith("data:"):
+            data_lines.append(line[5:].lstrip())
+        # ``event:``, ``id:``, ``retry:``, comments (``:``) — ignored; the JSON
+        # payload's ``type`` field is authoritative.
+
+    # Flush a final event missing a trailing blank line.
+    if data_lines:
+        payload = "\n".join(data_lines)
+        try:
+            evt = json.loads(payload)
+            if isinstance(evt, dict):
+                yield evt
+        except json.JSONDecodeError:
+            logger.warning("sanitizer: dropping trailing non-JSON SSE payload")
+
+
+def _format_sse(evt: Dict[str, Any]) -> bytes:
+    """Serialize an event dict back into an SSE frame."""
+    etype = evt.get("type", "message")
+    data = json.dumps(evt, separators=(",", ":"), ensure_ascii=False)
+    return f"event: {etype}\ndata: {data}\n\n".encode("utf-8")
+
+
+@router.post("/v1/messages")
+async def sanitize_messages(request: Request) -> Response:
+    """Proxy ``/v1/messages`` to the upstream and rewrite the SSE stream."""
+    body = await request.body()
+    fwd_headers = _filter_headers(request.headers.items())
+
+    # Decide stream vs non-stream from the request body, falling back to
+    # non-stream on parse failure (matches Anthropic API behavior).
+    is_stream = False
+    try:
+        parsed = json.loads(body) if body else {}
+        if isinstance(parsed, dict):
+            is_stream = bool(parsed.get("stream", False))
+    except json.JSONDecodeError:
+        pass
+
+    upstream_url = f"{get_upstream_url()}/v1/messages"
+    timeout = get_request_timeout_seconds()
+    client = _make_client(timeout)
+
+    upstream_req = client.build_request(
+        "POST",
+        upstream_url,
+        content=body,
+        headers=fwd_headers,
+    )
+
+    if not is_stream:
+        try:
+            upstream = await client.send(upstream_req)
+            content = upstream.content
+            resp_headers = _filter_headers(upstream.headers.items())
+            return Response(
+                content=content,
+                status_code=upstream.status_code,
+                headers=resp_headers,
+                media_type=upstream.headers.get("content-type"),
+            )
+        finally:
+            await client.aclose()
+
+    upstream = await client.send(upstream_req, stream=True)
+
+    async def body_iter() -> AsyncIterator[bytes]:
+        try:
+            async for sanitized in sanitize_events(_iter_sse_events(upstream)):
+                yield _format_sse(sanitized)
+        finally:
+            await upstream.aclose()
+            await client.aclose()
+
+    resp_headers = _filter_headers(upstream.headers.items())
+    # Streaming-specific headers must not be cached or buffered by proxies.
+    resp_headers["Cache-Control"] = "no-cache"
+    resp_headers["X-Accel-Buffering"] = "no"
+
+    return StreamingResponse(
+        body_iter(),
+        status_code=upstream.status_code,
+        headers=resp_headers,
+        media_type="text/event-stream",
+    )

--- a/src/sanitizer/routes.py
+++ b/src/sanitizer/routes.py
@@ -18,7 +18,11 @@ from fastapi.responses import Response, StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials
 
 from src.auth import security, verify_api_key
-from src.sanitizer.config import get_request_timeout_seconds, get_upstream_url
+from src.sanitizer.config import (
+    get_request_timeout_seconds,
+    get_upstream_api_key,
+    get_upstream_url,
+)
 from src.sanitizer.stream_sanitizer import sanitize_events
 
 logger = logging.getLogger(__name__)
@@ -30,9 +34,8 @@ def _make_client(timeout: float | None) -> httpx.AsyncClient:
     """AsyncClient factory; tests monkeypatch this to inject a MockTransport."""
     return httpx.AsyncClient(timeout=timeout)
 
-# Headers that must not be forwarded upstream or back to the client because
-# they describe the *transport* (length, encoding, host) rather than the
-# request/response itself. ``httpx`` and ``Starlette`` set them automatically.
+# Hop-by-hop headers (RFC 7230 §6.1) plus transport-framing headers set by
+# httpx/Starlette automatically. Never forwarded in either direction.
 _HOP_BY_HOP = frozenset(
     {
         "host",
@@ -48,9 +51,24 @@ _HOP_BY_HOP = frozenset(
     }
 )
 
+# Stripped from the request before forwarding to upstream:
+# - ``authorization``: the gateway has its own API key; upstream is a different
+#   trust boundary and gets its bearer from SANITIZER_UPSTREAM_API_KEY.
+# - ``accept-encoding``: httpx negotiates and auto-decompresses internally; if
+#   we forwarded the client's value, upstream would compress and we'd decode
+#   anyway — wasted upstream CPU.
+_DROP_FROM_REQUEST = _HOP_BY_HOP | frozenset({"authorization", "accept-encoding"})
 
-def _filter_headers(items) -> Dict[str, str]:
-    return {k: v for k, v in items if k.lower() not in _HOP_BY_HOP}
+# Stripped from the upstream response before returning to the client:
+# - ``content-encoding``: httpx returns decoded bytes from .content/.aread()/
+#   .aiter_lines(), and the SSE branch re-serializes events as plain UTF-8.
+#   Forwarding the original encoding would mislead the client into decompressing
+#   already-decoded data.
+_DROP_FROM_RESPONSE = _HOP_BY_HOP | frozenset({"content-encoding"})
+
+
+def _filter_headers(items, drop: frozenset) -> Dict[str, str]:
+    return {k: v for k, v in items if k.lower() not in drop}
 
 
 async def _iter_sse_events(
@@ -115,7 +133,10 @@ async def sanitize_messages(
     await verify_api_key(request, credentials)
 
     body = await request.body()
-    fwd_headers = _filter_headers(request.headers.items())
+    fwd_headers = _filter_headers(request.headers.items(), _DROP_FROM_REQUEST)
+    upstream_key = get_upstream_api_key()
+    if upstream_key is not None:
+        fwd_headers["Authorization"] = f"Bearer {upstream_key}"
 
     # Decide stream vs non-stream from the request body, falling back to
     # non-stream on parse failure (matches Anthropic API behavior).
@@ -142,7 +163,7 @@ async def sanitize_messages(
         try:
             upstream = await client.send(upstream_req)
             content = upstream.content
-            resp_headers = _filter_headers(upstream.headers.items())
+            resp_headers = _filter_headers(upstream.headers.items(), _DROP_FROM_RESPONSE)
             return Response(
                 content=content,
                 status_code=upstream.status_code,
@@ -162,7 +183,7 @@ async def sanitize_messages(
     if not upstream_ctype.lower().startswith("text/event-stream"):
         try:
             content = await upstream.aread()
-            resp_headers = _filter_headers(upstream.headers.items())
+            resp_headers = _filter_headers(upstream.headers.items(), _DROP_FROM_RESPONSE)
             return Response(
                 content=content,
                 status_code=upstream.status_code,
@@ -181,7 +202,7 @@ async def sanitize_messages(
             await upstream.aclose()
             await client.aclose()
 
-    resp_headers = _filter_headers(upstream.headers.items())
+    resp_headers = _filter_headers(upstream.headers.items(), _DROP_FROM_RESPONSE)
     # Streaming-specific headers must not be cached or buffered by proxies.
     resp_headers["Cache-Control"] = "no-cache"
     resp_headers["X-Accel-Buffering"] = "no"

--- a/src/sanitizer/routes.py
+++ b/src/sanitizer/routes.py
@@ -20,8 +20,8 @@ from fastapi.security import HTTPAuthorizationCredentials
 from src.auth import security, verify_api_key
 from src.sanitizer.config import (
     get_request_timeout_seconds,
-    get_upstream_api_key,
     get_upstream_url,
+    is_enabled,
 )
 from src.sanitizer.stream_sanitizer import sanitize_events
 
@@ -130,13 +130,21 @@ async def sanitize_messages(
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
 ) -> Response:
     """Proxy ``/v1/messages`` to the upstream and rewrite the SSE stream."""
+    if not is_enabled():
+        # The route is always mounted so admins can flip it on/off at runtime;
+        # when disabled it should look effectively absent to the client.
+        return Response(
+            status_code=503,
+            content=json.dumps(
+                {"error": {"type": "service_unavailable", "message": "sanitizer is disabled"}}
+            ).encode("utf-8"),
+            media_type="application/json",
+        )
+
     await verify_api_key(request, credentials)
 
     body = await request.body()
     fwd_headers = _filter_headers(request.headers.items(), _DROP_FROM_REQUEST)
-    upstream_key = get_upstream_api_key()
-    if upstream_key is not None:
-        fwd_headers["Authorization"] = f"Bearer {upstream_key}"
 
     # Decide stream vs non-stream from the request body, falling back to
     # non-stream on parse failure (matches Anthropic API behavior).

--- a/src/sanitizer/routes.py
+++ b/src/sanitizer/routes.py
@@ -52,8 +52,8 @@ _HOP_BY_HOP = frozenset(
 )
 
 # Stripped from the request before forwarding to upstream:
-# - ``authorization``: the gateway has its own API key; upstream is a different
-#   trust boundary and gets its bearer from SANITIZER_UPSTREAM_API_KEY.
+# - ``authorization``: the gateway has its own API key; we don't want it
+#   leaking onto the loopback port as a de-facto upstream credential.
 # - ``accept-encoding``: httpx negotiates and auto-decompresses internally; if
 #   we forwarded the client's value, upstream would compress and we'd decode
 #   anyway — wasted upstream CPU.
@@ -131,12 +131,14 @@ async def sanitize_messages(
 ) -> Response:
     """Proxy ``/v1/messages`` to the upstream and rewrite the SSE stream."""
     if not is_enabled():
-        # The route is always mounted so admins can flip it on/off at runtime;
-        # when disabled it should look effectively absent to the client.
+        # The route is always mounted so admins can flip it on/off at runtime,
+        # but to the outside world a disabled sanitizer must look exactly as if
+        # ``/v1/messages`` were never registered. This preserves the legacy
+        # contract that tests/clients depend on (``status in (404, 405)``).
         return Response(
-            status_code=503,
+            status_code=404,
             content=json.dumps(
-                {"error": {"type": "service_unavailable", "message": "sanitizer is disabled"}}
+                {"error": {"type": "not_found", "message": "Not Found"}}
             ).encode("utf-8"),
             media_type="application/json",
         )

--- a/src/sanitizer/stream_sanitizer.py
+++ b/src/sanitizer/stream_sanitizer.py
@@ -7,17 +7,35 @@ serialization.
 
 from __future__ import annotations
 
-from typing import Any, AsyncIterator, Dict, Optional
+from typing import Any, AsyncIterator, Dict, FrozenSet, Optional
 
 
-# Mapping from a delta event's ``delta.type`` to the ``content_block.type`` it
-# must live inside, per the Anthropic Messages stream spec.
-DELTA_TO_BLOCK_TYPE: Dict[str, str] = {
+# Block types a given ``delta.type`` is allowed to appear inside. The Anthropic
+# Messages stream emits ``input_json_delta`` for both regular ``tool_use`` and
+# server-side variants (e.g. ``server_tool_use`` for web search), so the
+# compatibility is a set rather than a single type.
+DELTA_COMPATIBLE_BLOCKS: Dict[str, FrozenSet[str]] = {
+    "text_delta": frozenset({"text"}),
+    "thinking_delta": frozenset({"thinking"}),
+    "signature_delta": frozenset({"thinking"}),
+    "input_json_delta": frozenset({"tool_use", "server_tool_use"}),
+}
+
+# When the sanitizer must synthesize a new ``content_block_start`` for a delta
+# that has no compatible open block, this is the block type it picks. Falls
+# back to a regular ``tool_use`` for tool deltas since synthesizing a
+# ``server_tool_use`` without an id/name is even less useful.
+DELTA_PRIMARY_BLOCK: Dict[str, str] = {
     "text_delta": "text",
     "thinking_delta": "thinking",
-    "input_json_delta": "tool_use",
     "signature_delta": "thinking",
+    "input_json_delta": "tool_use",
 }
+
+# Backward-compatible alias: external callers (tests, etc.) may still reference
+# the old single-value mapping. The new compatibility set above is the source
+# of truth for the sanitizer's split decision.
+DELTA_TO_BLOCK_TYPE: Dict[str, str] = dict(DELTA_PRIMARY_BLOCK)
 
 
 def _synthetic_block(block_type: str) -> Dict[str, Any]:
@@ -77,16 +95,23 @@ async def sanitize_events(
 
         if etype == "content_block_delta":
             delta_type = evt.get("delta", {}).get("type")
-            expected = DELTA_TO_BLOCK_TYPE.get(delta_type)
-            if expected is not None and expected != current_block_type:
+            compatible = DELTA_COMPATIBLE_BLOCKS.get(delta_type)
+            if compatible is not None and current_block_type not in compatible:
+                # Current block can't validly hold this delta — close it and
+                # open a synthetic block of the delta's primary type. This is
+                # the LiteLLM #21128 path (text block opened, thinking_delta
+                # arrives) but it must NOT fire when an already-compatible
+                # block (e.g. server_tool_use receiving input_json_delta) is
+                # open, since that would strip the upstream id/name/type.
                 if current_block_type is not None:
                     yield _close_current()
                 current_index += 1
-                current_block_type = expected
+                primary = DELTA_PRIMARY_BLOCK[delta_type]
+                current_block_type = primary
                 yield {
                     "type": "content_block_start",
                     "index": current_index,
-                    "content_block": _synthetic_block(expected),
+                    "content_block": _synthetic_block(primary),
                 }
             new_evt = dict(evt)
             new_evt["index"] = current_index

--- a/src/sanitizer/stream_sanitizer.py
+++ b/src/sanitizer/stream_sanitizer.py
@@ -1,0 +1,119 @@
+"""Pure event-stream transformation for Anthropic Messages SSE.
+
+The transformation is independent of HTTP/SSE encoding so it can be unit-tested
+against plain Python dicts. The route layer is responsible for SSE parsing and
+serialization.
+"""
+
+from __future__ import annotations
+
+from typing import Any, AsyncIterator, Dict, Optional
+
+
+# Mapping from a delta event's ``delta.type`` to the ``content_block.type`` it
+# must live inside, per the Anthropic Messages stream spec.
+DELTA_TO_BLOCK_TYPE: Dict[str, str] = {
+    "text_delta": "text",
+    "thinking_delta": "thinking",
+    "input_json_delta": "tool_use",
+    "signature_delta": "thinking",
+}
+
+
+def _synthetic_block(block_type: str) -> Dict[str, Any]:
+    """Build a minimal ``content_block`` payload for a synthesized start event."""
+    if block_type == "text":
+        return {"type": "text", "text": ""}
+    if block_type == "thinking":
+        return {"type": "thinking", "thinking": ""}
+    if block_type == "tool_use":
+        # Real tool_use blocks carry id/name/input — those should arrive from
+        # upstream's own content_block_start. When we synthesize one, downstream
+        # may still reject; we emit best-effort defaults rather than crashing.
+        return {"type": "tool_use", "id": "", "name": "", "input": {}}
+    return {"type": block_type}
+
+
+async def sanitize_events(
+    upstream: AsyncIterator[Dict[str, Any]],
+) -> AsyncIterator[Dict[str, Any]]:
+    """Yield a spec-conforming sequence of Anthropic Messages events.
+
+    Guarantees on the output stream:
+    - ``message_start`` is emitted at most once.
+    - Every ``content_block_delta.delta.type`` matches the type of the most
+      recent (still-open) ``content_block_start``.
+    - Indices on emitted events are monotonically increasing, starting at 0.
+    - Every ``content_block_start`` has a matching ``content_block_stop``
+      before the next start, ``message_delta``, or ``message_stop``.
+    """
+    seen_message_start = False
+    current_index = -1
+    current_block_type: Optional[str] = None
+
+    def _close_current() -> Dict[str, Any]:
+        return {"type": "content_block_stop", "index": current_index}
+
+    async for evt in upstream:
+        etype = evt.get("type")
+
+        if etype == "message_start":
+            if seen_message_start:
+                continue
+            seen_message_start = True
+            yield evt
+            continue
+
+        if etype == "content_block_start":
+            if current_block_type is not None:
+                yield _close_current()
+                current_block_type = None
+            current_index += 1
+            current_block_type = evt.get("content_block", {}).get("type")
+            new_evt = dict(evt)
+            new_evt["index"] = current_index
+            yield new_evt
+            continue
+
+        if etype == "content_block_delta":
+            delta_type = evt.get("delta", {}).get("type")
+            expected = DELTA_TO_BLOCK_TYPE.get(delta_type)
+            if expected is not None and expected != current_block_type:
+                if current_block_type is not None:
+                    yield _close_current()
+                current_index += 1
+                current_block_type = expected
+                yield {
+                    "type": "content_block_start",
+                    "index": current_index,
+                    "content_block": _synthetic_block(expected),
+                }
+            new_evt = dict(evt)
+            new_evt["index"] = current_index
+            yield new_evt
+            continue
+
+        if etype == "content_block_stop":
+            if current_block_type is None:
+                # Sanitizer already closed this block (or none was ever open).
+                continue
+            yield _close_current()
+            current_block_type = None
+            continue
+
+        if etype == "message_delta":
+            if current_block_type is not None:
+                yield _close_current()
+                current_block_type = None
+            yield evt
+            continue
+
+        if etype == "message_stop":
+            if current_block_type is not None:
+                yield _close_current()
+                current_block_type = None
+            yield evt
+            continue
+
+        # ping / error / unknown — pass through.
+        yield evt

--- a/tests/test_claude_cli_unit.py
+++ b/tests/test_claude_cli_unit.py
@@ -804,6 +804,34 @@ class TestSdkEnvContextManager:
         else:
             assert os.environ.get("ANTHROPIC_AUTH_TOKEN") == original
 
+    def test_sdk_env_routes_base_url_to_sanitizer_when_enabled(self, cli_instance, monkeypatch):
+        """Sanitizer keeps global ANTHROPIC_BASE_URL as upstream and rewrites only SDK env."""
+        from src.runtime_config import runtime_config
+
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://litellm:4000")
+        monkeypatch.setenv("PORT", "8765")
+        runtime_config.set("sanitizer_enabled", True)
+        try:
+            with cli_instance._sdk_env():
+                assert os.environ.get("ANTHROPIC_BASE_URL") == "http://127.0.0.1:8765"
+                assert os.environ.get("ANTHROPIC_AUTH_TOKEN") == "test-key"
+
+            assert os.environ.get("ANTHROPIC_BASE_URL") == "http://litellm:4000"
+        finally:
+            runtime_config.reset("sanitizer_enabled")
+
+    def test_sdk_env_preserves_base_url_when_sanitizer_disabled(self, cli_instance, monkeypatch):
+        """Disabled sanitizer should leave Claude's upstream base URL untouched."""
+        from src.runtime_config import runtime_config
+
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://litellm:4000")
+        runtime_config.set("sanitizer_enabled", False)
+        try:
+            with cli_instance._sdk_env():
+                assert os.environ.get("ANTHROPIC_BASE_URL") == "http://litellm:4000"
+        finally:
+            runtime_config.reset("sanitizer_enabled")
+
     def test_sdk_env_noop_when_no_vars(self):
         """_sdk_env is a no-op when no auth env vars configured."""
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_claude_cli_unit.py
+++ b/tests/test_claude_cli_unit.py
@@ -405,6 +405,31 @@ class TestClaudeCodeCLIVerifyCLI:
             assert result is True
 
     @pytest.mark.asyncio
+    async def test_verify_cli_uses_sdk_options_env(self, cli_instance, monkeypatch):
+        """Health checks should use the same SDK env routing as real sessions."""
+        from src.runtime_config import runtime_config
+
+        captured = {}
+        mock_message = {"type": "assistant", "content": [{"type": "text", "text": "Hello"}]}
+
+        async def mock_query(*args, **kwargs):
+            captured.update(kwargs)
+            yield mock_message
+
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://litellm:4000")
+        monkeypatch.setenv("PORT", "8765")
+        runtime_config.set("sanitizer_enabled", True)
+        try:
+            with patch("src.backends.claude.client.query", mock_query):
+                result = await cli_instance.verify_cli()
+            assert result is True
+            assert captured["options"].env["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:8765"
+            assert captured["options"].env["ANTHROPIC_AUTH_TOKEN"] == "test-key"
+            assert os.environ.get("ANTHROPIC_BASE_URL") == "http://litellm:4000"
+        finally:
+            runtime_config.reset("sanitizer_enabled")
+
+    @pytest.mark.asyncio
     async def test_verify_cli_no_messages(self, cli_instance):
         """verify_cli returns False when no messages returned."""
 
@@ -599,6 +624,38 @@ class TestBuildSdkOptions:
         with patch("src.backends.claude.client.DEFAULT_TASK_BUDGET", 100000):
             opts = cli_instance._build_sdk_options(task_budget=25000)
             assert opts.task_budget == {"total": 25000}
+
+    def test_sdk_options_routes_base_url_to_sanitizer_when_enabled(
+        self, cli_instance, monkeypatch
+    ):
+        """Only the SDK subprocess env should point at the local sanitizer."""
+        from src.runtime_config import runtime_config
+
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://litellm:4000")
+        monkeypatch.setenv("PORT", "8765")
+        runtime_config.set("sanitizer_enabled", True)
+        try:
+            opts = cli_instance._build_sdk_options()
+            assert opts.env["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:8765"
+            assert opts.env["ANTHROPIC_AUTH_TOKEN"] == "test-key"
+            assert os.environ.get("ANTHROPIC_BASE_URL") == "http://litellm:4000"
+        finally:
+            runtime_config.reset("sanitizer_enabled")
+
+    def test_sdk_options_preserve_base_url_when_sanitizer_disabled(
+        self, cli_instance, monkeypatch
+    ):
+        """Disabled sanitizer leaves Claude's upstream base URL untouched."""
+        from src.runtime_config import runtime_config
+
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://litellm:4000")
+        runtime_config.set("sanitizer_enabled", False)
+        try:
+            opts = cli_instance._build_sdk_options()
+            assert "ANTHROPIC_BASE_URL" not in opts.env
+            assert opts.env["ANTHROPIC_AUTH_TOKEN"] == "test-key"
+        finally:
+            runtime_config.reset("sanitizer_enabled")
 
 
 class TestConvertMessageTypeMap:
@@ -804,8 +861,11 @@ class TestSdkEnvContextManager:
         else:
             assert os.environ.get("ANTHROPIC_AUTH_TOKEN") == original
 
-    def test_sdk_env_routes_base_url_to_sanitizer_when_enabled(self, cli_instance, monkeypatch):
-        """Sanitizer keeps global ANTHROPIC_BASE_URL as upstream and rewrites only SDK env."""
+    def test_sdk_env_does_not_mutate_base_url_when_sanitizer_enabled(
+        self, cli_instance, monkeypatch
+    ):
+        """Sanitizer upstream must remain readable while SDK env is active."""
+        from src.sanitizer.config import get_upstream_url
         from src.runtime_config import runtime_config
 
         monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://litellm:4000")
@@ -813,7 +873,8 @@ class TestSdkEnvContextManager:
         runtime_config.set("sanitizer_enabled", True)
         try:
             with cli_instance._sdk_env():
-                assert os.environ.get("ANTHROPIC_BASE_URL") == "http://127.0.0.1:8765"
+                assert os.environ.get("ANTHROPIC_BASE_URL") == "http://litellm:4000"
+                assert get_upstream_url() == "http://litellm:4000"
                 assert os.environ.get("ANTHROPIC_AUTH_TOKEN") == "test-key"
 
             assert os.environ.get("ANTHROPIC_BASE_URL") == "http://litellm:4000"

--- a/tests/test_sanitizer_routes_unit.py
+++ b/tests/test_sanitizer_routes_unit.py
@@ -15,6 +15,18 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 import src.sanitizer.routes as sanitizer_routes
+from src.runtime_config import runtime_config
+
+
+@pytest.fixture(autouse=True)
+def _enable_sanitizer(monkeypatch):
+    """Most tests assume the sanitizer accepts requests; the disabled-path test
+    overrides this with its own ``runtime_config.set(..., False)`` call.
+    """
+    monkeypatch.setenv("SANITIZER_ENABLED", "true")
+    runtime_config.reset("sanitizer_enabled")
+    yield
+    runtime_config.reset("sanitizer_enabled")
 
 
 def _sse_payload(events: Iterable[dict]) -> bytes:
@@ -190,11 +202,15 @@ def _capture_request_handler(response: httpx.Response):
 
 
 def test_client_authorization_is_not_forwarded_upstream(monkeypatch):
-    """Client bearer authenticates the gateway; upstream is a different trust boundary."""
+    """Client bearer authenticates the gateway; localhost upstream gets no bearer.
+
+    Even though localhost is the same trust boundary, we still strip the
+    client's Authorization so the gateway key doesn't accidentally become a
+    de-facto credential for whatever runs on the loopback port.
+    """
     from src.auth import auth_manager
 
     monkeypatch.setattr(auth_manager, "runtime_api_key", "secret-key")
-    monkeypatch.delenv("SANITIZER_UPSTREAM_API_KEY", raising=False)
 
     handler, captured = _capture_request_handler(
         httpx.Response(200, headers={"content-type": "application/json"}, content=b"{}")
@@ -210,25 +226,21 @@ def test_client_authorization_is_not_forwarded_upstream(monkeypatch):
     assert "authorization" not in {k.lower() for k in captured["request"].headers.keys()}
 
 
-def test_upstream_api_key_replaces_authorization(monkeypatch):
-    """When SANITIZER_UPSTREAM_API_KEY is set, upstream sees that bearer instead."""
-    from src.auth import auth_manager
+def test_disabled_via_runtime_config_returns_503():
+    """Admin toggle sets sanitizer_enabled=False → route short-circuits to 503."""
 
-    monkeypatch.setattr(auth_manager, "runtime_api_key", "secret-key")
-    monkeypatch.setenv("SANITIZER_UPSTREAM_API_KEY", "upstream-key")
+    def handler(request: httpx.Request) -> httpx.Response:  # noqa: ARG001
+        raise AssertionError("upstream was contacted despite sanitizer being disabled")
 
-    handler, captured = _capture_request_handler(
-        httpx.Response(200, headers={"content-type": "application/json"}, content=b"{}")
-    )
     app = _make_app(handler)
+    runtime_config.set("sanitizer_enabled", False)
     client = TestClient(app)
     resp = client.post(
         "/v1/messages",
         json={"model": "x", "stream": False, "messages": []},
-        headers={"Authorization": "Bearer secret-key"},
     )
-    assert resp.status_code == 200
-    assert captured["request"].headers.get("authorization") == "Bearer upstream-key"
+    assert resp.status_code == 503
+    assert json.loads(resp.content)["error"]["type"] == "service_unavailable"
 
 
 def test_accept_encoding_is_not_forwarded_upstream():

--- a/tests/test_sanitizer_routes_unit.py
+++ b/tests/test_sanitizer_routes_unit.py
@@ -176,3 +176,104 @@ def test_verify_api_key_accepts_correct_bearer(monkeypatch):
     )
     assert resp.status_code == 200
     assert resp.content == body
+
+
+def _capture_request_handler(response: httpx.Response):
+    """Return (handler, captured) where captured["request"] holds the last call."""
+    captured: dict[str, httpx.Request] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["request"] = request
+        return response
+
+    return handler, captured
+
+
+def test_client_authorization_is_not_forwarded_upstream(monkeypatch):
+    """Client bearer authenticates the gateway; upstream is a different trust boundary."""
+    from src.auth import auth_manager
+
+    monkeypatch.setattr(auth_manager, "runtime_api_key", "secret-key")
+    monkeypatch.delenv("SANITIZER_UPSTREAM_API_KEY", raising=False)
+
+    handler, captured = _capture_request_handler(
+        httpx.Response(200, headers={"content-type": "application/json"}, content=b"{}")
+    )
+    app = _make_app(handler)
+    client = TestClient(app)
+    resp = client.post(
+        "/v1/messages",
+        json={"model": "x", "stream": False, "messages": []},
+        headers={"Authorization": "Bearer secret-key"},
+    )
+    assert resp.status_code == 200
+    assert "authorization" not in {k.lower() for k in captured["request"].headers.keys()}
+
+
+def test_upstream_api_key_replaces_authorization(monkeypatch):
+    """When SANITIZER_UPSTREAM_API_KEY is set, upstream sees that bearer instead."""
+    from src.auth import auth_manager
+
+    monkeypatch.setattr(auth_manager, "runtime_api_key", "secret-key")
+    monkeypatch.setenv("SANITIZER_UPSTREAM_API_KEY", "upstream-key")
+
+    handler, captured = _capture_request_handler(
+        httpx.Response(200, headers={"content-type": "application/json"}, content=b"{}")
+    )
+    app = _make_app(handler)
+    client = TestClient(app)
+    resp = client.post(
+        "/v1/messages",
+        json={"model": "x", "stream": False, "messages": []},
+        headers={"Authorization": "Bearer secret-key"},
+    )
+    assert resp.status_code == 200
+    assert captured["request"].headers.get("authorization") == "Bearer upstream-key"
+
+
+def test_accept_encoding_is_not_forwarded_upstream():
+    """We re-serialize SSE as plain UTF-8, so requesting compression upstream is wasteful."""
+    handler, captured = _capture_request_handler(
+        httpx.Response(200, headers={"content-type": "application/json"}, content=b"{}")
+    )
+    app = _make_app(handler)
+    client = TestClient(app)
+    resp = client.post(
+        "/v1/messages",
+        json={"model": "x", "stream": False, "messages": []},
+        headers={"Accept-Encoding": "gzip, deflate, br"},
+    )
+    assert resp.status_code == 200
+    # httpx may add its own default accept-encoding; the important contract is
+    # that the *client's* value did not bleed through verbatim.
+    forwarded = captured["request"].headers.get("accept-encoding", "")
+    assert "br" not in forwarded
+
+
+def test_content_encoding_stripped_from_response():
+    """httpx auto-decodes bodies; passing content-encoding to the client would mislead it."""
+    import gzip
+
+    body = json.dumps({"id": "msg_1"}).encode()
+    gz_body = gzip.compress(body)
+
+    def handler(request: httpx.Request) -> httpx.Response:  # noqa: ARG001
+        return httpx.Response(
+            200,
+            headers={
+                "content-type": "application/json",
+                "content-encoding": "gzip",
+            },
+            content=gz_body,
+        )
+
+    app = _make_app(handler)
+    client = TestClient(app)
+    resp = client.post(
+        "/v1/messages",
+        json={"model": "x", "stream": False, "messages": []},
+    )
+    assert resp.status_code == 200
+    # httpx auto-decoded the body; we must not advertise it as still encoded.
+    assert "content-encoding" not in {k.lower() for k in resp.headers.keys()}
+    assert resp.content == body

--- a/tests/test_sanitizer_routes_unit.py
+++ b/tests/test_sanitizer_routes_unit.py
@@ -1,0 +1,116 @@
+"""Route-level tests for the sanitizer proxy.
+
+Verifies that ``POST /v1/messages`` forwards to the upstream and the response
+SSE stream is rewritten so block-type/delta-type pairs are consistent.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Iterable
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import src.sanitizer.routes as sanitizer_routes
+
+
+def _sse_payload(events: Iterable[dict]) -> bytes:
+    """Encode a sequence of event dicts as Anthropic-style SSE bytes."""
+    parts = []
+    for evt in events:
+        parts.append(f"event: {evt['type']}\ndata: {json.dumps(evt)}\n\n")
+    return "".join(parts).encode("utf-8")
+
+
+def _make_app(handler) -> FastAPI:
+    app = FastAPI()
+    app.include_router(sanitizer_routes.router)
+    transport = httpx.MockTransport(handler)
+
+    def _factory(timeout):  # noqa: ARG001
+        return httpx.AsyncClient(transport=transport, timeout=timeout)
+
+    sanitizer_routes._make_client = _factory  # type: ignore[assignment]
+    return app
+
+
+@pytest.fixture
+def buggy_litellm():
+    """MockTransport that mimics LiteLLM #21128: text block start with thinking_delta."""
+
+    events = [
+        {"type": "message_start", "message": {"id": "msg_1", "role": "assistant"}},
+        {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+        {"type": "content_block_delta", "index": 0, "delta": {"type": "thinking_delta", "thinking": "User asks..."}},
+        {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Hello!"}},
+        {"type": "content_block_stop", "index": 0},
+        {"type": "message_delta", "delta": {"stop_reason": "end_turn"}},
+        {"type": "message_stop"},
+    ]
+    body = _sse_payload(events)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/messages"
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=body,
+        )
+
+    return handler
+
+
+def _parse_sse(raw: str) -> list[dict]:
+    events: list[dict] = []
+    for block in raw.split("\n\n"):
+        if not block.strip():
+            continue
+        for line in block.splitlines():
+            if line.startswith("data:"):
+                events.append(json.loads(line[5:].lstrip()))
+    return events
+
+
+def test_streaming_rewrites_buggy_litellm_stream(buggy_litellm):
+    app = _make_app(buggy_litellm)
+    client = TestClient(app)
+
+    resp = client.post(
+        "/v1/messages",
+        json={"model": "GLM-5.1-FP8", "stream": True, "messages": []},
+    )
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/event-stream")
+
+    events = _parse_sse(resp.text)
+
+    # The thinking_delta must live inside a thinking block, not the text block.
+    for evt in events:
+        if evt["type"] == "content_block_delta" and evt["delta"]["type"] == "thinking_delta":
+            # find enclosing block start
+            idx = evt["index"]
+            block_start = next(
+                e
+                for e in events
+                if e["type"] == "content_block_start" and e["index"] == idx
+            )
+            assert block_start["content_block"]["type"] == "thinking"
+
+
+def test_non_streaming_passes_through_verbatim():
+    body = json.dumps({"id": "msg_1", "content": [{"type": "text", "text": "hi"}]}).encode()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, headers={"content-type": "application/json"}, content=body)
+
+    app = _make_app(handler)
+    client = TestClient(app)
+    resp = client.post(
+        "/v1/messages",
+        json={"model": "GLM-5.1-FP8", "stream": False, "messages": []},
+    )
+    assert resp.status_code == 200
+    assert resp.content == body

--- a/tests/test_sanitizer_routes_unit.py
+++ b/tests/test_sanitizer_routes_unit.py
@@ -226,8 +226,8 @@ def test_client_authorization_is_not_forwarded_upstream(monkeypatch):
     assert "authorization" not in {k.lower() for k in captured["request"].headers.keys()}
 
 
-def test_disabled_via_runtime_config_returns_503():
-    """Admin toggle sets sanitizer_enabled=False → route short-circuits to 503."""
+def test_disabled_via_runtime_config_returns_404():
+    """Admin toggle off → route must look exactly absent to clients (404)."""
 
     def handler(request: httpx.Request) -> httpx.Response:  # noqa: ARG001
         raise AssertionError("upstream was contacted despite sanitizer being disabled")
@@ -239,8 +239,7 @@ def test_disabled_via_runtime_config_returns_503():
         "/v1/messages",
         json={"model": "x", "stream": False, "messages": []},
     )
-    assert resp.status_code == 503
-    assert json.loads(resp.content)["error"]["type"] == "service_unavailable"
+    assert resp.status_code == 404
 
 
 def test_accept_encoding_is_not_forwarded_upstream():

--- a/tests/test_sanitizer_routes_unit.py
+++ b/tests/test_sanitizer_routes_unit.py
@@ -114,3 +114,65 @@ def test_non_streaming_passes_through_verbatim():
     )
     assert resp.status_code == 200
     assert resp.content == body
+
+
+def test_streaming_upstream_returns_json_error_is_passed_through_verbatim():
+    """Upstream may return a JSON error even when client asked for SSE.
+
+    The sanitizer must forward the raw payload (not silently drop it through
+    the SSE parser), so the client can see the real error.
+    """
+    err_body = json.dumps({"error": {"message": "model not found", "type": "not_found_error"}}).encode()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, headers={"content-type": "application/json"}, content=err_body)
+
+    app = _make_app(handler)
+    client = TestClient(app)
+    resp = client.post(
+        "/v1/messages",
+        json={"model": "missing", "stream": True, "messages": []},
+    )
+    assert resp.status_code == 404
+    assert resp.headers["content-type"].startswith("application/json")
+    assert resp.content == err_body
+
+
+def test_verify_api_key_rejects_unauthorized_request(monkeypatch):
+    """When API_KEY is configured, /v1/messages must require Bearer auth."""
+    from src.auth import auth_manager
+
+    monkeypatch.setattr(auth_manager, "runtime_api_key", "secret-key")
+
+    def handler(request: httpx.Request) -> httpx.Response:  # noqa: ARG001
+        # Should never be called — auth must reject before forwarding.
+        raise AssertionError("upstream was contacted despite missing API key")
+
+    app = _make_app(handler)
+    client = TestClient(app)
+    resp = client.post(
+        "/v1/messages",
+        json={"model": "x", "stream": False, "messages": []},
+    )
+    assert resp.status_code == 401
+
+
+def test_verify_api_key_accepts_correct_bearer(monkeypatch):
+    from src.auth import auth_manager
+
+    monkeypatch.setattr(auth_manager, "runtime_api_key", "secret-key")
+
+    body = json.dumps({"id": "msg_1"}).encode()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, headers={"content-type": "application/json"}, content=body)
+
+    app = _make_app(handler)
+    client = TestClient(app)
+    resp = client.post(
+        "/v1/messages",
+        json={"model": "x", "stream": False, "messages": []},
+        headers={"Authorization": "Bearer secret-key"},
+    )
+    assert resp.status_code == 200
+    assert resp.content == body

--- a/tests/test_sanitizer_routes_unit.py
+++ b/tests/test_sanitizer_routes_unit.py
@@ -128,6 +128,25 @@ def test_non_streaming_passes_through_verbatim():
     assert resp.content == body
 
 
+def test_upstream_uses_anthropic_base_url(monkeypatch):
+    """ANTHROPIC_BASE_URL remains the real upstream the sanitizer forwards to."""
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://litellm:4000")
+    body = json.dumps({"id": "msg_1"}).encode()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert str(request.url) == "http://litellm:4000/v1/messages"
+        return httpx.Response(200, headers={"content-type": "application/json"}, content=body)
+
+    app = _make_app(handler)
+    client = TestClient(app)
+    resp = client.post(
+        "/v1/messages",
+        json={"model": "GLM-5.1-FP8", "stream": False, "messages": []},
+    )
+    assert resp.status_code == 200
+    assert resp.content == body
+
+
 def test_streaming_upstream_returns_json_error_is_passed_through_verbatim():
     """Upstream may return a JSON error even when client asked for SSE.
 
@@ -202,11 +221,10 @@ def _capture_request_handler(response: httpx.Response):
 
 
 def test_client_authorization_is_not_forwarded_upstream(monkeypatch):
-    """Client bearer authenticates the gateway; localhost upstream gets no bearer.
+    """External client bearer authenticates the gateway, not the upstream.
 
-    Even though localhost is the same trust boundary, we still strip the
-    client's Authorization so the gateway key doesn't accidentally become a
-    de-facto credential for whatever runs on the loopback port.
+    Non-loopback requests use gateway auth, so that credential must not become
+    a de-facto upstream credential.
     """
     from src.auth import auth_manager
 
@@ -224,6 +242,24 @@ def test_client_authorization_is_not_forwarded_upstream(monkeypatch):
     )
     assert resp.status_code == 200
     assert "authorization" not in {k.lower() for k in captured["request"].headers.keys()}
+
+
+def test_loopback_authorization_is_forwarded_to_upstream(monkeypatch):
+    """Claude SDK self-calls carry the real Anthropic/LiteLLM bearer upstream."""
+    monkeypatch.setattr(sanitizer_routes, "_is_loopback_request", lambda request: True)
+
+    handler, captured = _capture_request_handler(
+        httpx.Response(200, headers={"content-type": "application/json"}, content=b"{}")
+    )
+    app = _make_app(handler)
+    client = TestClient(app)
+    resp = client.post(
+        "/v1/messages",
+        json={"model": "x", "stream": False, "messages": []},
+        headers={"Authorization": "Bearer upstream-key"},
+    )
+    assert resp.status_code == 200
+    assert captured["request"].headers.get("authorization") == "Bearer upstream-key"
 
 
 def test_disabled_via_runtime_config_returns_404():

--- a/tests/test_sanitizer_stream_unit.py
+++ b/tests/test_sanitizer_stream_unit.py
@@ -13,7 +13,7 @@ from typing import AsyncIterator, Iterable, List
 
 import pytest
 
-from src.sanitizer.stream_sanitizer import DELTA_TO_BLOCK_TYPE, sanitize_events
+from src.sanitizer.stream_sanitizer import DELTA_COMPATIBLE_BLOCKS, sanitize_events
 
 
 # ---------------------------------------------------------------------------
@@ -51,10 +51,11 @@ def assert_spec_conforming(events: List[dict]) -> None:
             idx, block_type = open_block
             assert evt["index"] == idx, f"delta index {evt['index']} != open {idx}"
             delta_type = evt["delta"]["type"]
-            expected = DELTA_TO_BLOCK_TYPE.get(delta_type, block_type)
-            assert expected == block_type, (
-                f"delta type {delta_type} in {block_type} block (idx={idx})"
-            )
+            compatible = DELTA_COMPATIBLE_BLOCKS.get(delta_type)
+            if compatible is not None:
+                assert block_type in compatible, (
+                    f"delta type {delta_type} in {block_type} block (idx={idx})"
+                )
         elif t == "content_block_stop":
             assert open_block is not None, f"stop with no open block: {evt}"
             assert evt["index"] == open_block[0]
@@ -238,6 +239,39 @@ class TestSanitizerSpecCompliance:
         out = await _collect(sanitize_events(_as_async(events)))
         assert any(e["type"] == "ping" for e in out)
         assert_spec_conforming(out)
+
+    async def test_input_json_delta_inside_server_tool_use_does_not_split(self):
+        """server_tool_use blocks (e.g. web_search) emit input_json_delta too.
+
+        The sanitizer must treat the existing server_tool_use as compatible and
+        leave the upstream id/name/type intact, instead of closing it and
+        synthesizing an empty tool_use block.
+        """
+        events = [
+            {"type": "message_start", "message": {"id": "msg_1"}},
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {
+                    "type": "server_tool_use",
+                    "id": "srvtoolu_abc",
+                    "name": "web_search",
+                    "input": {},
+                },
+            },
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": "{\"q\":"}},
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": "\"x\"}"}},
+            {"type": "content_block_stop", "index": 0},
+            {"type": "message_stop"},
+        ]
+        out = await _collect(sanitize_events(_as_async(events)))
+        assert_spec_conforming(out)
+        starts = [e for e in out if e["type"] == "content_block_start"]
+        # Exactly one block, the original server_tool_use — no synthetic split.
+        assert len(starts) == 1
+        assert starts[0]["content_block"]["type"] == "server_tool_use"
+        assert starts[0]["content_block"]["id"] == "srvtoolu_abc"
+        assert starts[0]["content_block"]["name"] == "web_search"
 
     async def test_explicit_block_start_after_synthetic_split_remains_consistent(self):
         """Upstream emits content_block_start mid-stream after we've already split."""

--- a/tests/test_sanitizer_stream_unit.py
+++ b/tests/test_sanitizer_stream_unit.py
@@ -1,0 +1,268 @@
+"""Unit tests for src.sanitizer.stream_sanitizer.
+
+The sanitizer rewrites a malformed Anthropic Messages SSE event stream into a
+spec-conforming one. The canonical bug it fixes is LiteLLM's
+``AnthropicStreamWrapper`` (#21128), which emits the first content block with
+``type: "text"`` regardless of whether the model is actually thinking — causing
+``thinking_delta`` events to land inside a ``type=text`` block.
+"""
+
+from __future__ import annotations
+
+from typing import AsyncIterator, Iterable, List
+
+import pytest
+
+from src.sanitizer.stream_sanitizer import DELTA_TO_BLOCK_TYPE, sanitize_events
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _as_async(events: Iterable[dict]) -> AsyncIterator[dict]:
+    for e in events:
+        yield e
+
+
+async def _collect(aiter: AsyncIterator[dict]) -> List[dict]:
+    return [e async for e in aiter]
+
+
+def assert_spec_conforming(events: List[dict]) -> None:
+    """Validate that *events* matches Anthropic Messages stream spec."""
+    seen_message_start = False
+    open_block: tuple[int, str] | None = None
+    last_index = -1
+    for evt in events:
+        t = evt["type"]
+        if t == "message_start":
+            assert not seen_message_start, "duplicate message_start"
+            seen_message_start = True
+        elif t == "content_block_start":
+            assert open_block is None, f"prior block {open_block} still open at {evt}"
+            idx = evt["index"]
+            assert idx == last_index + 1, f"index {idx} not monotonic after {last_index}"
+            last_index = idx
+            open_block = (idx, evt["content_block"]["type"])
+        elif t == "content_block_delta":
+            assert open_block is not None, f"delta with no open block: {evt}"
+            idx, block_type = open_block
+            assert evt["index"] == idx, f"delta index {evt['index']} != open {idx}"
+            delta_type = evt["delta"]["type"]
+            expected = DELTA_TO_BLOCK_TYPE.get(delta_type, block_type)
+            assert expected == block_type, (
+                f"delta type {delta_type} in {block_type} block (idx={idx})"
+            )
+        elif t == "content_block_stop":
+            assert open_block is not None, f"stop with no open block: {evt}"
+            assert evt["index"] == open_block[0]
+            open_block = None
+        elif t in ("message_delta", "message_stop", "ping", "error"):
+            pass
+        else:
+            pytest.fail(f"unknown event type: {t}")
+    assert open_block is None, f"stream ended with block {open_block} still open"
+
+
+# ---------------------------------------------------------------------------
+# Cases
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizerSpecCompliance:
+    async def test_pattern4_clean_stream_passthrough(self):
+        """Anthropic-direct (correct) stream should pass through unchanged structurally."""
+        events = [
+            {"type": "message_start", "message": {"id": "msg_1", "role": "assistant"}},
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "thinking", "thinking": ""},
+            },
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "thinking_delta", "thinking": "User asks..."}},
+            {"type": "content_block_stop", "index": 0},
+            {
+                "type": "content_block_start",
+                "index": 1,
+                "content_block": {"type": "text", "text": ""},
+            },
+            {"type": "content_block_delta", "index": 1, "delta": {"type": "text_delta", "text": "Hello!"}},
+            {"type": "content_block_stop", "index": 1},
+            {"type": "message_delta", "delta": {"stop_reason": "end_turn"}},
+            {"type": "message_stop"},
+        ]
+        out = await _collect(sanitize_events(_as_async(events)))
+        assert_spec_conforming(out)
+        # No structural splits needed → same length and type sequence.
+        assert [e["type"] for e in out] == [e["type"] for e in events]
+
+    async def test_pattern2_text_block_with_thinking_delta_splits(self):
+        """LiteLLM bug: content_block_start says type=text but first delta is thinking_delta."""
+        events = [
+            {"type": "message_start", "message": {"id": "msg_1"}},
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text", "text": ""},
+            },
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "thinking_delta", "thinking": "User says..."}},
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "thinking_delta", "thinking": "..."}},
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Hello!"}},
+            {"type": "content_block_stop", "index": 0},
+            {"type": "message_delta", "delta": {"stop_reason": "end_turn"}},
+            {"type": "message_stop"},
+        ]
+        out = await _collect(sanitize_events(_as_async(events)))
+        assert_spec_conforming(out)
+        types = [e["type"] for e in out]
+        # Expected structure: text-start (empty, immediately closed) → thinking → text → stop → end
+        assert types == [
+            "message_start",
+            "content_block_start",   # upstream text start (idx 0)
+            "content_block_stop",    # synthetic close because next delta is thinking
+            "content_block_start",   # synthetic thinking start (idx 1)
+            "content_block_delta",
+            "content_block_delta",
+            "content_block_stop",    # synthetic close because next delta is text
+            "content_block_start",   # synthetic text start (idx 2)
+            "content_block_delta",
+            "content_block_stop",    # remapped upstream stop
+            "message_delta",
+            "message_stop",
+        ]
+        # Verify the synthesized blocks carry correct types.
+        starts = [e for e in out if e["type"] == "content_block_start"]
+        assert [s["content_block"]["type"] for s in starts] == ["text", "thinking", "text"]
+        assert [s["index"] for s in starts] == [0, 1, 2]
+
+    async def test_pattern3_duplicate_message_start_deduped(self):
+        events = [
+            {"type": "message_start", "message": {"id": "msg_1"}},
+            {"type": "message_start", "message": {"id": "msg_1"}},
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text", "text": ""},
+            },
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "hi"}},
+            {"type": "content_block_stop", "index": 0},
+            {"type": "message_stop"},
+        ]
+        out = await _collect(sanitize_events(_as_async(events)))
+        assert_spec_conforming(out)
+        assert sum(1 for e in out if e["type"] == "message_start") == 1
+
+    async def test_delta_without_content_block_start_synthesizes_one(self):
+        """Some upstreams skip content_block_start entirely."""
+        events = [
+            {"type": "message_start", "message": {"id": "msg_1"}},
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "hi"}},
+            {"type": "message_stop"},
+        ]
+        out = await _collect(sanitize_events(_as_async(events)))
+        assert_spec_conforming(out)
+        starts = [e for e in out if e["type"] == "content_block_start"]
+        assert len(starts) == 1
+        assert starts[0]["content_block"]["type"] == "text"
+
+    async def test_dangling_block_at_message_stop_is_auto_closed(self):
+        """Upstream drops final content_block_stop — sanitizer must inject one."""
+        events = [
+            {"type": "message_start", "message": {"id": "msg_1"}},
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text", "text": ""},
+            },
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "hi"}},
+            # NO content_block_stop here
+            {"type": "message_stop"},
+        ]
+        out = await _collect(sanitize_events(_as_async(events)))
+        assert_spec_conforming(out)
+        types = [e["type"] for e in out]
+        assert types[-2:] == ["content_block_stop", "message_stop"]
+
+    async def test_message_delta_closes_dangling_block(self):
+        events = [
+            {"type": "message_start", "message": {"id": "msg_1"}},
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text", "text": ""},
+            },
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "hi"}},
+            {"type": "message_delta", "delta": {"stop_reason": "end_turn"}},
+            {"type": "message_stop"},
+        ]
+        out = await _collect(sanitize_events(_as_async(events)))
+        assert_spec_conforming(out)
+        # message_delta must be preceded by a content_block_stop.
+        idx = next(i for i, e in enumerate(out) if e["type"] == "message_delta")
+        assert out[idx - 1]["type"] == "content_block_stop"
+
+    async def test_tool_use_delta_transition(self):
+        """input_json_delta after a text block must trigger split to tool_use."""
+        events = [
+            {"type": "message_start", "message": {"id": "msg_1"}},
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text", "text": ""},
+            },
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "let me check"}},
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": "{\"q\":"}},
+            {"type": "content_block_stop", "index": 0},
+            {"type": "message_stop"},
+        ]
+        out = await _collect(sanitize_events(_as_async(events)))
+        assert_spec_conforming(out)
+        starts = [e for e in out if e["type"] == "content_block_start"]
+        assert [s["content_block"]["type"] for s in starts] == ["text", "tool_use"]
+
+    async def test_ping_and_unknown_events_passthrough(self):
+        events = [
+            {"type": "message_start", "message": {"id": "msg_1"}},
+            {"type": "ping"},
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text", "text": ""},
+            },
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "hi"}},
+            {"type": "content_block_stop", "index": 0},
+            {"type": "message_stop"},
+        ]
+        out = await _collect(sanitize_events(_as_async(events)))
+        assert any(e["type"] == "ping" for e in out)
+        assert_spec_conforming(out)
+
+    async def test_explicit_block_start_after_synthetic_split_remains_consistent(self):
+        """Upstream emits content_block_start mid-stream after we've already split."""
+        events = [
+            {"type": "message_start", "message": {"id": "msg_1"}},
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text", "text": ""},
+            },
+            # First delta is thinking → forces split.
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "thinking_delta", "thinking": "..."}},
+            # Upstream then opens a real text block at index=1; sanitizer remaps.
+            {
+                "type": "content_block_start",
+                "index": 1,
+                "content_block": {"type": "text", "text": ""},
+            },
+            {"type": "content_block_delta", "index": 1, "delta": {"type": "text_delta", "text": "answer"}},
+            {"type": "content_block_stop", "index": 1},
+            {"type": "message_stop"},
+        ]
+        out = await _collect(sanitize_events(_as_async(events)))
+        assert_spec_conforming(out)
+        starts = [e for e in out if e["type"] == "content_block_start"]
+        assert [s["content_block"]["type"] for s in starts] == ["text", "thinking", "text"]
+        # Indices must be 0, 1, 2 (monotonic), not the upstream values.
+        assert [s["index"] for s in starts] == [0, 1, 2]


### PR DESCRIPTION
## Summary

- Adds an opt-in Anthropic Messages stream sanitizer at `POST /v1/messages` for LiteLLM-style SSE streams where `content_block_start.type` does not match later `content_block_delta.delta.type`.
- Default remains OFF. When disabled, `/v1/messages` returns the same 404-style behavior clients already saw before this branch.
- When enabled, the gateway rewrites only the Claude SDK subprocess environment so Claude calls the local sanitizer route first. The gateway process keeps `ANTHROPIC_BASE_URL` as the real upstream, and the sanitizer forwards there.

## Context

Target chain:

```text
Claude SDK subprocess -> oh-my-gateway /v1/messages -> ANTHROPIC_BASE_URL -> model upstream
```

This targets LiteLLM stream-shape issues such as `thinking_delta` arriving inside a `type=text` content block, which Claude Code's strict SDK validation rejects.

## Design

| Path | Purpose |
|---|---|
| `src/sanitizer/stream_sanitizer.py` | Pure async event transformer; keeps block starts/stops and deltas spec-consistent |
| `src/sanitizer/routes.py` | `POST /v1/messages` proxy; forwards to `ANTHROPIC_BASE_URL`, sanitizes SSE, passes non-SSE responses through |
| `src/sanitizer/config.py` | `SANITIZER_ENABLED`, `SANITIZER_REQUEST_TIMEOUT`, local gateway base URL helper |
| `src/backends/claude/client.py` | Injects SDK-only env so Claude calls the local gateway when sanitizer is enabled |
| `src/runtime_config.py` | Runtime admin toggle for `sanitizer_enabled` |
| `src/request_logger.py` | Excludes `/v1/messages` from request log noise |

Important env behavior:

- `ANTHROPIC_BASE_URL` keeps pointing at the real Anthropic-compatible upstream, for example LiteLLM.
- `SANITIZER_ENABLED=true` makes only the Claude SDK subprocess see `ANTHROPIC_BASE_URL=http://127.0.0.1:${PORT}`.
- The sanitizer route still reads the original process-level `ANTHROPIC_BASE_URL` and forwards upstream there.
- There is no separate `SANITIZER_UPSTREAM_URL`.

## Sanitizer Rules

- Deduplicates `message_start`.
- On `content_block_delta`, if the delta is incompatible with the open block type, closes the open block and starts a compatible synthetic block.
- Treats `input_json_delta` as compatible with both `tool_use` and `server_tool_use` when an upstream block is already open.
- Drops duplicate stops for already-closed blocks.
- Auto-closes dangling blocks before `message_delta` / `message_stop`.
- Remaps output indices monotonically.

## Usage

```bash
export ANTHROPIC_BASE_URL=http://litellm:4000
export SANITIZER_ENABLED=true
# optional; 0 disables timeout for long-lived streams
export SANITIZER_REQUEST_TIMEOUT=0
```

For Docker Compose, keep `ANTHROPIC_BASE_URL` pointed at the upstream service name reachable from the gateway container, for example `http://litellm:4000`.

## Test Plan

- [x] `ruff check src/sanitizer/ src/main.py src/runtime_config.py src/backends/claude/client.py tests/test_sanitizer_routes_unit.py tests/test_claude_cli_unit.py tests/test_runtime_config.py`
- [x] `pytest tests/test_sanitizer_routes_unit.py tests/test_sanitizer_stream_unit.py tests/test_claude_cli_unit.py::TestClaudeCodeCLIVerifyCLI tests/test_claude_cli_unit.py::TestBuildSdkOptions tests/test_claude_cli_unit.py::TestSdkEnvContextManager tests/test_runtime_config.py tests/test_ask_user_question.py -k "not live"`
- [x] `pytest -q` — `1581 passed, 3 skipped, 4 deselected`
- [x] `docker compose config`
- [x] `docker compose -f docker-compose.codex.yml config`

## Follow-ups

- End-to-end smoke against the real LiteLLM + model deployment is still environment-dependent and should be run in the target deployment.