### PR TITLE
refactor: fix audit findings across backends, routes, sanitizer, config

### DIFF
--- a/src/admin_page.py
+++ b/src/admin_page.py
@@ -6,6 +6,8 @@ maintainability while the final output is identical to the
 original monolithic version.
 """
 
+from functools import lru_cache
+
 from src.admin_html_config import get_config_html
 from src.admin_html_dashboard import get_dashboard_html
 from src.admin_html_files import get_files_html
@@ -18,6 +20,7 @@ from src.admin_js import get_admin_js
 from src.admin_styles import get_admin_css
 
 
+@lru_cache(maxsize=1)
 def build_admin_page() -> str:
     """Build the admin dashboard HTML.
 

--- a/src/admin_service.py
+++ b/src/admin_service.py
@@ -74,7 +74,10 @@ def _resolve_workspace_root() -> Optional[Path]:
             if hasattr(client, "cwd"):
                 return Path(client.cwd).resolve()
     except Exception:
-        pass
+        logger.debug(
+            "Failed to resolve workspace root from live Claude backend",
+            exc_info=True,
+        )
 
     return None
 
@@ -468,7 +471,7 @@ def get_redacted_config() -> Dict[str, Any]:
         if servers:
             mcp_servers_info = list(servers.keys())
     except Exception:
-        pass
+        logger.debug("Failed to read MCP server names for config", exc_info=True)
 
     return {
         "runtime": {
@@ -597,6 +600,7 @@ def get_tools_registry() -> Dict[str, Any]:
         else:
             result["mcp_tools"] = []
     except Exception:
+        logger.warning("Failed to read MCP tools", exc_info=True)
         result["mcp_tools"] = []
 
     return result
@@ -625,6 +629,7 @@ def get_mcp_servers_detail() -> List[Dict[str, Any]]:
             )
         return result
     except Exception:
+        logger.warning("Failed to read MCP servers detail", exc_info=True)
         return []
 
 
@@ -663,7 +668,7 @@ def export_session_json(session_id: str) -> Optional[Dict[str, Any]]:
         display = str(content) if content else ""
         thinking = [str(text) for text in getattr(msg, "thinking", []) if text]
 
-        item = {"role": msg.role, "content": display, "name": msg.name}
+        item: Dict[str, Any] = {"role": msg.role, "content": display, "name": msg.name}
         if thinking:
             item["thinking"] = thinking
         messages.append(item)

--- a/src/auth.py
+++ b/src/auth.py
@@ -114,7 +114,9 @@ class ClaudeCodeAuthManager:
                 if hasattr(client, "get_auth_provider"):
                     return client.get_auth_provider()
         except Exception:
-            pass
+            logger.debug(
+                "live auth provider lookup failed for %s", backend, exc_info=True
+            )
 
         # Pre-startup / fallback: direct instantiation for known backends
         if backend == "claude":
@@ -270,6 +272,9 @@ def get_all_backends_auth_info() -> Dict[str, Any]:
                 "environment_variables": list(provider.build_env().keys()),
             }
         except Exception as e:
+            logger.warning(
+                "auth validate failed for %s", backend_name, exc_info=True
+            )
             result[backend_name] = {"status": {"valid": False, "errors": [str(e)]}}
     return result
 

--- a/src/backends/__init__.py
+++ b/src/backends/__init__.py
@@ -38,15 +38,19 @@ def discover_backends(registry_cls=None) -> None:
 
     for name in _enabled_backend_names():
         if name == "claude":
-            from src.backends import claude as backend_pkg
+            from src.backends import claude
+
+            claude.register(registry_cls=registry_cls)
         elif name == "opencode":
-            from src.backends import opencode as backend_pkg
+            from src.backends import opencode
+
+            opencode.register(registry_cls=registry_cls)
         elif name == "codex":
-            from src.backends import codex as backend_pkg
+            from src.backends import codex
+
+            codex.register(registry_cls=registry_cls)
         else:
             logger.warning("Unknown backend in BACKENDS=%r; skipping", name)
-            continue
-        backend_pkg.register(registry_cls=registry_cls)
 
 
 def resolve_model(model: str) -> Optional[ResolvedModel]:

--- a/src/backends/base.py
+++ b/src/backends/base.py
@@ -16,7 +16,6 @@ from typing import (
     Optional,
     Protocol,
     Union,
-    runtime_checkable,
 )
 
 
@@ -66,7 +65,6 @@ class BackendDescriptor:
 # ---------------------------------------------------------------------------
 
 
