### PR TITLE
fix(sanitizer): require explicit upstream base url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@
 # (for example LiteLLM in Docker Compose: http://litellm:4000). When enabled,
 # the gateway rewrites only the Claude SDK subprocess env so Claude calls the
 # local sanitizer route first, and the sanitizer forwards to ANTHROPIC_BASE_URL.
+# If ANTHROPIC_BASE_URL is unset, enabling the sanitizer has no effect.
 # SANITIZER_ENABLED=false
 # SANITIZER_REQUEST_TIMEOUT=0
 

--- a/src/runtime_config.py
+++ b/src/runtime_config.py
@@ -54,7 +54,7 @@ EDITABLE_KEYS: Dict[str, Dict[str, Any]] = {
     "sanitizer_enabled": {
         "label": "Sanitizer (/v1/messages)",
         "type": "bool",
-        "description": "Anthropic SSE sanitizer in front of ANTHROPIC_BASE_URL",
+        "description": "Anthropic SSE sanitizer; effective only when ANTHROPIC_BASE_URL is set",
     },
 }
 

--- a/src/sanitizer/config.py
+++ b/src/sanitizer/config.py
@@ -1,10 +1,10 @@
 """Configuration for the Anthropic Messages sanitizer proxy.
 
 ``ANTHROPIC_BASE_URL`` keeps its normal meaning: the Anthropic-compatible
-upstream Claude Code would have called directly. When the sanitizer is enabled,
-the Claude SDK environment is rewritten to call this gateway's local
-``/v1/messages`` route instead, and the route forwards to the original
-``ANTHROPIC_BASE_URL`` value.
+upstream Claude Code would have called directly. When the sanitizer toggle is
+enabled and ``ANTHROPIC_BASE_URL`` is explicitly configured, the Claude SDK
+environment is rewritten to call this gateway's local ``/v1/messages`` route
+instead, and the route forwards to the original ``ANTHROPIC_BASE_URL`` value.
 """
 
 from __future__ import annotations
@@ -22,7 +22,16 @@ def get_upstream_url() -> str:
     in the usual place; the gateway only overrides Claude's view of that env
     var while launching the SDK subprocess.
     """
-    return os.getenv("ANTHROPIC_BASE_URL", "https://api.anthropic.com").rstrip("/")
+    raw = os.getenv("ANTHROPIC_BASE_URL")
+    if raw is None or not raw.strip():
+        raise RuntimeError("ANTHROPIC_BASE_URL is required when the sanitizer is enabled")
+    return raw.strip().rstrip("/")
+
+
+def has_upstream_url() -> bool:
+    """Whether a sanitizer upstream was explicitly configured."""
+    raw = os.getenv("ANTHROPIC_BASE_URL")
+    return raw is not None and bool(raw.strip())
 
 
 def get_gateway_base_url() -> str:
@@ -52,10 +61,11 @@ def is_enabled() -> bool:
 
     The admin panel may override the boot-time env value at runtime via
     ``runtime_config.set("sanitizer_enabled", ...)``. Restarting reverts to
-    the ``SANITIZER_ENABLED`` env value.
+    the ``SANITIZER_ENABLED`` env value. A configured upstream is also required;
+    if ``ANTHROPIC_BASE_URL`` is unset, enabling the toggle has no effect.
     """
     # Local import avoids a circular dependency: ``runtime_config._get_original``
     # imports from this module to resolve the boot default.
     from src.runtime_config import runtime_config
 
-    return bool(runtime_config.get("sanitizer_enabled"))
+    return bool(runtime_config.get("sanitizer_enabled")) and has_upstream_url()

--- a/tests/test_claude_cli_unit.py
+++ b/tests/test_claude_cli_unit.py
@@ -642,6 +642,23 @@ class TestBuildSdkOptions:
         finally:
             runtime_config.reset("sanitizer_enabled")
 
+    def test_sdk_options_do_not_route_to_sanitizer_without_base_url(
+        self, cli_instance, monkeypatch
+    ):
+        """SANITIZER_ENABLED has no SDK effect unless ANTHROPIC_BASE_URL is explicit."""
+        from src.runtime_config import runtime_config
+
+        monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+        monkeypatch.setenv("PORT", "8765")
+        runtime_config.set("sanitizer_enabled", True)
+        try:
+            opts = cli_instance._build_sdk_options()
+            assert "ANTHROPIC_BASE_URL" not in opts.env
+            assert opts.env["ANTHROPIC_AUTH_TOKEN"] == "test-key"
+            assert "ANTHROPIC_BASE_URL" not in os.environ
+        finally:
+            runtime_config.reset("sanitizer_enabled")
+
     def test_sdk_options_preserve_base_url_when_sanitizer_disabled(
         self, cli_instance, monkeypatch
     ):

--- a/tests/test_sanitizer_routes_unit.py
+++ b/tests/test_sanitizer_routes_unit.py
@@ -24,6 +24,7 @@ def _enable_sanitizer(monkeypatch):
     overrides this with its own ``runtime_config.set(..., False)`` call.
     """
     monkeypatch.setenv("SANITIZER_ENABLED", "true")
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://upstream.test")
     runtime_config.reset("sanitizer_enabled")
     yield
     runtime_config.reset("sanitizer_enabled")
@@ -145,6 +146,22 @@ def test_upstream_uses_anthropic_base_url(monkeypatch):
     )
     assert resp.status_code == 200
     assert resp.content == body
+
+
+def test_enabled_without_anthropic_base_url_returns_404(monkeypatch):
+    """SANITIZER_ENABLED alone should not route traffic without an explicit upstream."""
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+
+    def handler(request: httpx.Request) -> httpx.Response:  # noqa: ARG001
+        raise AssertionError("upstream was contacted without ANTHROPIC_BASE_URL")
+
+    app = _make_app(handler)
+    client = TestClient(app)
+    resp = client.post(
+        "/v1/messages",
+        json={"model": "x", "stream": False, "messages": []},
+    )
+    assert resp.status_code == 404
 
 
 def test_streaming_upstream_returns_json_error_is_passed_through_verbatim():


### PR DESCRIPTION
## Summary

- Makes the sanitizer effective only when `ANTHROPIC_BASE_URL` is explicitly set.
- If `SANITIZER_ENABLED=true` but `ANTHROPIC_BASE_URL` is unset or blank, Claude SDK env is no longer rewritten to the local sanitizer route.
- In the same unset case, direct `/v1/messages` sanitizer requests keep the disabled/absent behavior and return 404 instead of forwarding to `https://api.anthropic.com`.
- Updates `.env.example` and runtime config text to document the effective behavior.

## Test Plan

- [x] `ruff check src/sanitizer/config.py src/runtime_config.py tests/test_sanitizer_routes_unit.py tests/test_claude_cli_unit.py`
- [x] `pytest tests/test_sanitizer_routes_unit.py tests/test_claude_cli_unit.py::TestBuildSdkOptions tests/test_claude_cli_unit.py::TestClaudeCodeCLIVerifyCLI tests/test_runtime_config.py -q`
- [x] `pytest tests/test_sanitizer_routes_unit.py tests/test_sanitizer_stream_unit.py tests/test_claude_cli_unit.py::TestBuildSdkOptions tests/test_claude_cli_unit.py::TestClaudeCodeCLIVerifyCLI tests/test_claude_cli_unit.py::TestSdkEnvContextManager tests/test_runtime_config.py tests/test_ask_user_question.py -k "not live" -q`
- [x] `pytest -q` — `1583 passed, 3 skipped, 4 deselected`