### PR TITLE
feat(responses): stream liveness events + preserve interleaved reasoning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -274,6 +274,19 @@ DEFAULT_MODEL=sonnet
 # SUBAGENT_STREAM_TOOL_BLOCKS=true
 # SUBAGENT_STREAM_PROGRESS=true
 
+# Liveness / "still working" progress signals (Responses API streaming)
+# Forward extra events so a UI can show activity in the gaps between text —
+# long tool-call generation, hook runs, and context compaction.
+# STREAM_TOOL_PROGRESS: Emit response.tool_use_started at a tool call's start,
+#   before its arguments finish streaming (default: true).
+# STREAM_HOOK_EVENTS: Enable the SDK's include_hook_events and forward hook
+#   lifecycle (PreToolUse/PostToolUse/Stop/…) as response.hook_event (default: true).
+# STREAM_COMPACTION_EVENTS: Forward context-compaction (compact_boundary) as
+#   response.compaction (default: true).
+# STREAM_TOOL_PROGRESS=true
+# STREAM_HOOK_EVENTS=true
+# STREAM_COMPACTION_EVENTS=true
+
 # Bash Sandbox (OS-level process isolation for Bash tool execution)
 # Tri-state: unset = respect project-level settings, true = force enable, false = force disable
 # Only affects Bash commands; Read/Edit/Write access is controlled by SDK permission rules.

--- a/docs/streaming-events.md
+++ b/docs/streaming-events.md
@@ -35,11 +35,14 @@ response.in_progress
 response.output_item.added
 response.content_part.added
 response.output_text.delta      # zero or more
+response.tool_use_started       # zero or more (liveness; precedes response.tool_use)
 response.tool_use               # zero or more
 response.tool_result            # zero or more
 response.task_started           # zero or more
 response.task_progress          # zero or more
 response.task_notification      # zero or more
+response.hook_event             # zero or more (liveness)
+response.compaction             # zero or more (liveness)
 response.output_text.done
 response.content_part.done
 response.output_item.done
@@ -48,6 +51,12 @@ response.completed
 
 Failures emit `response.failed`. Empty SDK output is also surfaced as
 `response.failed` so clients receive a definite terminal event.
+
+Reasoning (thinking) blocks are emitted as `reasoning` output items with
+`response.reasoning_summary_text.delta` / `response.reasoning_text.delta`
+events. A turn that interleaves thinking and text (think → text → think → text)
+produces multiple `reasoning` and `message` output items in emission order;
+clients that concatenate all `message` items' text reconstruct the full answer.
 
 ## Lifecycle Events
 
@@ -208,6 +217,71 @@ Subagent visibility is controlled by:
 | `SUBAGENT_STREAM_TEXT` | `false` | Forward subagent text deltas |
 | `SUBAGENT_STREAM_TOOL_BLOCKS` | `true` | Forward subagent tool events |
 | `SUBAGENT_STREAM_PROGRESS` | `true` | Forward subagent task progress |
+
+## Liveness / Progress Events
+
+These optional events keep the client informed that the agent is still working
+during the gaps between visible text — long tool-call generation, hook
+execution, and context compaction — instead of a silent stream punctuated only
+by SSE keepalive comments. They are advisory: clients may ignore any event type
+they don't recognize.
+
+`response.tool_use_started` is emitted at the *start* of a tool call, before its
+JSON arguments finish streaming. The matching `response.tool_use` (same
+`tool_use_id`) arrives once the arguments are complete. Use it to show
+"preparing <tool>…" during long argument generation.
+
+```json
+{
+  "type": "response.tool_use_started",
+  "tool_use_id": "toolu_01ABC123",
+  "name": "Bash",
+  "sequence_number": 6
+}
+```
+
+`response.hook_event` mirrors the SDK's hook lifecycle (PreToolUse, PostToolUse,
+Stop, …) so a UI can show "running <tool>…" / "<tool> finished". `phase` is
+`hook_started` or `hook_response`; `outcome` is present on `hook_response`.
+
+```json
+{
+  "type": "response.hook_event",
+  "phase": "hook_started",
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_use_id": "toolu_01ABC123",
+  "outcome": null,
+  "session_id": "sdk-session-id",
+  "sequence_number": 7
+}
+```
+
+`response.compaction` is emitted when the SDK compacts the context window (an
+otherwise-silent pause). `trigger` is `auto` or `manual` when the SDK reports it.
+
+```json
+{
+  "type": "response.compaction",
+  "subtype": "compact_boundary",
+  "trigger": "auto",
+  "session_id": "sdk-session-id",
+  "sequence_number": 8
+}
+```
+
+Liveness events are controlled by:
+
+| Env var | Default | Effect |
+|---------|---------|--------|
+| `STREAM_TOOL_PROGRESS` | `true` | Emit `response.tool_use_started` |
+| `STREAM_HOOK_EVENTS` | `true` | Enable SDK `include_hook_events`; forward `response.hook_event` |
+| `STREAM_COMPACTION_EVENTS` | `true` | Forward `response.compaction` |
+
+Subagent-originated liveness events (with `parent_tool_use_id`) follow the same
+subagent gates as their block type: `response.tool_use_started` respects
+`SUBAGENT_STREAM_TOOL_BLOCKS`; `response.hook_event` respects
+`SUBAGENT_STREAM_PROGRESS`.
 
 ## AskUserQuestion Pauses
 

--- a/src/backends/claude/client.py
+++ b/src/backends/claude/client.py
@@ -428,6 +428,15 @@ class ClaudeCodeCLI(TokenEstimateMixin):
         if get_token_streaming():
             options.include_partial_messages = True
 
+        # Surface hook lifecycle events (PreToolUse/PostToolUse/Stop/…) into the
+        # message stream so the gateway can forward them as `response.hook_event`
+        # liveness signals. Additive: does not change hook *callback* behaviour
+        # (e.g. the AskUserQuestion PreToolUse hook still parks as before).
+        from src.constants import STREAM_HOOK_EVENTS
+
+        if STREAM_HOOK_EVENTS:
+            options.include_hook_events = True
+
         self._configure_session_identity(options, session_id, resume)
         self._configure_task_budget(options, task_budget)
         self._configure_metadata_env(options, extra_env)