-@runtime_checkable
 class BackendClient(Protocol):
     """Interface that every backend must satisfy.
 
@@ -202,9 +200,9 @@ class BackendRegistry:
         return dict(cls._descriptors)
 
     @classmethod
-    def all_model_ids(cls) -> set:
+    def all_model_ids(cls) -> set[str]:
         """Return a set of all model IDs across all descriptors."""
-        ids: set = set()
+        ids: set[str] = set()
         for desc in cls._descriptors.values():
             ids.update(desc.models)
         return ids

--- a/src/backends/claude/client.py
+++ b/src/backends/claude/client.py
@@ -10,7 +10,7 @@ import tempfile
 import atexit
 import shutil
 import contextlib
-from typing import AsyncGenerator, Dict, Any, Optional, List, cast
+from typing import AsyncGenerator, Dict, Any, Literal, Optional, List, cast
 from pathlib import Path
 import logging
 
@@ -43,11 +43,13 @@ from src.backends.claude.constants import (
     CLAUDE_SANDBOX_NETWORK_ALLOW_LOCAL,
     CLAUDE_SANDBOX_WEAKER_NESTED,
 )
+from src.backends.common import error_chunk
 from src.backends.common import estimate_token_usage as estimate_backend_token_usage
 from src.constants import ASK_USER_TIMEOUT_SECONDS, DEFAULT_TIMEOUT_MS
 from src.message_adapter import MessageAdapter
 from src.image_handler import ImageHandler
 from src.mcp_config import get_mcp_tool_patterns
+from src.response_models import PermissionMode
 from src.runtime_config import get_default_max_turns
 
 logger = logging.getLogger(__name__)
@@ -56,16 +58,17 @@ _DEFAULT_SETTING_SOURCES = ["project", "local"]
 _VALID_SETTING_SOURCES = {"user", "project", "local"}
 
 
-def _get_setting_sources() -> List[str]:
+def _get_setting_sources() -> List[Literal["user", "project", "local"]]:
     """Return Claude config sources for SDK calls.
 
     By default the gateway keeps user-level Claude config out of non-Docker
     runs. Docker Compose sets CLAUDE_SETTING_SOURCES=user,project,local so
     user-scope plugins installed at container startup are visible to Claude.
     """
+    SettingSource = Literal["user", "project", "local"]
     raw = os.getenv("CLAUDE_SETTING_SOURCES")
     if raw is None or not raw.strip():
-        return list(_DEFAULT_SETTING_SOURCES)
+        return cast(List[SettingSource], list(_DEFAULT_SETTING_SOURCES))
 
     sources = [part.strip() for part in raw.split(",") if part.strip()]
     invalid = [source for source in sources if source not in _VALID_SETTING_SOURCES]
@@ -75,13 +78,13 @@ def _get_setting_sources() -> List[str]:
             raw,
             ",".join(_DEFAULT_SETTING_SOURCES),
         )
-        return list(_DEFAULT_SETTING_SOURCES)
+        return cast(List[SettingSource], list(_DEFAULT_SETTING_SOURCES))
 
-    deduped = []
+    deduped: List[SettingSource] = []
     seen = set()
     for source in sources:
         if source not in seen:
-            deduped.append(source)
+            deduped.append(cast(SettingSource, source))
             seen.add(source)
     return deduped
 
@@ -203,10 +206,7 @@ class ClaudeCodeCLI:
         if disallowed_tools:
             base_disallowed.extend(disallowed_tools)
         if base_disallowed:
-            seen: set[str] = set()
-            options.disallowed_tools = [
-                t for t in base_disallowed if not (t in seen or seen.add(t))
-            ]
+            options.disallowed_tools = list(dict.fromkeys(base_disallowed))
 
     def _set_allowed_tools(self, options: ClaudeAgentOptions, tools: List[str]) -> None:
         """Set allowed_tools while translating deprecated Skill access."""
@@ -419,6 +419,8 @@ class ClaudeCodeCLI:
         custom_base = self._resolve_custom_base_prompt(_custom_base, effective_cwd)
         self._configure_system_prompt(options, custom_base, system_prompt)
         if permission_mode:
+            # The SDK narrows to a 6-value Literal; the value is validated
+            # upstream (request schema / runtime), so cast at this boundary.
             options.permission_mode = cast(Any, permission_mode)
         if output_format:
             options.output_format = output_format
@@ -642,7 +644,7 @@ class ClaudeCodeCLI:
         *,
         allowed_tools: Optional[List[str]] = None,
         disallowed_tools: Optional[List[str]] = None,
-        permission_mode: Optional[str] = None,
+        permission_mode: Optional[PermissionMode] = None,
         model_params: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Refresh per-request policy on an existing Claude SDK client.
@@ -801,7 +803,7 @@ class ClaudeCodeCLI:
         except Exception as exc:
             logger.error("ClaudeSDKClient error: %s", exc, exc_info=True)
             session.client = None
-            yield {"type": "error", "is_error": True, "error_message": str(exc)}
+            yield error_chunk(str(exc))
         finally:
             session.stream_break_event = None
 
@@ -822,7 +824,7 @@ class ClaudeCodeCLI:
         except Exception as exc:
             logger.error("ClaudeSDKClient receive error: %s", exc, exc_info=True)
             session.client = None
-            yield {"type": "error", "is_error": True, "error_message": str(exc)}
+            yield error_chunk(str(exc))
 
     # ------------------------------------------------------------------
     # Response parsing helpers

--- a/src/backends/claude/constants.py
+++ b/src/backends/claude/constants.py
@@ -115,8 +115,8 @@ DISALLOWED_TOOLS = [t.strip() for t in _raw_disallowed_tools.split(",") if t.str
 # Only affects Bash commands; Read/Edit/Write access is controlled by SDK permission rules.
 #
 # Tri-state: unset = respect project-level settings, true = force enable, false = force disable.
-_SANDBOX_VALID_TRUE = {"true", "1", "yes"}
-_SANDBOX_VALID_FALSE = {"false", "0", "no"}
+_SANDBOX_VALID_TRUE = {"true", "1", "yes", "on"}
+_SANDBOX_VALID_FALSE = {"false", "0", "no", "off"}
 _SANDBOX_VALID_ALL = _SANDBOX_VALID_TRUE | _SANDBOX_VALID_FALSE
 
 _sandbox_raw = os.getenv("CLAUDE_SANDBOX_ENABLED")

--- a/src/backends/codex/client.py
+++ b/src/backends/codex/client.py
@@ -32,6 +32,8 @@ from src.backends.codex.constants import (
 )
 from src.backends.common import (
     combine_system_prompt,
+    completion_chunks,
+    error_chunk,
     estimate_token_usage as estimate_backend_token_usage,
 )
 from src.constants import DEFAULT_TIMEOUT_MS
@@ -831,11 +833,7 @@ class CodexClient:
                 client.rpc = rpc
                 turn_obj = turn.get("turn")
                 if not isinstance(turn_obj, dict) or not turn_obj.get("id"):
-                    yield {
-                        "type": "error",
-                        "is_error": True,
-                        "error_message": "turn/start response missing turn.id",
-                    }
+                    yield error_chunk("turn/start response missing turn.id")
                     return
                 turn_id = str(turn_obj["id"])
                 notification_iter = self._notification_iterator(
@@ -859,11 +857,7 @@ class CodexClient:
             except Exception as exc:
                 await self._close_rpc_locked()
                 logger.error("Codex app-server turn failed: %s", exc, exc_info=True)
-                yield {
-                    "type": "error",
-                    "is_error": True,
-                    "error_message": self._public_error_message(exc),
-                }
+                yield error_chunk(self._public_error_message(exc))
 
     async def resume_approval_with_client(
         self,
@@ -884,11 +878,7 @@ class CodexClient:
                         "Codex approval continuation is missing pending request id for call_id %r",
                         call_id,
                     )
-                    yield {
-                        "type": "error",
-                        "is_error": True,
-                        "error_message": "Codex approval continuation is missing request id",
-                    }
+                    yield error_chunk("Codex approval continuation is missing request id")
                     return
                 if str(request_id) != str(call_id):
                     message = (
@@ -896,7 +886,7 @@ class CodexClient:
                         f"{request_id!r}, received {call_id!r}"
                     )
                     logger.error(message)
-                    yield {"type": "error", "is_error": True, "error_message": message}
+                    yield error_chunk(message)
                     return
                 pending_rpc = client.pending_approval_rpc
                 if pending_rpc is not None and pending_rpc is not rpc:
@@ -915,15 +905,11 @@ class CodexClient:
                     client.pending_approval_turn_id = None
                     client.pending_approval_params = None
                     client.pending_approval_rpc = None
-                    yield {"type": "error", "is_error": True, "error_message": message}
+                    yield error_chunk(message)
                     return
                 turn_id = client.pending_approval_turn_id or str(params.get("turnId") or "")
                 if not turn_id:
-                    yield {
-                        "type": "error",
-                        "is_error": True,
-                        "error_message": "Codex approval continuation is missing turn id",
-                    }
+                    yield error_chunk("Codex approval continuation is missing turn id")
                     return
 
                 result = self._approval_result_from_output(method, output, params)
@@ -955,11 +941,7 @@ class CodexClient:
             except Exception as exc:
                 await self._close_rpc_locked()
                 logger.error("Codex approval continuation failed: %s", exc, exc_info=True)
-                yield {
-                    "type": "error",
-                    "is_error": True,
-                    "error_message": self._public_error_message(exc),
-                }
+                yield error_chunk(self._public_error_message(exc))
 
     def _public_error_message(self, exc: Exception) -> str:
         message = str(exc)
@@ -1206,11 +1188,7 @@ class CodexClient:
             return
 
         if isinstance(turn, dict) and turn.get("status") == "failed":
-            yield {
-                "type": "error",
-                "is_error": True,
-                "error_message": self._turn_error_message(turn),
-            }
+            yield error_chunk(self._turn_error_message(turn))
             return
 
         yield from self._completion_chunks(items, usage_box)
@@ -1555,22 +1533,8 @@ class CodexClient:
         usage_box: dict[str, Optional[dict[str, int]]],
     ) -> Iterator[Dict[str, Any]]:
         final_text = self._final_response_from_items(items) or ""
-
-        assistant: Dict[str, Any] = {
-            "type": "assistant",
-            "content": [{"type": "text", "text": final_text}],
-        }
-        result: Dict[str, Any] = {
-            "type": "result",
-            "subtype": "success",
-            "result": final_text,
-        }
         usage = usage_box.get("usage")
-        if usage:
-            assistant["usage"] = usage
-            result["usage"] = usage
-        yield assistant
-        yield result
+        yield from completion_chunks(final_text, usage)
 
     def _extract_usage(self, token_usage: Any) -> Optional[dict[str, int]]:
         if not isinstance(token_usage, dict):

--- a/src/backends/common.py
+++ b/src/backends/common.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, Optional
+from typing import Any, Dict, Iterator, Optional
 
 
 def parse_csv(value: str) -> list[str]:
@@ -23,6 +23,34 @@ def combine_system_prompt(
     if custom_base and system_prompt:
         return f"{custom_base}\n\n{system_prompt}"
     return custom_base or system_prompt
+
+
+def error_chunk(message: str) -> Dict[str, Any]:
+    """Build the shared error chunk emitted by streaming backends."""
+    return {"type": "error", "is_error": True, "error_message": message}
+
+
+def completion_chunks(
+    text: str,
+    usage: Optional[Dict[str, int]] = None,
+) -> Iterator[Dict[str, Any]]:
+    """Yield the terminal assistant + result chunks for a completed turn."""
+    assistant: Dict[str, Any] = {
+        "type": "assistant",
+        "content": [{"type": "text", "text": text}],
+    }
+    result: Dict[str, Any] = {"type": "result", "subtype": "success", "result": text}
+    if usage:
+        assistant["usage"] = {
+            "input_tokens": usage["input_tokens"],
+            "output_tokens": usage["output_tokens"],
+        }
+        result["usage"] = {
+            "input_tokens": usage["input_tokens"],
+            "output_tokens": usage["output_tokens"],
+        }
+    yield assistant
+    yield result
 
 
 def estimate_token_usage(prompt: str, completion: str) -> Dict[str, int]:

--- a/src/backends/opencode/client.py
+++ b/src/backends/opencode/client.py
@@ -41,6 +41,8 @@ import httpx
 import src.mcp_config as mcp_config
 from src.backends.common import (
     combine_system_prompt,
+    completion_chunks,
+    error_chunk,
     estimate_token_usage as estimate_backend_token_usage,
 )
 from src.backends.opencode.auth import OpenCodeAuthProvider, normalize_opencode_base_url
@@ -558,11 +560,7 @@ class OpenCodeClient:
                     async for event in self._iter_sse_events(event_response):
                         error_message = converter.error_message(event)
                         if error_message:
-                            yield {
-                                "type": "error",
-                                "is_error": True,
-                                "error_message": error_message,
-                            }
+                            yield error_chunk(error_message)
                             return
                         if converter.finished(event):
                             break
@@ -570,27 +568,13 @@ class OpenCodeClient:
                             yield chunk
         except Exception as exc:
             logger.error("OpenCode streaming prompt failed: %s", exc, exc_info=True)
-            yield {"type": "error", "is_error": True, "error_message": str(exc)}
+            yield error_chunk(str(exc))
             return
 
         text = converter.final_text()
         usage = converter.usage
-        assistant: Dict[str, Any] = {
-            "type": "assistant",
-            "content": [{"type": "text", "text": text}],
-        }
-        result: Dict[str, Any] = {"type": "result", "subtype": "success", "result": text}
-        if usage:
-            assistant["usage"] = {
-                "input_tokens": usage["input_tokens"],
-                "output_tokens": usage["output_tokens"],
-            }
-            result["usage"] = {
-                "input_tokens": usage["input_tokens"],
-                "output_tokens": usage["output_tokens"],
-            }
-        yield assistant
-        yield result
+        for chunk in completion_chunks(text, usage):
+            yield chunk
 
     async def run_completion_with_client(
         self,
@@ -619,41 +603,22 @@ class OpenCodeClient:
                 except json.JSONDecodeError:
                     error_message = self._describe_non_json_response(response)
                     logger.error("OpenCode session prompt returned invalid JSON: %s", error_message)
-                    yield {"type": "error", "is_error": True, "error_message": error_message}
+                    yield error_chunk(error_message)
                     return
         except Exception as exc:
             logger.error("OpenCode session prompt failed: %s", exc, exc_info=True)
-            yield {"type": "error", "is_error": True, "error_message": str(exc)}
+            yield error_chunk(str(exc))
             return
 
         info = payload.get("info")
         if isinstance(info, dict) and info.get("error"):
-            yield {
-                "type": "error",
-                "is_error": True,
-                "error_message": str(info["error"]),
-            }
+            yield error_chunk(str(info["error"]))
             return
 
         text = self._extract_text(payload)
         usage = self._extract_usage(payload)
-        assistant: Dict[str, Any] = {
-            "type": "assistant",
-            "content": [{"type": "text", "text": text}],
-        }
-        result: Dict[str, Any] = {"type": "result", "subtype": "success", "result": text}
-        if usage:
-            assistant["usage"] = {
-                "input_tokens": usage["input_tokens"],
-                "output_tokens": usage["output_tokens"],
-            }
-            result["usage"] = {
-                "input_tokens": usage["input_tokens"],
-                "output_tokens": usage["output_tokens"],
-            }
-
-        yield assistant
-        yield result
+        for chunk in completion_chunks(text, usage):
+            yield chunk
 
     async def _resume_with_client(
         self,
@@ -687,11 +652,7 @@ class OpenCodeClient:
                     async for event in self._iter_sse_events(event_response):
                         error_message = converter.error_message(event)
                         if error_message:
-                            yield {
-                                "type": "error",
-                                "is_error": True,
-                                "error_message": error_message,
-                            }
+                            yield error_chunk(error_message)
                             return
                         if converter.finished(event):
                             break
@@ -699,12 +660,12 @@ class OpenCodeClient:
                             yield chunk
         except Exception as exc:
             logger.error("OpenCode %s continuation failed: %s", label, exc, exc_info=True)
-            yield {"type": "error", "is_error": True, "error_message": str(exc)}
+            yield error_chunk(str(exc))
             return
 
         text = converter.final_text()
-        yield {"type": "assistant", "content": [{"type": "text", "text": text}]}
-        yield {"type": "result", "subtype": "success", "result": text}
+        for chunk in completion_chunks(text):
+            yield chunk
 
     async def resume_question_with_client(
         self,

--- a/src/backends/opencode/config.py
+++ b/src/backends/opencode/config.py
@@ -34,7 +34,9 @@ def _copy_optional_fields(
             target[field] = copy.deepcopy(source[field])
 
 
-def _command_list(server: Dict[str, Any]) -> list[str]:
+def _command_list(server: Dict[str, Any], name: str = "<unnamed>") -> list[str]:
+    if "command" not in server:
+        raise ValueError(f"MCP server '{name}' missing required 'command'")
     command = server["command"]
     args = server.get("args") or []
     if isinstance(command, list):
@@ -42,12 +44,12 @@ def _command_list(server: Dict[str, Any]) -> list[str]:
     return [str(command), *[str(item) for item in args]]
 
 
-def _convert_mcp_server(server: Dict[str, Any]) -> Dict[str, Any]:
+def _convert_mcp_server(server: Dict[str, Any], name: str = "<unnamed>") -> Dict[str, Any]:
     server_type = server.get("type", "stdio")
     if server_type == "stdio":
         converted: Dict[str, Any] = {
             "type": "local",
-            "command": _command_list(server),
+            "command": _command_list(server, name),
         }
         environment = server.get("environment", server.get("env"))
         if environment is not None:
@@ -56,6 +58,8 @@ def _convert_mcp_server(server: Dict[str, Any]) -> Dict[str, Any]:
         return converted
 
     if server_type in _REMOTE_MCP_TYPES:
+        if "url" not in server:
+            raise ValueError(f"MCP server '{name}' missing required 'url'")
         converted = {
             "type": "remote",
             "url": server["url"],
@@ -87,7 +91,7 @@ def build_opencode_config(
         mcp_config = config.setdefault("mcp", {})
         if isinstance(mcp_config, dict):
             for name, server in mcp_servers.items():
-                mcp_config.setdefault(name, _convert_mcp_server(server))
+                mcp_config.setdefault(name, _convert_mcp_server(server, name))
 
     return config
 

--- a/src/backends/opencode/events.py
+++ b/src/backends/opencode/events.py
@@ -60,7 +60,7 @@ class OpenCodeEventConverter:
         event_session = self._event_session_id(event)
         if event_session not in (None, self.session_id):
             return None
-        props = event.get("properties") if isinstance(event.get("properties"), dict) else {}
+        props = self._as_dict(event.get("properties"))
         error = props.get("error") or props.get("message") or props
         return str(error)
 
@@ -92,7 +92,7 @@ class OpenCodeEventConverter:
     def _record_message_role(self, event: Dict[str, Any]) -> None:
         if event.get("type") != "message.updated":
             return
-        props = event.get("properties") if isinstance(event.get("properties"), dict) else {}
+        props = self._as_dict(event.get("properties"))
         info = props.get("info")
         if not isinstance(info, dict):
             return
@@ -108,6 +108,16 @@ class OpenCodeEventConverter:
         role = self.message_roles.get(message_id)
         return role in (None, "assistant")
 
+    @staticmethod
+    def _as_dict(value: Any) -> Dict[str, Any]:
+        """Return *value* if it is a dict, else an empty dict.
+
+        Binding the fetched value through this helper lets the type checker
+        narrow it to ``Dict[str, Any]`` (an inline ``x if isinstance(x, dict)``
+        on a fresh ``.get(...)`` call does not narrow the bound result).
+        """
+        return value if isinstance(value, dict) else {}
+
     def _text_delta_chunk(self, delta: str) -> Dict[str, Any]:
         return {
             "type": "stream_event",
@@ -120,12 +130,12 @@ class OpenCodeEventConverter:
     def _convert_question_event(self, event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         if event.get("type") != "question.asked":
             return None
-        props = event.get("properties") if isinstance(event.get("properties"), dict) else {}
+        props = self._as_dict(event.get("properties"))
         request_id = props.get("id")
         questions = props.get("questions")
         if not isinstance(request_id, str) or not request_id or not isinstance(questions, list):
             return None
-        tool = props.get("tool") if isinstance(props.get("tool"), dict) else {}
+        tool = self._as_dict(props.get("tool"))
         metadata = {"opencode_question_request_id": request_id}
         tool_call_id = tool.get("callID")
         if isinstance(tool_call_id, str) and tool_call_id:
@@ -147,7 +157,7 @@ class OpenCodeEventConverter:
     def _convert_permission_event(self, event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         if event.get("type") != "permission.asked":
             return None
-        props = event.get("properties") if isinstance(event.get("properties"), dict) else {}
+        props = self._as_dict(event.get("properties"))
         request_id = props.get("id")
         permission = props.get("permission")
         if not isinstance(request_id, str) or not request_id:
@@ -165,7 +175,7 @@ class OpenCodeEventConverter:
             "metadata": metadata_value if isinstance(metadata_value, dict) else {},
         }
         metadata = {"opencode_permission_request_id": request_id}
-        tool = props.get("tool") if isinstance(props.get("tool"), dict) else {}
+        tool = self._as_dict(props.get("tool"))
         tool_call_id = tool.get("callID")
         if isinstance(tool_call_id, str) and tool_call_id:
             metadata["opencode_tool_call_id"] = tool_call_id
@@ -188,7 +198,7 @@ class OpenCodeEventConverter:
         if not self._is_assistant_output_event(event):
             return None
         event_type = event.get("type")
-        props = event.get("properties") if isinstance(event.get("properties"), dict) else {}
+        props = self._as_dict(event.get("properties"))
 
         if event_type == "message.part.delta":
             if props.get("field") not in (None, "text"):
@@ -242,14 +252,14 @@ class OpenCodeEventConverter:
             return
         if event.get("type") != "message.part.updated":
             return
-        props = event.get("properties") if isinstance(event.get("properties"), dict) else {}
+        props = self._as_dict(event.get("properties"))
         part = props.get("part")
         if not isinstance(part, dict) or part.get("type") != "step-finish":
             return
         tokens = part.get("tokens")
         if not isinstance(tokens, dict):
             return
-        cache = tokens.get("cache") if isinstance(tokens.get("cache"), dict) else {}
+        cache = self._as_dict(tokens.get("cache"))
         input_tokens = int(tokens.get("input") or 0)
         input_tokens += int(cache.get("read") or 0)
         input_tokens += int(cache.get("write") or 0)
@@ -272,7 +282,7 @@ class OpenCodeEventConverter:
             return []
         if event.get("type") != "message.part.updated":
             return []
-        props = event.get("properties") if isinstance(event.get("properties"), dict) else {}
+        props = self._as_dict(event.get("properties"))
         part = props.get("part")
         if not isinstance(part, dict) or part.get("type") != "tool":
             return []

--- a/src/chat_page.py
+++ b/src/chat_page.py
@@ -5,7 +5,10 @@ Supports multi-turn conversation via previous_response_id chaining,
 and AskUserQuestion (function_call / function_call_output) flow.
 """
 
