### PR TITLE
refactor(docker): split OpenCode into a dedicated image and Compose file

### DIFF
--- a/Dockerfile.opencode
+++ b/Dockerfile.opencode
@@ -1,3 +1,28 @@
+FROM python:3.12-slim-trixie AS opencode-builder
+
+ARG APT_MIRROR_URL=
+ARG APT_SECURITY_MIRROR_URL=
+
+COPY docker/apt_mirror_sources.sh /usr/local/bin/apt_mirror_sources.sh
+
+RUN sh /usr/local/bin/apt_mirror_sources.sh \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates nodejs npm \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG OPENCODE_VERSION=1.14.29
+ARG NPM_CONFIG_REGISTRY=
+
+# Install OpenCode through npm in the builder, then keep only the native binary.
+RUN if [ -n "$NPM_CONFIG_REGISTRY" ]; then \
+        npm install -g --include=optional --registry "$NPM_CONFIG_REGISTRY" "opencode-ai@${OPENCODE_VERSION}"; \
+    else \
+        npm install -g --include=optional "opencode-ai@${OPENCODE_VERSION}"; \
+    fi \
+    && opencode --version \
+    && install -m 0755 /usr/local/lib/node_modules/opencode-ai/bin/.opencode /usr/local/bin/opencode \
+    && /usr/local/bin/opencode --version
+
 FROM python:3.12-slim-trixie AS runtime
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -8,7 +33,6 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 ARG APT_MIRROR_URL=
 ARG APT_SECURITY_MIRROR_URL=
 
-# Install system dependencies.
 COPY docker/apt_mirror_sources.sh /usr/local/bin/apt_mirror_sources.sh
 
 RUN sh /usr/local/bin/apt_mirror_sources.sh \