--- a/src/chat_page.py
+++ b/src/chat_page.py
@@ -1651,6 +1651,25 @@ async function streamRequest(body) {
           setStatus('streaming', 'agent: ' + label);
         }
 
+        // --- Liveness: tool call starting (before its arguments finish) ---
+        if (type === 'response.tool_use_started') {
+          const meta = toolMeta(evt.name);
+          setStatus('streaming', meta.glyph + ' 준비 중: ' + (evt.name || 'tool'));
+        }
+
+        // --- Liveness: hook lifecycle (PreToolUse/PostToolUse/…) ---
+        if (type === 'response.hook_event') {
+          const hookName = evt.hook_event_name || 'hook';
+          const toolPart = evt.tool_name ? (' · ' + evt.tool_name) : '';
+          const phase = evt.phase === 'hook_response' ? '완료' : '실행';
+          setStatus('streaming', '🪝 ' + hookName + toolPart + ' ' + phase);
+        }
+
+        // --- Liveness: context compaction in progress ---
+        if (type === 'response.compaction') {
+          setStatus('streaming', '🗜️ 컨텍스트 압축 중…');
+        }
+
         // --- function_call (AskUserQuestion) ---
         if (type === 'response.output_item.added' && evt.item && evt.item.type === 'function_call') {
           // Will be handled in response.completed

--- a/src/constants.py
+++ b/src/constants.py
@@ -87,6 +87,28 @@ SUBAGENT_STREAM_TEXT = parse_bool_env("SUBAGENT_STREAM_TEXT", "false")
 SUBAGENT_STREAM_TOOL_BLOCKS = parse_bool_env("SUBAGENT_STREAM_TOOL_BLOCKS", "true")
 SUBAGENT_STREAM_PROGRESS = parse_bool_env("SUBAGENT_STREAM_PROGRESS", "true")
 
+# ---------------------------------------------------------------------------
+# Liveness / "still working" progress signals forwarded to the Responses API
+# client during streaming. These let a UI show what the agent is doing in the
+# gaps between text — large tool-call generation, tool execution, hook runs,
+# and context compaction — instead of a silent stream punctuated only by SSE
+# keepalive comments.
+#
+# STREAM_TOOL_PROGRESS: Emit `response.tool_use_started` at content_block_start
+#   for a tool_use block (before its arguments finish streaming), so the client
+#   can show "preparing tool call…" during long argument generation.
+#   Default true.
+# STREAM_HOOK_EVENTS: Enable the SDK's include_hook_events and forward hook
+#   lifecycle messages (PreToolUse/PostToolUse/Stop/…) as `response.hook_event`.
+#   This is the SDK's purpose-built "about to run X / finished X" feed.
+#   Default true.
+# STREAM_COMPACTION_EVENTS: Forward context-compaction system messages
+#   (compact_boundary/compaction) as `response.compaction`, so the client can
+#   show "compacting context…" during the pause. Default true.
+STREAM_TOOL_PROGRESS = parse_bool_env("STREAM_TOOL_PROGRESS", "true")
+STREAM_HOOK_EVENTS = parse_bool_env("STREAM_HOOK_EVENTS", "true")
+STREAM_COMPACTION_EVENTS = parse_bool_env("STREAM_COMPACTION_EVENTS", "true")
+
 # Rate Limiting defaults (requests per minute)
 # These are used by rate_limiter.py as the single source of truth
 RATE_LIMITS = {

--- a/src/sse_builders.py
+++ b/src/sse_builders.py
@@ -119,7 +119,7 @@ def _build_progress_event(chunk: Dict[str, Any]) -> Optional[Dict[str, Any]]:
             or ""
         )
         tool_use_id = data.get("tool_use_id") or chunk.get("tool_use_id")
-        return {
+        event = {
             "type": "hook_event",
             "phase": subtype,  # "hook_started" | "hook_response"
             "hook_event_name": hook_event_name,
@@ -127,8 +127,10 @@ def _build_progress_event(chunk: Dict[str, Any]) -> Optional[Dict[str, Any]]:
             "tool_use_id": tool_use_id,
             "outcome": data.get("outcome"),  # present on hook_response
             "session_id": chunk.get("session_id"),
-            "parent_tool_use_id": chunk.get("parent_tool_use_id") or tool_use_id,
         }
+        if chunk.get("parent_tool_use_id") is not None:
+            event["parent_tool_use_id"] = chunk.get("parent_tool_use_id")
+        return event
     if subtype in ("compact_boundary", "compaction"):
         if not STREAM_COMPACTION_EVENTS:
             return None

--- a/src/sse_builders.py
+++ b/src/sse_builders.py
@@ -3,6 +3,7 @@
 import json
 from typing import Any, Dict, Optional
 
+from src.constants import STREAM_COMPACTION_EVENTS, STREAM_HOOK_EVENTS
 from src.content_blocks import normalize_tool_result_for_sse
 
 
@@ -84,6 +85,90 @@ def make_task_response_sse(task_event: Dict[str, Any], *, sequence_number: int =
     """Build an SSE line for Responses API with a custom task event type."""
     event_type = f"response.{task_event['type']}"
     data = {**task_event, "type": event_type, "sequence_number": sequence_number}
+    return f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
+
+
+def _build_progress_event(chunk: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Build a liveness ("still working") event dict from a system chunk, or None.
+
+    Complements :func:`_build_task_event` (which only handles subagent task
+    messages). Surfaces two more classes of progress that the SDK reports as
+    ``system`` messages but the gateway previously dropped:
+
+    * Hook lifecycle (``hook_started`` / ``hook_response``) — emitted when
+      ``include_hook_events`` is on. Becomes ``response.hook_event`` carrying
+      the hook name (e.g. ``PreToolUse``), the tool it fired for, and the run
+      phase, so a UI can show "running <tool>…" / "<tool> finished".
+    * Context compaction (``compact_boundary`` / ``compaction``) — becomes
+      ``response.compaction`` so a UI can show "compacting context…" during the
+      otherwise-silent pause.
+
+    Returns ``None`` for any other subtype (caller leaves it dropped) and when
+    the corresponding feature flag is disabled.
+    """
+    subtype = chunk.get("subtype")
+    if subtype in ("hook_started", "hook_response"):
+        if not STREAM_HOOK_EVENTS:
+            return None
+        data = chunk.get("data") if isinstance(chunk.get("data"), dict) else {}
+        hook_event_name = (
+            chunk.get("hook_event_name")
+            or data.get("hook_event")
+            or data.get("hook_event_name")
+            or data.get("hook_name")
+            or ""
+        )
+        tool_use_id = data.get("tool_use_id") or chunk.get("tool_use_id")
+        return {
+            "type": "hook_event",
+            "phase": subtype,  # "hook_started" | "hook_response"
+            "hook_event_name": hook_event_name,
+            "tool_name": data.get("tool_name") or data.get("tool"),
+            "tool_use_id": tool_use_id,
+            "outcome": data.get("outcome"),  # present on hook_response
+            "session_id": chunk.get("session_id"),
+            "parent_tool_use_id": chunk.get("parent_tool_use_id") or tool_use_id,
+        }
+    if subtype in ("compact_boundary", "compaction"):
+        if not STREAM_COMPACTION_EVENTS:
+            return None
+        data = chunk.get("data") if isinstance(chunk.get("data"), dict) else {}
+        trigger = data.get("trigger")
+        if trigger is None and isinstance(data.get("compact_metadata"), dict):
+            trigger = data["compact_metadata"].get("trigger")
+        return {
+            "type": "compaction",
+            "subtype": subtype,
+            "trigger": trigger,
+            "session_id": chunk.get("session_id"),
+        }
+    return None
+
+
+def make_tool_use_started_response_sse(
+    tool_use_id: str,
+    name: str,
+    *,
+    sequence_number: int = 0,
+    parent_tool_use_id: Optional[str] = None,
+) -> str:
+    """Build an SSE line announcing a tool call is starting.
+
+    Emitted at ``content_block_start`` for a tool_use block — before its JSON
+    arguments finish streaming — so a UI can show "preparing <tool>…" instead
+    of a silent gap while a large tool input is generated. The matching
+    ``response.tool_use`` (same ``tool_use_id``) arrives once the input is
+    complete.
+    """
+    event_type = "response.tool_use_started"
+    data = {
+        "type": event_type,
+        "tool_use_id": tool_use_id or "",
+        "name": name or "",
+        "sequence_number": sequence_number,
+    }
+    if parent_tool_use_id:
+        data["parent_tool_use_id"] = parent_tool_use_id
     return f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
 
 

--- a/src/streaming_utils.py
+++ b/src/streaming_utils.py
@@ -1013,20 +1013,23 @@ async def stream_response_chunks(
 
             # Handle task system messages (structured JSON, not content)
             if chunk.get("type") == "system":
-                # SDK task messages identify their spawning Task tool via
-                # ``tool_use_id``; treat either field as the subagent signal so
-                # SUBAGENT_STREAM_PROGRESS actually gates real SDK output.
-                is_subagent_task = (
-                    chunk.get("parent_tool_use_id") is not None
-                    or chunk.get("tool_use_id") is not None
-                )
-                if not is_subagent_task or SUBAGENT_STREAM_PROGRESS:
-                    # Subagent task progress (task_started/progress/notification).
-                    task_event = _build_task_event(chunk)
-                    if task_event:
+                # Subagent task messages identify their spawning Task tool via
+                # ``tool_use_id``. Hook events also carry ``tool_use_id``, but
+                # that is the hook's target tool, not a parent/nesting marker.
+                task_event = _build_task_event(chunk)
+                if task_event:
+                    is_subagent_task = (
+                        chunk.get("parent_tool_use_id") is not None
+                        or chunk.get("tool_use_id") is not None
+                    )
+                    if not is_subagent_task or SUBAGENT_STREAM_PROGRESS:
                         yield make_task_response_sse(task_event, sequence_number=_next_seq())
-                    else:
-                        # Other liveness signals: hook lifecycle + compaction.
+                else:
+                    # Other liveness signals: hook lifecycle + compaction.
+                    # For these, only an explicit parent_tool_use_id marks
+                    # subagent origin. A plain tool_use_id is the target tool.
+                    is_subagent_progress = chunk.get("parent_tool_use_id") is not None
+                    if not is_subagent_progress or SUBAGENT_STREAM_PROGRESS:
                         progress_event = _build_progress_event(chunk)
                         if progress_event:
                             yield make_task_response_sse(

--- a/src/streaming_utils.py
+++ b/src/streaming_utils.py
@@ -5,6 +5,7 @@ from typing import Any, AsyncGenerator, Callable, Dict, Optional
 
 from src.constants import (
     SSE_KEEPALIVE_INTERVAL,
+    STREAM_TOOL_PROGRESS,
     SUBAGENT_STREAM_PROGRESS,
     SUBAGENT_STREAM_TOOL_BLOCKS,
 )
@@ -26,6 +27,7 @@ from src.usage_logger import usage_logger
 # External callers continue to use `from src.streaming_utils import X`.
 from src.collab_filter import CollabJsonStreamFilter, strip_collab_json  # noqa: F401
 from src.sse_builders import (  # noqa: F401
+    _build_progress_event,
     _build_task_event,
     _normalize_tool_result,
     make_function_call_response_sse,
@@ -33,6 +35,7 @@ from src.sse_builders import (  # noqa: F401
     make_task_response_sse,
     make_tool_result_response_sse,
     make_tool_use_response_sse,
+    make_tool_use_started_response_sse,
 )
 from src.chunk_processing import (  # noqa: F401
     _extract_tool_blocks,
@@ -495,6 +498,11 @@ def _generate_rs_id() -> str:
     return f"rs_{uuid.uuid4().hex[:24]}"
 
 
+def _generate_msg_id() -> str:
+    import uuid
+    return f"msg_{uuid.uuid4().hex[:24]}"
+
+
 def _is_synthetic_ask_user_response_result(
     result_block: Dict[str, Any],
     tool_names_by_id: Dict[str, str],
@@ -514,6 +522,41 @@ def _is_synthetic_ask_user_response_result(
     if not isinstance(request_context, dict):
         return False
     return request_context.get("function_call_output_call_id") == tool_use_id
+
+
+def _tool_use_started_events(
+    chunk: Dict[str, Any],
+    next_seq: Callable[[], int],
+) -> list[str]:
+    """Emit a ``response.tool_use_started`` signal at the tool_use block start.
+
+    Fires once per tool call at ``content_block_start`` — before its JSON
+    arguments finish streaming — so a UI can show "preparing <tool>…" during
+    long argument generation instead of a silent gap. The matching
+    ``response.tool_use`` (same ``tool_use_id``) arrives once the input is
+    complete. Honours STREAM_TOOL_PROGRESS and the subagent tool-block gate.
+    """
+    if not STREAM_TOOL_PROGRESS:
+        return []
+    if chunk.get("type") != "stream_event":
+        return []
+    event = chunk.get("event")
+    if not isinstance(event, dict) or event.get("type") != "content_block_start":
+        return []
+    block = event.get("content_block")
+    if not isinstance(block, dict) or block.get("type") != "tool_use":
+        return []
+    parent_id = chunk.get("parent_tool_use_id")
+    if parent_id is not None and not SUBAGENT_STREAM_TOOL_BLOCKS:
+        return []
+    return [
+        make_tool_use_started_response_sse(
+            block.get("id", ""),
+            block.get("name", ""),
+            sequence_number=next_seq(),
+            parent_tool_use_id=parent_id,
+        )
+    ]
 
 
 def _tool_use_events(
@@ -657,8 +700,16 @@ async def stream_response_chunks(
     tool_acc = ToolUseAccumulator()
     collab_filter = CollabJsonStreamFilter()
     full_text = []
+    # Accumulates *all* visible text across every message segment.  ``full_text``
+    # is reset at each segment boundary (think→text→think), so this is the
+    # source of truth for the complete assistant text handed back to the route.
+    all_visible_text: list[str] = []
     seq = 0
     message_item_opened = False
+    # True once *any* message output item has been opened (never reset), so
+    # finalization can tell "thinking-only response" (needs a trailing empty
+    # message item) apart from "stream ended after a real message segment".
+    any_message_item = False
     output_index = 0
     reasoning_open = False
     reasoning_item_id: Optional[str] = None
@@ -666,7 +717,9 @@ async def stream_response_chunks(
     thinking_seen = False
     thinking_texts: list[str] = []
     thinking_capture_buf: list[str] = []
-    completed_reasoning_items: list[ReasoningOutputItem] = []
+    # Every completed output item (reasoning and message) in emission order.
+    # Interleaving is allowed, so this is no longer reasoning-only.
+    completed_output_items: list = []
     _metadata = metadata or {}
     if stream_result is None:
         stream_result = {}
@@ -739,10 +792,11 @@ async def stream_response_chunks(
 
     def _open_message_item() -> list[str]:
         """Emit message output_item.added + content_part.added. Idempotent."""
-        nonlocal message_item_opened
+        nonlocal message_item_opened, any_message_item
         if message_item_opened:
             return []
         message_item_opened = True
+        any_message_item = True
         out_item = OutputItem(id=output_item_id, status="in_progress")
         content_part = ResponseContentPart(type="output_text", text="")
         return [
@@ -800,7 +854,7 @@ async def stream_response_chunks(
             summary=[ReasoningSummary(text=full_text)],
             content=[ReasoningContent(text=full_text)],
         )
-        completed_reasoning_items.append(item)
+        completed_output_items.append(item)
         lines = [
             make_response_sse(
                 "response.reasoning_summary_text.done",
@@ -837,6 +891,73 @@ async def stream_response_chunks(
         reasoning_item_id = None
         reasoning_text_buf = []
         output_index += 1
+        return lines
+
+    def _close_message_item() -> list[str]:
+        """Close the currently-open message item and record it.
+
+        Flushes the collab filter into the segment, emits
+        output_text.done / content_part.done / output_item.done, appends the
+        completed item to ``completed_output_items`` (preserving emission
+        order), then resets the per-segment state, advances ``output_index``,
+        and mints a fresh ``output_item_id`` so a following reasoning or
+        message item gets its own slot.  No-op when no message item is open.
+
+        This is what makes interleaved think→text→think→text turns work: each
+        text run becomes its own message item rather than the second thinking
+        block being dropped because reasoning can't reopen after text started.
+        """
+        nonlocal message_item_opened, full_text, output_index, output_item_id
+        nonlocal content_sent
+        if not message_item_opened:
+            return []
+        lines: list[str] = []
+        remaining = collab_filter.flush()
+        if remaining:
+            lines.append(_emit_delta(remaining))
+            full_text.append(remaining)
+            all_visible_text.append(remaining)
+            content_sent = True
+        seg_text = "".join(full_text)
+        item = OutputItem(
+            id=output_item_id,
+            status="completed",
+            content=[ResponseContentPart(text=seg_text)],
+        )
+        lines.append(
+            make_response_sse(
+                "response.output_text.done",
+                item_id=output_item_id,
+                output_index=output_index,
+                content_index=0,
+                text=seg_text,
+                logprobs=[],
+                sequence_number=_next_seq(),
+            )
+        )
+        lines.append(
+            make_response_sse(
+                "response.content_part.done",
+                item_id=output_item_id,
+                output_index=output_index,
+                content_index=0,
+                part=ResponseContentPart(text=seg_text),
+                sequence_number=_next_seq(),
+            )
+        )
+        lines.append(
+            make_response_sse(
+                "response.output_item.done",
+                output_index=output_index,
+                item=item,
+                sequence_number=_next_seq(),
+            )
+        )
+        completed_output_items.append(item)
+        message_item_opened = False
+        full_text = []
+        output_index += 1
+        output_item_id = _generate_msg_id()
         return lines
 
     # --- Main streaming loop ---
@@ -900,9 +1021,17 @@ async def stream_response_chunks(
                     or chunk.get("tool_use_id") is not None
                 )
                 if not is_subagent_task or SUBAGENT_STREAM_PROGRESS:
+                    # Subagent task progress (task_started/progress/notification).
                     task_event = _build_task_event(chunk)
                     if task_event:
                         yield make_task_response_sse(task_event, sequence_number=_next_seq())
+                    else:
+                        # Other liveness signals: hook lifecycle + compaction.
+                        progress_event = _build_progress_event(chunk)
+                        if progress_event:
+                            yield make_task_response_sse(
+                                progress_event, sequence_number=_next_seq()
+                            )
                 continue
 
             # Token-level streaming (text/thinking deltas)
@@ -919,13 +1048,18 @@ async def stream_response_chunks(
             text_delta, in_thinking = extract_stream_event_delta(chunk, in_thinking)
             if text_delta is not None:
                 token_streaming = True
-                # Open reasoning output_item on first thinking delta of a block,
-                # but only if the message item is not already open. The OpenAI
-                # Responses API contract does not support interleaving reasoning
-                # back in after a message item has started emitting text; if a
-                # second thinking block arrives after text in the rare
-                # think→text→think case, those thinking deltas are dropped.
-                if in_thinking and not was_thinking and not message_item_opened:
+                # Open a reasoning output_item on the first thinking delta of a
+                # block. If a message item is already streaming text (the
+                # think→text→think case), close it first so this thinking block
+                # gets its OWN reasoning item at a fresh output_index. The
+                # OpenAI Responses output array is an ordered sequence, so
+                # interleaving reasoning and message items is valid — we open a
+                # new reasoning item, we never reopen the closed one — and the
+                # later thinking blocks are preserved instead of dropped.
+                if in_thinking and not was_thinking:
+                    if message_item_opened:
+                        for line in _close_message_item():
+                            yield line
                     reasoning_item_id = _generate_rs_id()
                     reasoning_open = True
                     reasoning_text_buf = []
@@ -985,9 +1119,11 @@ async def stream_response_chunks(
                             sequence_number=_next_seq(),
                         )
                     continue
-                # We're inside a thinking block but couldn't open a reasoning item
-                # (message item already opened — OpenAI Responses contract doesn't support
-                # reopening reasoning). Drop these deltas so they don't leak as message text.
+                # Safety net: inside a thinking block but no reasoning item is
+                # open. This should no longer happen — a new thinking block now
+                # closes any open message item and opens its own reasoning item
+                # above — but keep the guard so thinking text can never leak
+                # into the visible message stream.
                 if in_thinking:
                     continue
                 # If reasoning was open and we just exited it, close it now.
@@ -1002,8 +1138,15 @@ async def stream_response_chunks(
                                 yield line
                         yield _emit_delta(cleaned)
                         full_text.append(cleaned)
+                        all_visible_text.append(cleaned)
                         content_sent = True
                 continue
+
+            # Announce a tool call as it starts (content_block_start), before
+            # its arguments finish streaming, so the client isn't left silent
+            # during long tool-input generation.
+            for event in _tool_use_started_events(chunk, _next_seq):
+                yield event
 
             # Accumulate tool_use blocks from stream events
             handled, tool_block = tool_acc.process_stream_event(chunk)
@@ -1052,6 +1195,7 @@ async def stream_response_chunks(
                         yield line
                 yield _emit_delta(text)
                 full_text.append(text)
+                all_visible_text.append(text)
                 content_sent = True
 
     except Exception as e:
@@ -1067,7 +1211,7 @@ async def stream_response_chunks(
         await _log_usage("failed", "server_error")
         return
 
-    # Flush remaining buffered chars from collab filter
+    # Flush remaining buffered chars from collab filter into the open segment.
     remaining_collab = collab_filter.flush()
     if remaining_collab:
         if not message_item_opened:
@@ -1075,6 +1219,7 @@ async def stream_response_chunks(
                 yield line
         yield _emit_delta(remaining_collab)
         full_text.append(remaining_collab)
+        all_visible_text.append(remaining_collab)
         content_sent = True
 
     if tool_acc.has_incomplete:
@@ -1093,69 +1238,38 @@ async def stream_response_chunks(
         stream_result["empty"] = True
         return
 
-    # Close reasoning if it's still open (stream ended without exiting thinking).
+    # Close a trailing reasoning item if the stream ended without exiting thinking.
     _close_thinking_capture()
     if reasoning_open:
         for line in _close_reasoning():
             yield line
 
-    # Emit closing events for successful stream
-    final_text = "".join(full_text)
-
-    # Ensure the message item has been announced (consumer always sees one).
-    if not message_item_opened:
+    # Close the final (or only) message segment.  If no message item was ever
+    # opened — a thinking-only response, or a stream that ended right after a
+    # think→text→think segment boundary — ensure the consumer still sees one
+    # trailing (possibly empty) message item.
+    if message_item_opened:
+        for line in _close_message_item():
+            yield line
+    elif not any_message_item:
         for line in _open_message_item():
             yield line
+        for line in _close_message_item():
+            yield line
 
-    # response.output_text.done
-    yield make_response_sse(
-        "response.output_text.done",
-        item_id=output_item_id,
-        output_index=output_index,
-        content_index=0,
-        text=final_text,
-        logprobs=[],
-        sequence_number=_next_seq(),
-    )
-
-    # response.content_part.done
-    yield make_response_sse(
-        "response.content_part.done",
-        item_id=output_item_id,
-        output_index=output_index,
-        content_index=0,
-        part=ResponseContentPart(text=final_text),
-        sequence_number=_next_seq(),
-    )
-
-    # response.output_item.done
-    yield make_response_sse(
-        "response.output_item.done",
-        output_index=output_index,
-        item=OutputItem(
-            id=output_item_id,
-            status="completed",
-            content=[ResponseContentPart(text=final_text)],
-        ),
-        sequence_number=_next_seq(),
-    )
-
-    # response.completed (with usage — prefer real SDK values)
+    # response.completed (with usage — prefer real SDK values).  ``output``
+    # carries every reasoning and message item in emission order, so an
+    # interleaved think→text→think→text turn round-trips intact rather than
+    # dropping the later thinking blocks.
+    complete_text = "".join(all_visible_text)
     prompt_tokens, completion_tokens = resolve_token_usage(
-        chunks_buffer, prompt_text or "", final_text
+        chunks_buffer, prompt_text or "", complete_text
     )
     final_resp = ResponseObject(
         id=response_id,
         model=model,
         status="completed",
-        output=[
-            *completed_reasoning_items,
-            OutputItem(
-                id=output_item_id,
-                status="completed",
-                content=[ResponseContentPart(text=final_text)],
-            ),
-        ],
+        output=list(completed_output_items),
         usage=ResponseUsage(
             input_tokens=prompt_tokens,
             output_tokens=completion_tokens,
@@ -1163,13 +1277,13 @@ async def stream_response_chunks(
         metadata=_metadata,
     )
     stream_result["success"] = True
-    stream_result["assistant_text"] = final_text
+    stream_result["assistant_text"] = complete_text
     stream_result["thinking_texts"] = thinking_texts
     logger.info(
         "Responses stream completed: response_id=%s assistant_chars=%d "
         "thinking_blocks=%d thinking_chars=%s",
         response_id,
-        len(final_text),
+        len(complete_text),
         len(thinking_texts),
         [len(text) for text in thinking_texts],
     )

--- a/tests/test_claude_cli_unit.py
+++ b/tests/test_claude_cli_unit.py
@@ -541,6 +541,18 @@ class TestBuildSdkOptions:
             opts = cli_instance._build_sdk_options()
             assert not getattr(opts, "include_partial_messages", False)
 
+    def test_include_hook_events_on_by_default(self, cli_instance):
+        """STREAM_HOOK_EVENTS (default True) enables include_hook_events so the
+        gateway can forward hook lifecycle events as liveness signals."""
+        opts = cli_instance._build_sdk_options()
+        assert opts.include_hook_events is True
+
+    def test_include_hook_events_disabled_by_flag(self, cli_instance, monkeypatch):
+        """STREAM_HOOK_EVENTS=False leaves include_hook_events off."""
+        monkeypatch.setattr("src.constants.STREAM_HOOK_EVENTS", False)
+        opts = cli_instance._build_sdk_options()
+        assert not getattr(opts, "include_hook_events", False)
+
     def test_mcp_servers_passthrough(self, cli_instance):
         """mcp_servers option is set on options."""
         servers = {"my_server": {"type": "stdio", "command": "node"}}

--- a/tests/test_streaming_utils_unit.py
+++ b/tests/test_streaming_utils_unit.py
@@ -2117,10 +2117,12 @@ async def test_stream_forwards_hook_lifecycle_events():
     assert hook_events[0]["hook_event_name"] == "PreToolUse"
     assert hook_events[0]["tool_name"] == "Bash"
     assert hook_events[0]["tool_use_id"] == "tu_9"
+    assert "parent_tool_use_id" not in hook_events[0]
 
     assert hook_events[1]["phase"] == "hook_response"
     assert hook_events[1]["hook_event_name"] == "PostToolUse"
     assert hook_events[1]["outcome"] == "success"
+    assert "parent_tool_use_id" not in hook_events[1]
 
     # Normal content still flows after the hook events.
     deltas = [p.get("delta") for t, p in events if t == "response.output_text.delta"]
@@ -2142,6 +2144,46 @@ async def test_stream_hook_events_disabled_by_flag(monkeypatch):
 
     events, _ = await _collect_response_events(chunk_source())
     assert not any(t == "response.hook_event" for t, _ in events)
+
+
+async def test_stream_hook_event_preserves_explicit_parent_tool_use_id():
+    """Only an explicit parent_tool_use_id marks hook_event nesting."""
+
+    async def chunk_source():
+        yield {
+            "type": "system", "subtype": "hook_started", "hook_event_name": "PreToolUse",
+            "parent_tool_use_id": "parent_1",
+            "data": {"hook_event": "PreToolUse", "tool_name": "Bash", "tool_use_id": "tu_child"},
+        }
+        yield {"type": "stream_event", "event": {
+            "type": "content_block_delta",
+            "delta": {"type": "text_delta", "text": "ok"},
+        }}
+
+    events, _ = await _collect_response_events(chunk_source())
+    hook_event = next(p for t, p in events if t == "response.hook_event")
+    assert hook_event["tool_use_id"] == "tu_child"
+    assert hook_event["parent_tool_use_id"] == "parent_1"
+
+
+async def test_stream_top_level_hook_event_not_gated_as_subagent(monkeypatch):
+    """A hook's tool_use_id is its target tool, not a subagent parent marker."""
+    monkeypatch.setattr("src.streaming_utils.SUBAGENT_STREAM_PROGRESS", False)
+
+    async def chunk_source():
+        yield {
+            "type": "system", "subtype": "hook_started", "hook_event_name": "PreToolUse",
+            "data": {"hook_event": "PreToolUse", "tool_name": "Bash", "tool_use_id": "tu_top"},
+        }
+        yield {"type": "stream_event", "event": {
+            "type": "content_block_delta",
+            "delta": {"type": "text_delta", "text": "ok"},
+        }}
+
+    events, _ = await _collect_response_events(chunk_source())
+    hook_event = next(p for t, p in events if t == "response.hook_event")
+    assert hook_event["tool_use_id"] == "tu_top"
+    assert "parent_tool_use_id" not in hook_event
 
 
 async def test_stream_forwards_compaction_event():

--- a/tests/test_streaming_utils_unit.py
+++ b/tests/test_streaming_utils_unit.py
@@ -1415,14 +1415,105 @@ async def test_stream_closes_reasoning_with_accumulated_text():
     assert msg_added["output_index"] == 1
 
 
-# NOTE: A test for fully-interleaved think → text → think → text was removed.
-# The OpenAI Responses API contract does not cleanly support reopening a
-# reasoning output_item after a message output_item has started emitting text.
-# Buffering text deltas until end-of-stream to preserve ordering would break
-# live token streaming for the common case (single thinking block followed by
-# text), so we accept that in the rare interleaved case the second thinking
-# block's content is dropped. See test_stream_text_after_thinking_emits_deltas_live
-# below for the live-streaming regression check.
+async def test_stream_interleaved_think_text_think_text_preserves_second_block():
+    """Fully-interleaved think → text → think → text must NOT drop the 2nd block.
+
+    The OpenAI Responses ``output`` array is an ordered sequence, so a new
+    thinking block after text closes the current message item and opens its
+    own reasoning item, then a fresh message item for the trailing text. All
+    four blocks (r1, m1, r2, m2) survive and stream live.
+    """
+    import logging
+    from src.streaming_utils import stream_response_chunks
+
+    def _think_start(idx):
+        return {"type": "stream_event", "event": {
+            "type": "content_block_start", "index": idx,
+            "content_block": {"type": "thinking", "thinking": ""},
+        }}
+
+    def _think_delta(idx, text):
+        return {"type": "stream_event", "event": {
+            "type": "content_block_delta", "index": idx,
+            "delta": {"type": "thinking_delta", "thinking": text},
+        }}
+
+    def _text_start(idx):
+        return {"type": "stream_event", "event": {
+            "type": "content_block_start", "index": idx,
+            "content_block": {"type": "text", "text": ""},
+        }}
+
+    def _text_delta(idx, text):
+        return {"type": "stream_event", "event": {
+            "type": "content_block_delta", "index": idx,
+            "delta": {"type": "text_delta", "text": text},
+        }}
+
+    def _stop(idx):
+        return {"type": "stream_event", "event": {"type": "content_block_stop", "index": idx}}
+
+    async def chunk_source():
+        yield _think_start(0)
+        yield _think_delta(0, "ponder-A")
+        yield _stop(0)
+        yield _text_start(1)
+        yield _text_delta(1, "answer-A")
+        yield _stop(1)
+        yield _think_start(2)
+        yield _think_delta(2, "ponder-B")
+        yield _stop(2)
+        yield _text_start(3)
+        yield _text_delta(3, "answer-B")
+        yield _stop(3)
+
+    events = []
+    stream_result: dict = {}
+    async for line in stream_response_chunks(
+        chunk_source(),
+        model="m",
+        response_id="resp_1",
+        output_item_id="msg_1",
+        chunks_buffer=[],
+        logger=logging.getLogger("test"),
+        stream_result=stream_result,
+    ):
+        events.append(_parse_response_sse(line))
+
+    # Both thinking blocks must be streamed as reasoning text (the 2nd is the regression).
+    reasoning_deltas = [p["delta"] for t, p in events if t == "response.reasoning_text.delta"]
+    assert "ponder-A" in reasoning_deltas
+    assert "ponder-B" in reasoning_deltas, "2nd thinking block was dropped"
+
+    # Both text runs must be streamed live as message deltas.
+    text_deltas = [p["delta"] for t, p in events if t == "response.output_text.delta"]
+    assert text_deltas == ["answer-A", "answer-B"]
+
+    # Two reasoning items and two message items closed, interleaved in order.
+    done_types = [
+        p["item"]["type"]
+        for t, p in events
+        if t == "response.output_item.done"
+    ]
+    assert done_types == ["reasoning", "message", "reasoning", "message"]
+
+    # output_index increases monotonically across the four items: 0,1,2,3.
+    done_indices = [p["output_index"] for t, p in events if t == "response.output_item.done"]
+    assert done_indices == [0, 1, 2, 3]
+
+    # The final response.completed carries all four items in order.
+    completed = next(p for t, p in events if t == "response.completed")
+    out_types = [item["type"] for item in completed["response"]["output"]]
+    assert out_types == ["reasoning", "message", "reasoning", "message"]
+
+    # The full visible text handed back to the route is the concatenation of
+    # both message segments (not just the last one).
+    assert stream_result["assistant_text"] == "answer-Aanswer-B"
+    assert stream_result["thinking_texts"] == ["ponder-A", "ponder-B"]
+
+
+# Regression: the common case (single thinking block then text) must still
+# stream text deltas live, not buffer them until end-of-stream.
 
 
 async def test_stream_text_after_thinking_emits_deltas_live_not_buffered():
@@ -1907,3 +1998,167 @@ class TestExtractVisibleAssistantText:
             {"type": "assistant", "content": [{"type": "text", "text": "second"}]},
         ]
         assert extract_visible_assistant_text(chunks) == "first\nsecond"
+
+
+# ---------------------------------------------------------------------------
+# Liveness / "still working" progress signals (tool_use_started, hook events,
+# compaction). These let a UI show activity in the gaps between text.
+# ---------------------------------------------------------------------------
+
+
+async def _collect_response_events(source):
+    import logging
+    from src.streaming_utils import stream_response_chunks
+
+    events = []
+    stream_result: dict = {}
+    async for line in stream_response_chunks(
+        source,
+        model="m",
+        response_id="resp_1",
+        output_item_id="msg_1",
+        chunks_buffer=[],
+        logger=logging.getLogger("test"),
+        stream_result=stream_result,
+    ):
+        events.append(_parse_response_sse(line))
+    return events, stream_result
+
+
+async def test_stream_emits_tool_use_started_before_full_tool_use():
+    """`response.tool_use_started` fires at content_block_start, before the
+    accumulated `response.tool_use` with the full arguments."""
+
+    async def chunk_source():
+        yield {"type": "stream_event", "event": {
+            "type": "content_block_start", "index": 0,
+            "content_block": {"type": "tool_use", "id": "tu_1", "name": "Bash"},
+        }}
+        yield {"type": "stream_event", "event": {
+            "type": "content_block_delta", "index": 0,
+            "delta": {"type": "input_json_delta", "partial_json": '{"command":'},
+        }}
+        yield {"type": "stream_event", "event": {
+            "type": "content_block_delta", "index": 0,
+            "delta": {"type": "input_json_delta", "partial_json": '"ls"}'},
+        }}
+        yield {"type": "stream_event", "event": {"type": "content_block_stop", "index": 0}}
+        yield {"subtype": "success", "result": "done"}
+
+    events, _ = await _collect_response_events(chunk_source())
+    types = [t for t, _ in events]
+
+    assert "response.tool_use_started" in types, "no tool_use_started signal emitted"
+    started_idx = types.index("response.tool_use_started")
+    full_idx = types.index("response.tool_use")
+    assert started_idx < full_idx, "started must precede the completed tool_use"
+
+    started = events[started_idx][1]
+    assert started["tool_use_id"] == "tu_1"
+    assert started["name"] == "Bash"
+    # No arguments yet on the started signal.
+    assert "input" not in started
+
+    # The completed tool_use carries the assembled arguments.
+    full = events[full_idx][1]
+    assert full["tool_use_id"] == "tu_1"
+    assert full["input"] == {"command": "ls"}
+
+
+async def test_stream_tool_use_started_disabled_by_flag(monkeypatch):
+    monkeypatch.setattr("src.streaming_utils.STREAM_TOOL_PROGRESS", False)
+
+    async def chunk_source():
+        yield {"type": "stream_event", "event": {
+            "type": "content_block_start", "index": 0,
+            "content_block": {"type": "tool_use", "id": "tu_1", "name": "Bash"},
+        }}
+        yield {"type": "stream_event", "event": {
+            "type": "content_block_delta", "index": 0,
+            "delta": {"type": "input_json_delta", "partial_json": "{}"},
+        }}
+        yield {"type": "stream_event", "event": {"type": "content_block_stop", "index": 0}}
+        yield {"subtype": "success", "result": "done"}
+
+    events, _ = await _collect_response_events(chunk_source())
+    types = [t for t, _ in events]
+    assert "response.tool_use_started" not in types
+    # The completed tool_use still flows.
+    assert "response.tool_use" in types
+
+
+async def test_stream_forwards_hook_lifecycle_events():
+    """hook_started/hook_response system messages become response.hook_event."""
+
+    async def chunk_source():
+        yield {
+            "type": "system", "subtype": "hook_started", "hook_event_name": "PreToolUse",
+            "data": {"hook_event": "PreToolUse", "tool_name": "Bash", "tool_use_id": "tu_9"},
+            "session_id": "s1",
+        }
+        yield {
+            "type": "system", "subtype": "hook_response", "hook_event_name": "PostToolUse",
+            "data": {
+                "hook_event": "PostToolUse", "tool_name": "Bash",
+                "tool_use_id": "tu_9", "outcome": "success",
+            },
+            "session_id": "s1",
+        }
+        yield {"type": "stream_event", "event": {
+            "type": "content_block_delta",
+            "delta": {"type": "text_delta", "text": "ok"},
+        }}
+
+    events, _ = await _collect_response_events(chunk_source())
+    hook_events = [p for t, p in events if t == "response.hook_event"]
+    assert len(hook_events) == 2
+
+    assert hook_events[0]["phase"] == "hook_started"
+    assert hook_events[0]["hook_event_name"] == "PreToolUse"
+    assert hook_events[0]["tool_name"] == "Bash"
+    assert hook_events[0]["tool_use_id"] == "tu_9"
+
+    assert hook_events[1]["phase"] == "hook_response"
+    assert hook_events[1]["hook_event_name"] == "PostToolUse"
+    assert hook_events[1]["outcome"] == "success"
+
+    # Normal content still flows after the hook events.
+    deltas = [p.get("delta") for t, p in events if t == "response.output_text.delta"]
+    assert "ok" in deltas
+
+
+async def test_stream_hook_events_disabled_by_flag(monkeypatch):
+    monkeypatch.setattr("src.sse_builders.STREAM_HOOK_EVENTS", False)
+
+    async def chunk_source():
+        yield {
+            "type": "system", "subtype": "hook_started", "hook_event_name": "PreToolUse",
+            "data": {"hook_event": "PreToolUse", "tool_name": "Bash"},
+        }
+        yield {"type": "stream_event", "event": {
+            "type": "content_block_delta",
+            "delta": {"type": "text_delta", "text": "ok"},
+        }}
+
+    events, _ = await _collect_response_events(chunk_source())
+    assert not any(t == "response.hook_event" for t, _ in events)
+
+
+async def test_stream_forwards_compaction_event():
+    """compact_boundary system messages become response.compaction."""
+
+    async def chunk_source():
+        yield {
+            "type": "system", "subtype": "compact_boundary",
+            "data": {"trigger": "auto"}, "session_id": "s1",
+        }
+        yield {"type": "stream_event", "event": {
+            "type": "content_block_delta",
+            "delta": {"type": "text_delta", "text": "ok"},
+        }}
+
+    events, _ = await _collect_response_events(chunk_source())
+    compaction = [p for t, p in events if t == "response.compaction"]
+    assert len(compaction) == 1
+    assert compaction[0]["subtype"] == "compact_boundary"
+    assert compaction[0]["trigger"] == "auto"


### PR DESCRIPTION
## Why

Audited whether every Claude Agent SDK event reaches the `/v1/responses` client. Two findings drove this PR:

1. **`think → text → think` dropped the 2nd thinking block.** A reasoning output item could only open *before* the message item started, so any thinking that arrived after text was silently discarded (never streamed, absent from the final `output`).
2. **The stream goes silent between visible text.** During long tool-call generation, hook runs, and context compaction, the only thing flowing was the SSE keepalive comment — the client had no way to show "still working".

## What changed

### 1. Interleaved reasoning (think → text → think → text)
The OpenAI Responses `output` array is an *ordered sequence*, so a new thinking block now **closes the current message item and opens its own reasoning item**, then the trailing text opens a fresh message item. Live token streaming is preserved (no end-of-stream buffering). `stream_result["assistant_text"]` accumulates across all message segments, so session history stays complete.

A client that concatenates all `message` output items' text reconstructs the full answer.

### 2. Liveness / "still working" events
Forward signals the gateway previously ignored:

| Event | When | Flag (default) |
|-------|------|----------------|
| `response.tool_use_started` | at a tool call's `content_block_start`, before arguments finish streaming | `STREAM_TOOL_PROGRESS` (on) |
| `response.hook_event` | SDK hook lifecycle (PreToolUse/PostToolUse/Stop/…) | `STREAM_HOOK_EVENTS` (on) |
| `response.compaction` | context compaction (`compact_boundary`) | `STREAM_COMPACTION_EVENTS` (on) |

- `STREAM_HOOK_EVENTS` enables the SDK's `include_hook_events`. This is **additive** — it does not change hook *callback* behaviour (the AskUserQuestion PreToolUse hook still parks exactly as before).
- Subagent-originated liveness events honour the existing subagent gates (`SUBAGENT_STREAM_TOOL_BLOCKS` / `SUBAGENT_STREAM_PROGRESS`).
- The bundled admin chat UI renders each as a transient status line ("준비 중…", hook running/done, "컨텍스트 압축 중…").

All new events are advisory — clients may ignore any type they don't recognize.

## Out of scope (intentionally not forwarded)
- `system` `init` payload — carries internal config (cwd, tools, mcp servers); forwarding it raw would be inconsistent with the gateway's redaction posture.

## Tests
- New unit tests: interleaved think→text→think (4 items, ordered, full text preserved), `tool_use_started` ordering + flag gate, `hook_event` lifecycle + flag gate, `compaction`, and `include_hook_events` default on/off.
- Full suite: **1693 passed, 2 skipped** (env-gated live tests). No failures.

## Docs
- `docs/streaming-events.md`: event-order diagram, new event schemas, env-var tables, interleaved-reasoning note.
- `.env.example`: new `STREAM_*` flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)