+from functools import lru_cache
 
+
+@lru_cache(maxsize=1)
 def build_chat_page() -> str:
     """Build the chat UI HTML."""
     return r"""<!DOCTYPE html>

--- a/src/collab_filter.py
+++ b/src/collab_filter.py
@@ -72,6 +72,9 @@ class CollabJsonStreamFilter:
         self._depth = 0
         self._in_string = False
         self._escape_next = False
+        # True while buffering but the first non-whitespace char after the
+        # opening '{' has not yet been seen.
+        self._awaiting_first_char = False
 
     @property
     def buffering(self) -> bool:
@@ -84,6 +87,19 @@ class CollabJsonStreamFilter:
         for ch in text:
             if self._buf:
                 self._buf += ch
+                # Collab blocks always start with a quoted key
+                # (see _COLLAB_MARKERS).  As soon as the first non-whitespace
+                # character after the opening '{' is known, if it is not a
+                # quote this block cannot be collab JSON: flush the buffer as
+                # plain output immediately so legitimate prose braces stream
+                # without stalling until the size cap.  No collab block can be
+                # mis-stripped because real collab JSON always begins with '"'.
+                if self._awaiting_first_char and not ch.isspace():
+                    self._awaiting_first_char = False
+                    if ch != '"':
+                        output.append(self._buf)
+                        self._reset()
+                        continue
                 if self._escape_next:
                     self._escape_next = False
                 elif ch == "\\" and self._in_string:
@@ -121,6 +137,7 @@ class CollabJsonStreamFilter:
                     self._depth = 1
                     self._in_string = False
                     self._escape_next = False
+                    self._awaiting_first_char = True
                 else:
                     output.append(ch)
 
@@ -137,3 +154,4 @@ class CollabJsonStreamFilter:
         self._depth = 0
         self._in_string = False
         self._escape_next = False
+        self._awaiting_first_char = False

--- a/src/constants.py
+++ b/src/constants.py
@@ -40,20 +40,20 @@ SYSTEM_PROMPT_FILE = os.getenv("SYSTEM_PROMPT_FILE", "")
 PROMPT_LANGUAGE = os.getenv("PROMPT_LANGUAGE", "English")
 
 # API Configuration
-DEFAULT_MAX_TURNS = int(os.getenv("DEFAULT_MAX_TURNS", "10"))
+DEFAULT_MAX_TURNS = parse_int_env("DEFAULT_MAX_TURNS", 10)
 DEFAULT_TIMEOUT_MS = parse_int_env("MAX_TIMEOUT", 600_000)  # 10 minutes
-DEFAULT_PORT = int(os.getenv("PORT", "8000"))
+DEFAULT_PORT = parse_int_env("PORT", 8000)
 DEFAULT_HOST = (
     os.getenv("GATEWAY_HOST") or os.getenv("CLAUDE_WRAPPER_HOST") or "0.0.0.0"
 )  # nosec B104
-MAX_REQUEST_SIZE = int(os.getenv("MAX_REQUEST_SIZE", str(10 * 1024 * 1024)))  # 10MB
+MAX_REQUEST_SIZE = parse_int_env("MAX_REQUEST_SIZE", 10 * 1024 * 1024)  # 10MB
 
 # Permission Modes
 PERMISSION_MODE_BYPASS = "bypassPermissions"
 
 # Session Management
-SESSION_CLEANUP_INTERVAL_MINUTES = int(os.getenv("SESSION_CLEANUP_INTERVAL_MINUTES", "5"))
-SESSION_MAX_AGE_MINUTES = int(os.getenv("SESSION_MAX_AGE_MINUTES", "60"))
+SESSION_CLEANUP_INTERVAL_MINUTES = parse_int_env("SESSION_CLEANUP_INTERVAL_MINUTES", 5)
+SESSION_MAX_AGE_MINUTES = parse_int_env("SESSION_MAX_AGE_MINUTES", 60)
 
 # Per-user workspace isolation
 # Base directory for user workspaces. Falls back to CLAUDE_CWD if empty.
@@ -69,7 +69,7 @@ MCP_CONFIG = os.getenv("MCP_CONFIG", "")
 # an SSE comment (`: keepalive\n\n`) on this interval prevents HTTP
 # proxies, load balancers, and client-side timeouts from closing the
 # connection.  Set to 0 to disable.
-SSE_KEEPALIVE_INTERVAL = int(os.getenv("SSE_KEEPALIVE_INTERVAL", "15"))
+SSE_KEEPALIVE_INTERVAL = parse_int_env("SSE_KEEPALIVE_INTERVAL", 15)
 
 # ---------------------------------------------------------------------------
 # Subagent Streaming Visibility
@@ -90,12 +90,12 @@ SUBAGENT_STREAM_PROGRESS = parse_bool_env("SUBAGENT_STREAM_PROGRESS", "true")
 # Rate Limiting defaults (requests per minute)
 # These are used by rate_limiter.py as the single source of truth
 RATE_LIMITS = {
-    "debug": int(os.getenv("RATE_LIMIT_DEBUG_PER_MINUTE", "2")),
-    "auth": int(os.getenv("RATE_LIMIT_AUTH_PER_MINUTE", "10")),
-    "session": int(os.getenv("RATE_LIMIT_SESSION_PER_MINUTE", "15")),
-    "health": int(os.getenv("RATE_LIMIT_HEALTH_PER_MINUTE", "30")),
-    "responses": int(os.getenv("RATE_LIMIT_RESPONSES_PER_MINUTE", "10")),
-    "general": int(os.getenv("RATE_LIMIT_PER_MINUTE", "30")),
+    "debug": parse_int_env("RATE_LIMIT_DEBUG_PER_MINUTE", 2),
+    "auth": parse_int_env("RATE_LIMIT_AUTH_PER_MINUTE", 10),
+    "session": parse_int_env("RATE_LIMIT_SESSION_PER_MINUTE", 15),
+    "health": parse_int_env("RATE_LIMIT_HEALTH_PER_MINUTE", 30),
+    "responses": parse_int_env("RATE_LIMIT_RESPONSES_PER_MINUTE", 10),
+    "general": parse_int_env("RATE_LIMIT_PER_MINUTE", 30),
 }
 
 # ---------------------------------------------------------------------------
@@ -124,7 +124,7 @@ METADATA_ENV_ALLOWLIST: frozenset[str] = frozenset(
 # AskUserQuestion hook timeout (seconds).
 # If the client does not respond within this window the hook denies the tool
 # call and the SDK resumes.  Set via ASK_USER_TIMEOUT_SECONDS env var.
-ASK_USER_TIMEOUT_SECONDS = int(os.environ.get("ASK_USER_TIMEOUT_SECONDS", "300"))
+ASK_USER_TIMEOUT_SECONDS = parse_int_env("ASK_USER_TIMEOUT_SECONDS", 300)
 
 # Debug / Verbose mode — single source of truth
 DEBUG_MODE = parse_bool_env("DEBUG_MODE", "false")

--- a/src/landing_page.py
+++ b/src/landing_page.py
@@ -1,12 +1,14 @@
+import html
 from typing import Any, Dict
 
 
 def build_root_page(version: str, auth_info: Dict[str, Any], default_port: int) -> str:
     """Build the landing page HTML."""
-    auth_method = auth_info.get("method", "unknown")
+    auth_method = html.escape(str(auth_info.get("method", "unknown")))
     auth_valid = auth_info.get("status", {}).get("valid", False)
-    status_text = "ONLINE" if auth_valid else "OFFLINE"
+    status_text = html.escape("ONLINE" if auth_valid else "OFFLINE")
     status_class = "online" if auth_valid else "offline"
+    version = html.escape(str(version))
 
     return f"""<!DOCTYPE html>
 <html lang="ko">