@@ -17,20 +41,20 @@ RUN sh /usr/local/bin/apt_mirror_sources.sh \
     && rm -rf /var/lib/apt/lists/* \
     && rm -f /usr/local/bin/apt_mirror_sources.sh
 
+# Install OpenCode native binary copied from the builder stage.
+COPY --from=opencode-builder /usr/local/bin/opencode /usr/local/bin/opencode
+RUN opencode --version
+
 # Install uv for skills/scripts that invoke `uv run` inside the container.
 COPY --from=ghcr.io/astral-sh/uv:0.9.26 /uv /uvx /usr/local/bin/
 RUN uv --version
 
 WORKDIR /app
 
-# Optional: point pip at a private/corporate PyPI mirror.
-# PIP_TRUSTED_HOST is required when the mirror is served over plain HTTP;
-# pip silently ignores HTTP indexes otherwise. Space-separated for multiple hosts.
 ARG PIP_INDEX_URL=
 ARG PIP_EXTRA_INDEX_URL=
 ARG PIP_TRUSTED_HOST=
 
-# Install pinned runtime dependencies exported from uv.lock.
 COPY requirements.txt ./
 RUN PIP_INDEX_URL="$PIP_INDEX_URL" \
     PIP_EXTRA_INDEX_URL="$PIP_EXTRA_INDEX_URL" \
@@ -41,14 +65,8 @@ RUN PIP_INDEX_URL="$PIP_INDEX_URL" \
     PIP_TRUSTED_HOST="$PIP_TRUSTED_HOST" \
     python -m pip install -r requirements.txt
 
-# Copy runtime files used by the app.
 COPY src ./src
-# The admin system-prompt UI loads these templates at runtime.
 COPY docs/*system-prompt*.md ./docs/
-
-# Optional GitHub plugin auto-install on container start (see CLAUDE_PLUGIN_* env vars).
-COPY docker/install_plugins.sh /usr/local/bin/install_plugins.sh
-RUN chmod +x /usr/local/bin/install_plugins.sh
 
 # Optional build-time install hook for private/corporate additions. Compose
 # supplies a no-op script by default; set GATEWAY_BUILD_INSTALL_SCRIPT to run
@@ -58,27 +76,23 @@ RUN --mount=type=secret,id=gateway_build_install_script,target=/tmp/gateway-buil
     echo "$GATEWAY_BUILD_INSTALL_CACHE_BUST" >/dev/null \
     && bash /tmp/gateway-build-install.sh
 
-# Startup shim repairs writable bind mounts while still root, then drops to the
-# unprivileged app uid before running the server.
 COPY docker/entrypoint.py /usr/local/bin/docker-entrypoint.py
 
-# The Claude CLI refuses --dangerously-skip-permissions under root, and the
-# gateway always opens sessions with permission_mode=bypassPermissions (see
-# src/routes/responses.py), so the server process must run as a regular user.
-# The entrypoint starts as root only long enough to repair Docker bind-mount
-# permissions for gateway-owned data, then drops to APP_UID/APP_GID.
+# OpenCode follows XDG conventions; persist config + state under HOME so the
+# named volume below survives container recreates.
 RUN useradd -m -u 1000 -s /bin/bash app \
-    && mkdir -p /app/data /app/working_dir /home/app/.claude /home/app/.cache/uv \
+    && mkdir -p /app/data /app/working_dir \
+                /home/app/.config/opencode \
+                /home/app/.local/share/opencode \
     && chown -R app:app /app /home/app
-ENV HOME=/home/app \
-    APP_UID=1000 \
-    APP_GID=1000 \
-    UV_CACHE_DIR=/home/app/.cache/uv
 
-# Expose the port (default 8000; overridable via PORT env var at runtime).
+ENV HOME=/home/app \
+    OPENCODE_HOME=/home/app/.local/share/opencode \
+    OPENCODE_BIN=opencode \
+    APP_UID=1000 \
+    APP_GID=1000
+
 EXPOSE 8000
 
-# Run the app with Uvicorn and honor PORT env var.
-# exec ensures SIGTERM from docker stop reaches uvicorn.
 ENTRYPOINT ["python", "/usr/local/bin/docker-entrypoint.py"]
-CMD ["sh", "-c", "/usr/local/bin/install_plugins.sh && exec python -m uvicorn src.main:app --host 0.0.0.0 --port ${PORT:-8000}"]
+CMD ["sh", "-c", "exec python -m uvicorn src.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/README.md
+++ b/README.md
@@ -178,8 +178,21 @@ BuildKit does not include secret contents in the cache key. If the script
 changes, rebuild with `docker compose build --no-cache` or set
 `GATEWAY_BUILD_INSTALL_CACHE_BUST` to a new non-secret value.
 
-The Docker image is pinned to Debian trixie. OpenCode is installed from npm as
-`opencode-ai@${OPENCODE_VERSION:-1.14.29}`; mirror that package plus the
+The Docker image is pinned to Debian trixie. The default `Dockerfile` /
+`docker-compose.yml` builds a Claude-only image and does not install OpenCode
+or Codex; pick a backend-specific Compose file when the gateway container
+should own that backend's runtime.
+
+For an OpenCode-only deployment, use the separate Compose file. It builds
+`Dockerfile.opencode`, installs `opencode-ai@${OPENCODE_VERSION:-1.14.29}`,
+forces `BACKENDS=opencode`, and persists OpenCode config and state in named
+Docker volumes:
+
+```bash
+docker compose -f docker-compose.opencode.yml up -d --build
+```
+
+When mirroring on corporate networks, host the `opencode-ai` package plus the
 matching platform package such as `opencode-linux-x64` or
 `opencode-linux-arm64`.
 

--- a/README.md
+++ b/README.md
@@ -185,8 +185,8 @@ should own that backend's runtime.
 
 For an OpenCode-only deployment, use the separate Compose file. It builds
 `Dockerfile.opencode`, installs `opencode-ai@${OPENCODE_VERSION:-1.14.29}`,
-forces `BACKENDS=opencode`, and persists OpenCode config and state in named
-Docker volumes:
+forces `BACKENDS=opencode`, defaults `OPENCODE_MODELS` to `openai/gpt-5.5`,
+and persists OpenCode config and state in named Docker volumes:
 
 ```bash
 docker compose -f docker-compose.opencode.yml up -d --build

--- a/docker-compose.opencode.yml
+++ b/docker-compose.opencode.yml
@@ -1,0 +1,80 @@
+services:
+  gateway:
+    build:
+      context: .
+      dockerfile: Dockerfile.opencode
+      args:
+        - HTTP_PROXY
+        - HTTPS_PROXY
+        - NO_PROXY
+        - http_proxy
+        - https_proxy
+        - no_proxy
+        - APT_MIRROR_URL
+        - APT_SECURITY_MIRROR_URL
+        - NPM_CONFIG_REGISTRY
+        - OPENCODE_VERSION
+        - PIP_INDEX_URL
+        - PIP_EXTRA_INDEX_URL
+        - PIP_TRUSTED_HOST
+        - GATEWAY_BUILD_INSTALL_CACHE_BUST
+      secrets:
+        - gateway_build_install_script
+    depends_on:
+      gateway-log:
+        condition: service_healthy
+        required: false
+    ports:
+      - "${PORT:-8000}:${PORT:-8000}"
+    volumes:
+      # Persist OpenCode config + state (XDG paths under HOME).
+      - opencode_home:/home/app/.local/share/opencode
+      - opencode_config:/home/app/.config/opencode
+      # Share the host CA bundle with the container for corporate roots.
+      - ${HOST_CA_CERTIFICATES_PATH:-/etc/ssl/certs/ca-certificates.crt}:/etc/ssl/certs/ca-certificates.crt:ro
+      # Persist admin overrides across restarts.
+      - ./data:/app/data
+      # Gateway workspaces. The workspace manager is shared across backends and
+      # still keys off CLAUDE_CWD internally.
+      - ${CLAUDE_CWD:-./working_dir}:/app/working_dir
+    env_file:
+      - .env
+    environment:
+      - ADMIN_API_KEY=${ADMIN_API_KEY:?Set ADMIN_API_KEY in .env}
+      - BACKENDS=opencode
+      - DEFAULT_MODEL=${OPENCODE_DEFAULT_GATEWAY_MODEL:-opencode/openai/gpt-5.5}
+      - OPENCODE_BIN=opencode
+      - OPENCODE_HOME=/home/app/.local/share/opencode
+      - CLAUDE_CWD=/app/working_dir
+
+  gateway-log:
+    profiles: ["logging"]
+    image: mysql:8.0
+    container_name: gateway-log
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+    ports:
+      - "${GATEWAY_LOG_PORT:-3306}:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: ${GATEWAY_LOG_MYSQL_ROOT_PASSWORD:-gateway_root}
+      MYSQL_DATABASE: ${GATEWAY_LOG_MYSQL_DATABASE:-gateway_log}
+      MYSQL_USER: ${GATEWAY_LOG_MYSQL_USER:-gateway}
+      MYSQL_PASSWORD: ${GATEWAY_LOG_MYSQL_PASSWORD:-gateway}
+    volumes:
+      - ./data/mysql_data:/var/lib/mysql
+      - ./docker/mysql_init:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-uroot", "-p${GATEWAY_LOG_MYSQL_ROOT_PASSWORD:-gateway_root}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+volumes:
+  opencode_home:
+  opencode_config:
+
+secrets:
+  gateway_build_install_script:
+    file: ${GATEWAY_BUILD_INSTALL_SCRIPT:-./docker/noop_build_install.sh}

--- a/docker-compose.opencode.yml
+++ b/docker-compose.opencode.yml
@@ -43,6 +43,7 @@ services:
       - ADMIN_API_KEY=${ADMIN_API_KEY:?Set ADMIN_API_KEY in .env}
       - BACKENDS=opencode
       - DEFAULT_MODEL=${OPENCODE_DEFAULT_GATEWAY_MODEL:-opencode/openai/gpt-5.5}
+      - OPENCODE_MODELS=${OPENCODE_MODELS:-openai/gpt-5.5}
       - OPENCODE_BIN=opencode
       - OPENCODE_HOME=/home/app/.local/share/opencode
       - CLAUDE_CWD=/app/working_dir

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,6 @@ services:
         - APT_MIRROR_URL
         - APT_SECURITY_MIRROR_URL
         - NPM_CONFIG_REGISTRY
-        - OPENCODE_VERSION
         - PIP_INDEX_URL
         - PIP_EXTRA_INDEX_URL
         - PIP_TRUSTED_HOST

--- a/docker/entrypoint.py
+++ b/docker/entrypoint.py
@@ -15,6 +15,7 @@ DEFAULT_CLAUDE_HOME = Path("/home/app/.claude")
 DEFAULT_CODEX_HOME = Path("/home/app/.codex")
 DEFAULT_OPENCODE_HOME = Path("/home/app/.local/share/opencode")
 DEFAULT_OPENCODE_CONFIG = Path("/home/app/.config/opencode")
+DEFAULT_UV_CACHE_DIR = Path("/home/app/.cache/uv")
 MYSQL_DATA_DIR_NAME = "mysql_data"
 
 
@@ -52,6 +53,22 @@ def _chown_tree(root: Path, uid: int, gid: int) -> None:
             _chown(current_path / name, uid, gid)
 
 
+def _chown_path_with_parents(path: Path, *, stop: Path, uid: int, gid: int) -> None:
+    try:
+        path.relative_to(stop)
+    except ValueError:
+        _chown(path, uid, gid)
+        return
+
+    paths = [path]
+    current = path
+    while current != stop and current.parent != current:
+        current = current.parent
+        paths.append(current)
+    for item in reversed(paths):
+        _chown(item, uid, gid)
+
+
 def prepare_writable_paths(
     *,
     uid: int,
@@ -61,6 +78,7 @@ def prepare_writable_paths(
     codex_home: Path = DEFAULT_CODEX_HOME,
     opencode_home: Path = DEFAULT_OPENCODE_HOME,
     opencode_config: Path = DEFAULT_OPENCODE_CONFIG,
+    uv_cache_dir: Path = DEFAULT_UV_CACHE_DIR,
 ) -> None:
     """Ensure gateway-owned writable paths are usable by the app process."""
     data_dir = Path(data_dir)
@@ -69,6 +87,7 @@ def prepare_writable_paths(
     codex_home = Path(codex_home)
     opencode_home = Path(opencode_home)
     opencode_config = Path(opencode_config)
+    uv_cache_dir = Path(uv_cache_dir)
     home_dir = claude_home.parent
 
     data_dir.mkdir(parents=True, exist_ok=True)
@@ -78,6 +97,7 @@ def prepare_writable_paths(
     codex_home.mkdir(parents=True, exist_ok=True)
     opencode_home.mkdir(parents=True, exist_ok=True)
     opencode_config.mkdir(parents=True, exist_ok=True)
+    uv_cache_dir.mkdir(parents=True, exist_ok=True)
 
     _chown(data_dir, uid, gid)
     for child in data_dir.iterdir():
@@ -88,11 +108,9 @@ def prepare_writable_paths(
         elif child.is_file() or child.is_symlink():
             _chown(child, uid, gid)
 
-    _chown(home_dir, uid, gid)
-    _chown_tree(claude_home, uid, gid)
-    _chown_tree(codex_home, uid, gid)
-    _chown_tree(opencode_home, uid, gid)
-    _chown_tree(opencode_config, uid, gid)
+    for path in (claude_home, codex_home, opencode_home, opencode_config, uv_cache_dir):
+        _chown_path_with_parents(path, stop=home_dir, uid=uid, gid=gid)
+        _chown_tree(path, uid, gid)
 
 
 def drop_privileges(uid: int, gid: int) -> None:

--- a/docker/entrypoint.py
+++ b/docker/entrypoint.py
@@ -13,6 +13,8 @@ DEFAULT_GID = 1000
 DEFAULT_DATA_DIR = Path("/app/data")
 DEFAULT_CLAUDE_HOME = Path("/home/app/.claude")
 DEFAULT_CODEX_HOME = Path("/home/app/.codex")
+DEFAULT_OPENCODE_HOME = Path("/home/app/.local/share/opencode")
+DEFAULT_OPENCODE_CONFIG = Path("/home/app/.config/opencode")
 MYSQL_DATA_DIR_NAME = "mysql_data"
 
 
@@ -57,12 +59,16 @@ def prepare_writable_paths(
     data_dir: Path = DEFAULT_DATA_DIR,
     claude_home: Path = DEFAULT_CLAUDE_HOME,
     codex_home: Path = DEFAULT_CODEX_HOME,
+    opencode_home: Path = DEFAULT_OPENCODE_HOME,
+    opencode_config: Path = DEFAULT_OPENCODE_CONFIG,
 ) -> None:
     """Ensure gateway-owned writable paths are usable by the app process."""
     data_dir = Path(data_dir)
     prompts_dir = data_dir / "prompts"
     claude_home = Path(claude_home)
     codex_home = Path(codex_home)
+    opencode_home = Path(opencode_home)
+    opencode_config = Path(opencode_config)
     home_dir = claude_home.parent
 
     data_dir.mkdir(parents=True, exist_ok=True)
@@ -70,6 +76,8 @@ def prepare_writable_paths(
     home_dir.mkdir(parents=True, exist_ok=True)
     claude_home.mkdir(parents=True, exist_ok=True)
     codex_home.mkdir(parents=True, exist_ok=True)
+    opencode_home.mkdir(parents=True, exist_ok=True)
+    opencode_config.mkdir(parents=True, exist_ok=True)
 
     _chown(data_dir, uid, gid)
     for child in data_dir.iterdir():
@@ -83,6 +91,8 @@ def prepare_writable_paths(
     _chown(home_dir, uid, gid)
     _chown_tree(claude_home, uid, gid)
     _chown_tree(codex_home, uid, gid)
+    _chown_tree(opencode_home, uid, gid)
+    _chown_tree(opencode_config, uid, gid)
 
 
 def drop_privileges(uid: int, gid: int) -> None:

--- a/docs/opencode/README.md
+++ b/docs/opencode/README.md
@@ -78,6 +78,26 @@ curl http://localhost:8000/v1/responses \
 
 Full walkthrough: [external.md](external.md).
 
+## Docker Compose (OpenCode-only image)
+
+The default `docker-compose.yml` builds a Claude-only image. For an
+OpenCode-only deployment that owns the `opencode` CLI inside the gateway
+container, use the separate Compose file:
+
+```bash
+cp .env.example .env
+# set ADMIN_API_KEY and your OpenCode provider credentials
+docker compose -f docker-compose.opencode.yml up -d --build
+```
+
+`docker-compose.opencode.yml` builds `Dockerfile.opencode`, installs
+`opencode-ai@${OPENCODE_VERSION:-1.14.29}`, forces `BACKENDS=opencode`, and
+stores OpenCode config + state in the `opencode_home` and `opencode_config`
+named volumes (XDG paths under `/home/app`).
+
+Use `OPENCODE_DEFAULT_GATEWAY_MODEL` to set the gateway's default model in
+this container without reusing a Claude-oriented `DEFAULT_MODEL` from `.env`.
+
 ## Model id format
 
 The gateway recognises any `model` field starting with `opencode/`:

--- a/docs/opencode/README.md
+++ b/docs/opencode/README.md
@@ -91,9 +91,10 @@ docker compose -f docker-compose.opencode.yml up -d --build
 ```
 
 `docker-compose.opencode.yml` builds `Dockerfile.opencode`, installs
-`opencode-ai@${OPENCODE_VERSION:-1.14.29}`, forces `BACKENDS=opencode`, and
-stores OpenCode config + state in the `opencode_home` and `opencode_config`
-named volumes (XDG paths under `/home/app`).
+`opencode-ai@${OPENCODE_VERSION:-1.14.29}`, forces `BACKENDS=opencode`,
+defaults `OPENCODE_MODELS` to `openai/gpt-5.5`, and stores OpenCode config +
+state in the `opencode_home` and `opencode_config` named volumes (XDG paths
+under `/home/app`).
 
 Use `OPENCODE_DEFAULT_GATEWAY_MODEL` to set the gateway's default model in
 this container without reusing a Claude-oriented `DEFAULT_MODEL` from `.env`.

--- a/tests/test_docker_packaging.py
+++ b/tests/test_docker_packaging.py
@@ -108,6 +108,8 @@ def test_docker_entrypoint_repairs_admin_data_without_touching_mysql_data(
     mysql_dir = data_dir / "mysql_data"
     claude_home = tmp_path / ".claude"
     codex_home = tmp_path / ".codex"
+    opencode_home = tmp_path / ".local" / "share" / "opencode"
+    opencode_config = tmp_path / ".config" / "opencode"
 
     prompts_dir.mkdir(parents=True)
     mysql_dir.mkdir()
@@ -133,6 +135,8 @@ def test_docker_entrypoint_repairs_admin_data_without_touching_mysql_data(
         data_dir=data_dir,
         claude_home=claude_home,
         codex_home=codex_home,
+        opencode_home=opencode_home,
+        opencode_config=opencode_config,
     )
 
     assert data_dir in chowned
@@ -142,6 +146,8 @@ def test_docker_entrypoint_repairs_admin_data_without_touching_mysql_data(
     assert claude_home.parent in chowned
     assert claude_home in chowned
     assert codex_home in chowned
+    assert opencode_home in chowned
+    assert opencode_config in chowned
     assert mysql_dir not in chowned
     assert mysql_file not in chowned
 
@@ -330,6 +336,7 @@ def test_opencode_compose_enables_opencode_backend_and_state_volume():
         "- DEFAULT_MODEL=${OPENCODE_DEFAULT_GATEWAY_MODEL:-opencode/openai/gpt-5.5}"
         in compose
     )
+    assert "- OPENCODE_MODELS=${OPENCODE_MODELS:-openai/gpt-5.5}" in compose
     assert "- OPENCODE_HOME=/home/app/.local/share/opencode" in compose
     assert "- opencode_home:/home/app/.local/share/opencode" in compose
     assert "- opencode_config:/home/app/.config/opencode" in compose

--- a/tests/test_docker_packaging.py
+++ b/tests/test_docker_packaging.py
@@ -110,6 +110,7 @@ def test_docker_entrypoint_repairs_admin_data_without_touching_mysql_data(
     codex_home = tmp_path / ".codex"
     opencode_home = tmp_path / ".local" / "share" / "opencode"
     opencode_config = tmp_path / ".config" / "opencode"
+    uv_cache_dir = tmp_path / ".cache" / "uv"
 
     prompts_dir.mkdir(parents=True)
     mysql_dir.mkdir()
@@ -137,6 +138,7 @@ def test_docker_entrypoint_repairs_admin_data_without_touching_mysql_data(
         codex_home=codex_home,
         opencode_home=opencode_home,
         opencode_config=opencode_config,
+        uv_cache_dir=uv_cache_dir,
     )
 
     assert data_dir in chowned
@@ -146,8 +148,13 @@ def test_docker_entrypoint_repairs_admin_data_without_touching_mysql_data(
     assert claude_home.parent in chowned
     assert claude_home in chowned
     assert codex_home in chowned
+    assert opencode_home.parent.parent in chowned
+    assert opencode_home.parent in chowned
     assert opencode_home in chowned
+    assert opencode_config.parent in chowned
     assert opencode_config in chowned
+    assert uv_cache_dir.parent in chowned
+    assert uv_cache_dir in chowned
     assert mysql_dir not in chowned
     assert mysql_file not in chowned
 

--- a/tests/test_docker_packaging.py
+++ b/tests/test_docker_packaging.py
@@ -27,7 +27,9 @@ APT_SOURCES = textwrap.dedent(
 
 
 def _final_docker_stage(dockerfile: str) -> str:
-    return "FROM " + dockerfile.rsplit("\nFROM ", 1)[1]
+    if "\nFROM " in dockerfile:
+        return "FROM " + dockerfile.rsplit("\nFROM ", 1)[1]
+    return dockerfile
 
 
 def _load_docker_entrypoint():
@@ -59,9 +61,9 @@ def _rewrite_apt_sources(tmp_path: Path, **env_overrides: str) -> str:
     return sources.read_text()
 
 
-def test_dockerfile_installs_opencode_binary_for_managed_mode():
-    """The gateway image should install managed OpenCode through npm."""
-    dockerfile = (ROOT / "Dockerfile").read_text()
+def test_opencode_dockerfile_installs_opencode_binary_for_managed_mode():
+    """The OpenCode-specific image should install managed OpenCode through npm."""
+    dockerfile = (ROOT / "Dockerfile.opencode").read_text()
 
     assert "FROM python:3.12-slim-trixie AS opencode-builder" in dockerfile
     assert "ARG OPENCODE_VERSION=" in dockerfile
@@ -75,6 +77,15 @@ def test_dockerfile_installs_opencode_binary_for_managed_mode():
     )
     assert "https://opencode.ai/install" not in dockerfile
     assert "opencode --version" in dockerfile
+
+
+def test_default_dockerfile_does_not_install_opencode():
+    """Default image is Claude-only; OpenCode lives in Dockerfile.opencode."""
+    dockerfile = (ROOT / "Dockerfile").read_text()
+
+    assert "opencode-builder" not in dockerfile
+    assert "opencode-ai" not in dockerfile
+    assert "nodejs npm" not in dockerfile
 
 
 def test_dockerfile_uses_entrypoint_for_bind_mount_permissions():
@@ -145,9 +156,9 @@ def test_docker_entrypoint_rejects_root_runtime_uid(monkeypatch):
         entrypoint._parse_id("APP_UID", 1000)
 
 
-def test_final_docker_stage_does_not_keep_node_or_npm():
-    """The runtime image should keep the OpenCode binary, not npm tooling."""
-    dockerfile = (ROOT / "Dockerfile").read_text()
+def test_opencode_final_docker_stage_does_not_keep_node_or_npm():
+    """The OpenCode runtime stage should keep the OpenCode binary, not npm tooling."""
+    dockerfile = (ROOT / "Dockerfile.opencode").read_text()
     final_stage = _final_docker_stage(dockerfile)
 
     assert "nodejs npm" not in final_stage
@@ -171,20 +182,18 @@ def test_dockerfiles_run_generic_build_install_hook():
     """Corporate builds should be able to run a local script without naming it."""
     dockerfile = (ROOT / "Dockerfile").read_text()
     codex_dockerfile = (ROOT / "Dockerfile.codex").read_text()
+    opencode_dockerfile = (ROOT / "Dockerfile.opencode").read_text()
 
     expected = (
         "RUN --mount=type=secret,id=gateway_build_install_script,"
         "target=/tmp/gateway-build-install.sh"
     )
 
-    assert "gateway_build_install_script" in dockerfile
-    assert expected in dockerfile
-    assert "GATEWAY_BUILD_INSTALL_SCRIPT" in dockerfile
-    assert "ARG GATEWAY_BUILD_INSTALL_CACHE_BUST=" in dockerfile
-    assert "gateway_build_install_script" in codex_dockerfile
-    assert expected in codex_dockerfile
-    assert "GATEWAY_BUILD_INSTALL_SCRIPT" in codex_dockerfile
-    assert "ARG GATEWAY_BUILD_INSTALL_CACHE_BUST=" in codex_dockerfile
+    for variant in (dockerfile, codex_dockerfile, opencode_dockerfile):
+        assert "gateway_build_install_script" in variant
+        assert expected in variant
+        assert "GATEWAY_BUILD_INSTALL_SCRIPT" in variant
+        assert "ARG GATEWAY_BUILD_INSTALL_CACHE_BUST=" in variant
 
 
 def test_apt_mirror_rewrite_uses_security_mirror_without_main_mirror(tmp_path):
@@ -231,7 +240,9 @@ def test_compose_forwards_corporate_build_mirror_args():
     assert "- APT_MIRROR_URL" in compose
     assert "- APT_SECURITY_MIRROR_URL" in compose
     assert "- NPM_CONFIG_REGISTRY" in compose
-    assert "- OPENCODE_VERSION" in compose
+    # OPENCODE_VERSION is consumed by Dockerfile.opencode, not the Claude-only
+    # default image, so the main compose intentionally omits it.
+    assert "- OPENCODE_VERSION" not in compose
     assert "- PIP_INDEX_URL" in compose
     assert "- PIP_EXTRA_INDEX_URL" in compose
     assert "- GATEWAY_BUILD_INSTALL_CACHE_BUST" in compose
@@ -241,16 +252,16 @@ def test_compose_provides_generic_build_install_hook():
     """Compose should expose a product-neutral build install script hook."""
     compose = (ROOT / "docker-compose.yml").read_text()
     codex_compose = (ROOT / "docker-compose.codex.yml").read_text()
+    opencode_compose = (ROOT / "docker-compose.opencode.yml").read_text()
     env_example = (ROOT / ".env.example").read_text()
 
     expected_secret = (
         "file: ${GATEWAY_BUILD_INSTALL_SCRIPT:-./docker/noop_build_install.sh}"
     )
 
-    assert "- gateway_build_install_script" in compose
-    assert expected_secret in compose
-    assert "- gateway_build_install_script" in codex_compose
-    assert expected_secret in codex_compose
+    for variant in (compose, codex_compose, opencode_compose):
+        assert "- gateway_build_install_script" in variant
+        assert expected_secret in variant
     assert "GATEWAY_BUILD_INSTALL_SCRIPT=" in env_example
     assert "GATEWAY_BUILD_INSTALL_CACHE_BUST=" in env_example
 
@@ -306,3 +317,21 @@ def test_codex_compose_enables_codex_backend_and_state_volume():
     assert "- CODEX_HOME=/home/app/.codex" in compose
     assert "- codex_home:/home/app/.codex" in compose
     assert "codex_home:" in compose
+
+
+def test_opencode_compose_enables_opencode_backend_and_state_volume():
+    """OpenCode Compose should run an OpenCode-only gateway with persistent state."""
+    compose = (ROOT / "docker-compose.opencode.yml").read_text()
+
+    assert "dockerfile: Dockerfile.opencode" in compose
+    assert "- OPENCODE_VERSION" in compose
+    assert "- BACKENDS=opencode" in compose
+    assert (
+        "- DEFAULT_MODEL=${OPENCODE_DEFAULT_GATEWAY_MODEL:-opencode/openai/gpt-5.5}"
+        in compose
+    )
+    assert "- OPENCODE_HOME=/home/app/.local/share/opencode" in compose
+    assert "- opencode_home:/home/app/.local/share/opencode" in compose
+    assert "- opencode_config:/home/app/.config/opencode" in compose
+    assert "opencode_home:" in compose
+    assert "opencode_config:" in compose


### PR DESCRIPTION
## Summary

- Default `Dockerfile` / `docker-compose.yml` is now Claude-only — no `nodejs`/`npm` stage, no `opencode` binary, and the unused `OPENCODE_VERSION` build arg is dropped from the main Compose file.
- New `Dockerfile.opencode` + `docker-compose.opencode.yml` opt-in image follows the existing `Dockerfile.codex` pattern: installs `opencode-ai@${OPENCODE_VERSION:-1.14.29}`, forces `BACKENDS=opencode`, defaults `OPENCODE_MODELS` to `openai/gpt-5.5`, exposes `OPENCODE_DEFAULT_GATEWAY_MODEL`, and persists OpenCode config/state in `opencode_home` and `opencode_config` named volumes (XDG paths under `/home/app`).
- Docker startup permission repair now includes OpenCode config/state paths and their parent directories, plus the uv cache, so non-1000 `APP_UID` / `APP_GID` deployments keep app-home paths writable.
- README and `docs/opencode/README.md` document the new opt-in flow next to the Codex equivalent.
- `tests/test_docker_packaging.py` is reorganised: the OpenCode binary/runtime assertions now target `Dockerfile.opencode`, a new test guards that the default `Dockerfile` no longer pulls OpenCode, the build-install hook and Compose hook tests cover all three variants, and `test_opencode_compose_enables_opencode_backend_and_state_volume` mirrors the Codex one. `_final_docker_stage` gracefully handles single-stage Dockerfiles.

## Test plan
- [x] `uv run ruff check docker/entrypoint.py tests/test_docker_packaging.py`
- [x] `uv run pytest tests/test_docker_packaging.py -q` (19 passed)
- [x] `uv run pytest --cov=src --cov-report=term -q` (1768 passed, 3 skipped, 4 deselected, 93% coverage)
- [x] `docker compose -f docker-compose.yml config -q`
- [x] `docker compose -f docker-compose.opencode.yml config -q`
- [x] `docker compose -f docker-compose.codex.yml config -q`
- [x] `docker compose -f docker-compose.yml build gateway`
- [x] Default Claude image runtime check: uid/gid 1000, `opencode=absent`, registered backend `claude`, `opus` resolves to Claude, OpenCode model does not resolve
- [x] Non-1000 runtime check: `APP_UID=1001 APP_GID=1001` can write `/home/app/.config/*`, `/home/app/.local/*`, and `/home/app/.cache/uv/*`
- [ ] Manual smoke: `docker compose -f docker-compose.opencode.yml up -d --build` on a host with `ADMIN_API_KEY` set and an OpenCode-compatible provider configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)