### PR TITLE
fix(session): verify transcript ownership on rehydration

### DIFF
--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -41,9 +41,13 @@ def _encode_cwd(cwd) -> str:
 
     The Claude SDK stores per-project transcripts under
     ``~/.claude/projects/<encoded-cwd>/<session_id>.jsonl``. The encoding
-    rule observed across recorded sessions: every ``/``, ``_`` and ``.``
-    is replaced with ``-``. (To be re-verified against SDK source if the
-    rule changes — see plan Task C-followup.)
+    rule (verified against on-disk transcript directories): every ``/``,
+    ``_`` and ``.`` is replaced with ``-``.
+
+    The rule is **lossy** — distinct workspaces such as ``a_b``, ``a.b`` and
+    ``a-b`` collapse to the same directory — so ``_try_rehydrate_from_jsonl``
+    additionally verifies the transcript's recorded ``cwd`` against the
+    requester's workspace before trusting it.
     """
     return _CWD_ENCODE_RE.sub("-", str(cwd))
 
@@ -76,6 +80,7 @@ def _try_rehydrate_from_jsonl(session_id: str, *, user: Optional[str], cwd) -> O
         jsonl_path = _session_jsonl_path(session_id, cwd)
         if not jsonl_path.is_file():
             return None
+        expected_cwd = Path(cwd)
         user_msg_count = 0
         with jsonl_path.open("r") as fh:
             for raw in fh:
@@ -83,6 +88,27 @@ def _try_rehydrate_from_jsonl(session_id: str, *, user: Optional[str], cwd) -> O
                     line = json.loads(raw)
                 except (ValueError, json.JSONDecodeError):
                     return None  # corrupt — refuse to guess
+                # Ownership guard. ``_encode_cwd`` is lossy ('/', '_', '.' all
+                # collapse to '-'), so distinct workspaces — e.g. users "a_b",
+                # "a.b" and "a-b" — share one on-disk transcript directory. The
+                # SDK records the REAL cwd on each turn line, so refuse to
+                # rehydrate a transcript whose recorded cwd does not match the
+                # requester's resolved workspace; otherwise a colliding user
+                # could rebuild another user's session and history.
+                recorded_cwd = line.get("cwd")
+                if (
+                    isinstance(recorded_cwd, str)
+                    and recorded_cwd
+                    and Path(recorded_cwd) != expected_cwd
+                ):
+                    logger.warning(
+                        "Refusing to rehydrate session %s: transcript cwd %r "
+                        "does not match requester workspace %r",
+                        session_id,
+                        recorded_cwd,
+                        str(cwd),
+                    )
+                    return None
                 if line.get("type") != "user":
                     continue
                 # Claude jsonl reuses type="user" for two distinct things:

--- a/tests/test_session_manager_rehydrate.py
+++ b/tests/test_session_manager_rehydrate.py
@@ -227,6 +227,77 @@ def test_try_rehydrate_skips_isMeta_user_entries(tmp_path, monkeypatch):
     assert sess.turn_counter == 1
 
 
+def test_try_rehydrate_allows_matching_recorded_cwd(tmp_path, monkeypatch):
+    """A transcript whose recorded cwd matches the requester rehydrates."""
+    from src import session_manager
+
+    monkeypatch.setattr(session_manager, "_PROJECTS_ROOT", tmp_path)
+    cwd = "/base/alice"
+    encoded = session_manager._encode_cwd(cwd)
+    sid = "owned-1"
+    jsonl = tmp_path / encoded / f"{sid}.jsonl"
+    _write_jsonl(
+        jsonl,
+        [
+            {"type": "user", "cwd": cwd, "message": {"role": "user", "content": "hi"}},
+            {"type": "assistant", "cwd": cwd, "message": {"role": "assistant", "content": "ok"}},
+        ],
+    )
+
+    sess = session_manager._try_rehydrate_from_jsonl(sid, user="alice", cwd=cwd)
+    assert sess is not None
+    assert sess.turn_counter == 1
+
+
+def test_try_rehydrate_refuses_on_recorded_cwd_mismatch(tmp_path, monkeypatch):
+    """Refuse to rehydrate when the transcript's recorded cwd differs from
+    the requester's workspace (cross-workspace transcript)."""
+    from src import session_manager
+
+    monkeypatch.setattr(session_manager, "_PROJECTS_ROOT", tmp_path)
+    requester_cwd = "/base/bob"
+    encoded = session_manager._encode_cwd(requester_cwd)
+    sid = "foreign-1"
+    jsonl = tmp_path / encoded / f"{sid}.jsonl"
+    _write_jsonl(
+        jsonl,
+        [
+            # Transcript was created in a DIFFERENT workspace.
+            {"type": "user", "cwd": "/base/someone-else", "message": {"role": "user", "content": "hi"}},
+        ],
+    )
+
+    sess = session_manager._try_rehydrate_from_jsonl(sid, user="bob", cwd=requester_cwd)
+    assert sess is None
+
+
+def test_try_rehydrate_isolates_colliding_workspaces(tmp_path, monkeypatch):
+    """Distinct usernames that differ only by '_'/'.'/'-' collapse to the same
+    encoded transcript dir; the recorded-cwd guard must keep them isolated."""
+    from src import session_manager
+
+    monkeypatch.setattr(session_manager, "_PROJECTS_ROOT", tmp_path)
+    owner_cwd = "/base/a_b"  # user "a_b"
+    attacker_cwd = "/base/a.b"  # user "a.b" — encodes to the SAME dir
+    assert session_manager._encode_cwd(owner_cwd) == session_manager._encode_cwd(attacker_cwd)
+
+    sid = "shared-sid"
+    jsonl = tmp_path / session_manager._encode_cwd(owner_cwd) / f"{sid}.jsonl"
+    _write_jsonl(
+        jsonl,
+        [
+            {"type": "user", "cwd": owner_cwd, "message": {"role": "user", "content": "secret"}},
+        ],
+    )
+
+    # The colliding user is refused...
+    assert session_manager._try_rehydrate_from_jsonl(sid, user="a.b", cwd=attacker_cwd) is None
+    # ...but the real owner still rehydrates.
+    owned = session_manager._try_rehydrate_from_jsonl(sid, user="a_b", cwd=owner_cwd)
+    assert owned is not None
+    assert owned.turn_counter == 1
+
+
 def test_session_jsonl_exists_reflects_filesystem(tmp_path, monkeypatch):
     from src import session_manager
     from src.session_manager import Session