--- a/src/main.py
+++ b/src/main.py
@@ -184,15 +184,16 @@ async def _verify_backends() -> None:
 async def _shutdown_backends() -> None:
     """Close backend-owned resources such as managed child processes."""
     for name, backend in BackendRegistry.all_backends().items():
-        close = getattr(backend, "close", None) or getattr(backend, "shutdown", None)
-        if close is None:
-            continue
-        try:
-            result = close()
-            if inspect.isawaitable(result):
-                await result
-        except Exception:
-            logger.warning("Backend %s shutdown failed", name, exc_info=True)
+        for method_name in ("close", "shutdown"):
+            method = getattr(backend, method_name, None)
+            if method is None:
+                continue
+            try:
+                result = method()
+                if inspect.isawaitable(result):
+                    await result
+            except Exception:
+                logger.warning("Backend %s shutdown failed", name, exc_info=True)
 
 
 @asynccontextmanager
@@ -475,8 +476,6 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
             response = await call_next(request)
             status_code = response.status_code
             return response
-        except Exception:
-            raise
         finally:
             elapsed_ms = (asyncio.get_event_loop().time() - start) * 1000
             client_ip = request.client.host if request.client else "unknown"

--- a/src/plugin_service.py
+++ b/src/plugin_service.py
@@ -103,6 +103,23 @@ def _validate_install_path(install_path: Path) -> Optional[Path]:
         return None
     if install_path.is_symlink():
         return None
+    # Reject a symlinked PARENT component: ``resolve()`` follows all symlinks,
+    # so a symlinked intermediate directory could still pass the containment
+    # check above.  Walk each component from the leaf up to (but not including)
+    # ``cache_dir`` and reject if any is a symlink.
+    try:
+        cache_anchor = cache_dir.resolve()
+    except OSError:
+        return None
+    for parent in install_path.parents:
+        try:
+            if parent.resolve() == cache_anchor:
+                break
+        except OSError:
+            return None
+        if parent.is_symlink():
+            logger.warning("Plugin install_path has symlinked parent: %s", parent)
+            return None
     return resolved if resolved.is_dir() else None
 
 

--- a/src/routes/admin.py
+++ b/src/routes/admin.py
@@ -196,7 +196,7 @@ async def get_server_info(request: Request, _=Depends(require_admin)):
     from src.session_manager import session_manager
 
     started_at = getattr(request.app.state, "started_at", None)
-    uptime_seconds = round(time.time() - started_at, 1) if started_at else None
+    uptime_seconds = round(time.time() - started_at, 1) if started_at is not None else None
 
     return {
         "version": __version__,
@@ -851,14 +851,15 @@ async def usage_summary_endpoint(
     """Overview counters for the usage tab."""
     from src.usage_queries import get_summary
 
+    window = max(1, min(window_days, 365))
     data = await get_summary(
-        window_days=max(1, min(window_days, 365)),
+        window_days=window,
         start_date=start_date,
         end_date=end_date,
     )
     if data is None:
         return {"enabled": False}
-    return {"enabled": True, "window_days": window_days, "summary": data}
+    return {"enabled": True, "window_days": window, "summary": data}
 
 
 @router.get("/api/usage/users")

--- a/src/routes/general.py
+++ b/src/routes/general.py
@@ -106,7 +106,7 @@ async def root():
                 any_valid = True
                 auth_method_parts.append(backend_name)
         except Exception:
-            pass
+            logger.debug("root auth status check failed for %s", backend_name, exc_info=True)
 
     auth_info = {
         "method": ", ".join(auth_method_parts) if auth_method_parts else "none",

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -1241,8 +1241,11 @@ async def create_response(
                         sequence_number=0,
                     )
                     # Commit turn even for requires_action so the next
-                    # function_call_output can reference this response_id
+                    # function_call_output can reference this response_id.
+                    # Record the user prompt too — a paused turn still
+                    # consumed the user's input, so history must reflect it.
                     session.turn_counter = next_turn
+                    session.add_messages([Message(role="user", content=prompt)])
                     stream_result["success"] = True
                 elif stream_result.get("empty"):
                     # Stream ended with no text and no pending tool call —
@@ -1365,7 +1368,10 @@ async def create_response(
             if session.pending_tool_call is not None:
                 tc = session.pending_tool_call
                 resp_id = _make_response_id(session_id, pf.next_turn)
+                # Record the user prompt too — a paused turn still consumed
+                # the user's input, so history must reflect it.
                 session.turn_counter = pf.next_turn
+                session.add_messages([Message(role="user", content=prompt)])
                 return _build_requires_action_response(
                     resp_id, body.model, tc, body.metadata
                 ).model_dump()

--- a/src/runtime_config.py
+++ b/src/runtime_config.py
@@ -111,15 +111,19 @@ class RuntimeConfig:
 
     def get_all(self) -> Dict[str, Any]:
         """Return all editable keys with their current effective values."""
+        # Snapshot overrides once under a single lock, then compute everything
+        # from the snapshot without re-acquiring the lock per key.
+        with self._lock:
+            overrides = dict(self._overrides)
         result = {}
         for key, meta in EDITABLE_KEYS.items():
-            value = self.get(key)
-            with self._lock:
-                is_overridden = key in self._overrides
+            original = self._get_original(key)
+            is_overridden = key in overrides
+            value = overrides[key] if is_overridden else original
             result[key] = {
                 **meta,
                 "value": value,
-                "original": self._get_original(key),
+                "original": original,
                 "overridden": is_overridden,
             }
         return result

--- a/src/sanitizer/openai_bridge.py
+++ b/src/sanitizer/openai_bridge.py
@@ -470,6 +470,10 @@ async def openai_stream_to_anthropic_events(
         # as canonical and ignore the duplicate to avoid double-emitting.
         reasoning = delta.get("reasoning_content")
         if isinstance(reasoning, str) and reasoning:
+            # Flush any buffered tool_calls before opening a new reasoning
+            # block. This is intentional: tool_use blocks always precede the
+            # text/reasoning that follows them in the converted stream, even
+            # when that text arrives after a tool-call delta in the same turn.
             for event in _flush_tool_calls(state):
                 yield event
             if state.open_kind != "thinking":
@@ -487,6 +491,10 @@ async def openai_stream_to_anthropic_events(
         # Plain assistant text.
         content = delta.get("content")
         if isinstance(content, str) and content:
+            # Flush any buffered tool_calls before opening a new text block.
+            # This is intentional: tool_use blocks always precede the
+            # text/reasoning that follows them in the converted stream, even
+            # when that text arrives after a tool-call delta in the same turn.
             for event in _flush_tool_calls(state):
                 yield event
             if state.open_kind != "text":

--- a/src/sanitizer/stream_sanitizer.py
+++ b/src/sanitizer/stream_sanitizer.py
@@ -32,11 +32,6 @@ DELTA_PRIMARY_BLOCK: Dict[str, str] = {
     "input_json_delta": "tool_use",
 }
 
-# Backward-compatible alias: external callers (tests, etc.) may still reference
-# the old single-value mapping. The new compatibility set above is the source
-# of truth for the sanitizer's split decision.
-DELTA_TO_BLOCK_TYPE: Dict[str, str] = dict(DELTA_PRIMARY_BLOCK)
-
 
 def _is_empty_delta(delta: Dict[str, Any]) -> bool:
     """Return True when a ``content_block_delta`` carries no payload.
@@ -127,7 +122,8 @@ async def sanitize_events(
                 # Drop zero-payload deltas before any split logic runs. See
                 # ``_is_empty_delta`` for why this is unconditionally safe.
                 continue
-            delta_type = delta.get("type")
+            delta_type_raw = delta.get("type")
+            delta_type = delta_type_raw if isinstance(delta_type_raw, str) else ""
             compatible = DELTA_COMPATIBLE_BLOCKS.get(delta_type)
             if compatible is not None and current_block_type not in compatible:
                 # Current block can't validly hold this delta — close it and
@@ -139,7 +135,7 @@ async def sanitize_events(
                 if current_block_type is not None:
                     yield _close_current()
                 current_index += 1
-                primary = DELTA_PRIMARY_BLOCK[delta_type]
+                primary = DELTA_PRIMARY_BLOCK.get(delta_type, "text")
                 current_block_type = primary
                 yield {
                     "type": "content_block_start",

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -239,10 +239,18 @@ class SessionManager:
         """
         with self.lock:
             expired = [
-                (sid, self.sessions[sid]) for sid, s in self.sessions.items() if s.is_expired()
+                (sid, s) for sid, s in self.sessions.items() if s.is_expired()
             ]
-        count = 0
-        for sid, session in expired:
+        doomed = []
+        with self.lock:
+            for sid, session in expired:
+                # Re-check: session might have been refreshed since snapshot
+                current = self.sessions.get(sid)
+                if current is session and current.is_expired():
+                    del self.sessions[sid]
+                    logger.info(f"Cleaned up expired session: {sid}")
+                    doomed.append((sid, session))
+        for sid, session in doomed:
             if session.client is not None:
                 try:
                     await session.client.disconnect()
@@ -251,14 +259,7 @@ class SessionManager:
                 session.client = None
             if session.workspace:
                 self._cleanup_workspace(session.workspace)
-            with self.lock:
-                # Re-check: session might have been refreshed since snapshot
-                current = self.sessions.get(sid)
-                if current is session and current.is_expired():
-                    del self.sessions[sid]
-                    logger.info(f"Cleaned up expired session: {sid}")
-                    count += 1
-        return count
+        return len(doomed)
 
     def _purge_all_expired_sync(self) -> int:
         """Synchronous variant: remove expired sessions without client disconnect.
@@ -339,7 +340,7 @@ class SessionManager:
                 if hasattr(backend, "cleanup_images"):
                     backend.cleanup_images()
         except Exception:
-            pass  # Registry may not be ready during tests/shutdown
+            logger.debug("backend image cleanup skipped/failed", exc_info=True)
 
         return removed
 
@@ -548,8 +549,9 @@ class SessionManager:
     def stats(self) -> dict:
         """Return a summary dict including rehydrate hit/miss counters."""
         with self.lock:
+            active = sum(1 for s in self.sessions.values() if not s.is_expired())
             return {
-                "active_sessions": len(self.sessions),
+                "active_sessions": active,
                 "rehydrate_hits": self._rehydrate_hits,
                 "rehydrate_misses": self._rehydrate_misses,
             }

--- a/src/streaming_utils.py
+++ b/src/streaming_utils.py
@@ -400,8 +400,6 @@ async def bridge_sse_stream(
 # SSE comment line — compliant clients silently ignore these.
 _SSE_KEEPALIVE = ": keepalive\n\n"
 
-_SENTINEL = object()
-
 
 async def _keepalive_wrapper(
     source: AsyncGenerator,
@@ -794,6 +792,7 @@ async def stream_response_chunks(
         nonlocal reasoning_open, reasoning_item_id, reasoning_text_buf, output_index
         if not reasoning_open:
             return []
+        assert reasoning_item_id is not None
         full_text = "".join(reasoning_text_buf)
         item = ReasoningOutputItem(
             id=reasoning_item_id,
@@ -962,22 +961,23 @@ async def stream_response_chunks(
                     thinking_capture_buf.append(text_delta)
                 if reasoning_open and in_thinking:
                     reasoning_text_buf.append(text_delta)
-                    yield make_response_sse(
-                        "response.reasoning_summary_text.delta",
-                        item_id=reasoning_item_id,
-                        output_index=output_index,
-                        summary_index=0,
-                        delta=text_delta,
-                        sequence_number=_next_seq(),
-                    )
-                    yield make_response_sse(
-                        "response.reasoning_text.delta",
-                        item_id=reasoning_item_id,
-                        output_index=output_index,
-                        content_index=0,
-                        delta=text_delta,
-                        sequence_number=_next_seq(),
-                    )
+                    if text_delta:
+                        yield make_response_sse(
+                            "response.reasoning_summary_text.delta",
+                            item_id=reasoning_item_id,
+                            output_index=output_index,
+                            summary_index=0,
+                            delta=text_delta,
+                            sequence_number=_next_seq(),
+                        )
+                        yield make_response_sse(
+                            "response.reasoning_text.delta",
+                            item_id=reasoning_item_id,
+                            output_index=output_index,
+                            content_index=0,
+                            delta=text_delta,
+                            sequence_number=_next_seq(),
+                        )
                     continue
                 # We're inside a thinking block but couldn't open a reasoning item
                 # (message item already opened — OpenAI Responses contract doesn't support

--- a/src/usage_queries.py
+++ b/src/usage_queries.py
@@ -70,7 +70,7 @@ async def get_summary(
           COALESCE(SUM(output_tokens), 0) AS output_tokens_window,
           COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens_window,
           COALESCE(SUM(cache_creation_tokens), 0) AS cache_creation_tokens_window,
-          SUM(status <> 'completed') AS errors_window
+          COALESCE(SUM(status <> 'completed'), 0) AS errors_window
         FROM usage_turn
         WHERE {where}
         """,
@@ -111,7 +111,7 @@ async def get_top_users(
           COALESCE(SUM(u.cache_read_tokens), 0) AS cache_read_tokens,
           COALESCE(SUM(t.call_count), 0) AS tool_calls,
           COALESCE(SUM(t.error_count), 0) AS tool_errors,
-          SUM(u.status <> 'completed') AS turn_errors
+          COALESCE(SUM(u.status <> 'completed'), 0) AS turn_errors
         FROM usage_turn u
         LEFT JOIN usage_tool t ON t.turn_id = u.id
         WHERE {where}

--- a/tests/test_admin_usage_routes.py
+++ b/tests/test_admin_usage_routes.py
@@ -79,12 +79,12 @@ def test_usage_summary_clamps_window_days(monkeypatch):
         resp = _client().get("/admin/api/usage/summary", params={"window_days": 9999})
         # Query received the clamped value (max 365)...
         assert captured["window_days"] == 365
-        # ...but the response body echoes the raw query param.
-        assert resp.json()["window_days"] == 9999
+        # ...and the response body echoes the same clamped value.
+        assert resp.json()["window_days"] == 365
 
         resp = _client().get("/admin/api/usage/summary", params={"window_days": 0})
         assert captured["window_days"] == 1
-        assert resp.json()["window_days"] == 0
+        assert resp.json()["window_days"] == 1
     finally:
         _restore()
 

--- a/tests/test_streaming_utils_unit.py
+++ b/tests/test_streaming_utils_unit.py
@@ -1004,9 +1004,11 @@ class TestCollabJsonStreamFilter:
 
     def test_flush_returns_buffered_text(self):
         f = CollabJsonStreamFilter()
-        f.feed("{incomplete")
+        # A '{' followed by a quote stays buffered as a potential collab block
+        # until the stream ends, so flush() returns the partial text.
+        assert f.feed('{"incomplete') == ""
         remaining = f.flush()
-        assert remaining == "{incomplete"
+        assert remaining == '{"incomplete'
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

A two-round subsystem audit with adversarial verification surfaced correctness, type-safety, error-handling, robustness, and duplication issues across the gateway. This PR addresses the **verified, low-risk subset**. Large complexity rewrites, test-suite restructuring, and a few design-dependent items are intentionally deferred (listed below).

**Gates:** mypy `31 → 0` errors · `ruff check` clean · `pytest` **1769 passed / 2 skipped / 0 failed**.

## Fixes

**Bugs**
- `responses`: persist the user message on `requires_action` (paused / AskUserQuestion) turns — stream + non-stream
- `admin`: echo the **clamped** `window_days` in `usage/summary`
- `usage_queries`: `COALESCE` `errors_window`/`turn_errors` (no `None` on an empty window)
- `streaming_utils`: drop zero-length reasoning SSE frames
- `stream_sanitizer`: guard `delta_type`; avoid `KeyError` if the delta maps diverge
- `collab_filter`: stop stalling the stream on a non-collab `{` in prose
- `main`: shut down backends via **both** `close()` and `shutdown()`

**Type-safety (mypy 31 → 0)**
- `opencode/events`: `_as_dict` helper clears the None-safety errors (18)
- `claude/client`: `dict.fromkeys` dedup; `PermissionMode`/`setting_sources` Literals
- `backends/__init__`: fix `backend_pkg` redefinition · `base`: `set[str]`, drop unused `@runtime_checkable`

**Error handling** — add logging to silently-swallowing diagnostic excepts (`auth` ×2, `admin_service` ×4, `session_manager` cleanup, `general.root`); remove a no-op `except` in `main` middleware.

**Robustness** — `parse_int_env` for numeric env vars (no import-time crash on typos) · MCP config `KeyError` → descriptive `ValueError` · HTML-escape landing-page values · plugin parent-symlink check · sandbox `on`/`off` parity.

**Cleanup / perf** — `common.error_chunk`/`completion_chunks` dedup (~21 sites) · `lru_cache` the admin/chat pages · remove dead `_SENTINEL`/`DELTA_TO_BLOCK_TYPE` · single-lock `RuntimeConfig.get_all` · session purge race fix + `stats()` consistency.

**Tests touched** — updated 2 tests that encoded the old buggy behavior (`test_usage_summary_clamps_window_days`, `test_flush_returns_buffered_text`).

## Deferred (need dedicated review or a design decision)
- Complexity decomposition (`stream_response_chunks` C901=62, `create_response`=30, …) — large rewrites
- Test-suite restructuring (merge `*_coverage_*` files, strip line-number-coupled comments)
- `landing_page` f-string → template; shared CRT/terminal CSS module
- `_encode_cwd` collision + rehydration ownership check (edge-case isolation — needs an ownership-verification policy)
- `tool_stats` duration undercount; plugin double-resolution; `usage_logger` `%s` binding (latent)
- Remaining backend dedup (estimate mixin, OpenCode `_stream_events`, `SessionHandle` Protocol)

5 candidate findings were dropped during verification as false positives / intentional design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)