### PR DESCRIPTION
## Summary

Closes a cross-user isolation gap in session rehydration surfaced by the repo audit.

`_encode_cwd` maps every `/`, `_` and `.` to `-`, so distinct workspaces — e.g. users **`a_b`**, **`a.b`** and **`a-b`** — collapse to a single on-disk Claude SDK transcript directory. Rehydration located the transcript by the **requester's** encoded cwd and stamped the requester as the owner, making the post-rehydration user check (`responses.py:425`) vacuous. After a cache eviction, a user with a colliding name could reuse another user's `session_id` and rehydrate their session/history.

## Fix

The SDK records the **real (un-encoded) cwd** on each turn line (verified against on-disk transcripts). `_try_rehydrate_from_jsonl` now refuses to rehydrate when the transcript's recorded `cwd` does not match the requester's resolved workspace (`return None` → 404) and logs a warning.

The encoding is left **unchanged** — it faithfully mirrors the SDK's directory naming, so altering it would break legitimate rehydration; the ownership guard closes the gap instead.

## Compatibility & tests
- Backward compatible: transcripts/fixtures without a `cwd` field skip the check (no-op), so all existing rehydration tests pass unchanged.
- Adds 3 tests: matching cwd allowed, mismatching cwd refused, and the colliding-workspace isolation scenario (`a_b` vs `a.b`).

**Gates:** mypy clean · `ruff check` clean · `pytest` 1771 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)