### PR TITLE
feat(claude): enforce per-user workspace boundary via PreToolUse hook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -303,6 +303,17 @@ DEFAULT_MODEL=sonnet
 # Enable weaker sandbox for unprivileged Docker containers on Linux (default: false)
 # CLAUDE_SANDBOX_WEAKER_NESTED=false
 
+# Per-workspace sandbox (PreToolUse hook confining file/Bash paths to the
+# session workspace root). Defends against cross-user access under the shared
+# workspace root that cwd/acceptEdits do not enforce. Default: disabled.
+# When enabled and CLAUDE_SANDBOX_ENABLED is unset, the OS-level bash sandbox
+# above is force-enabled as a defense-in-depth backstop for runtime shell
+# expansions ($VAR, command substitution) the hook cannot resolve statically.
+# WORKSPACE_SANDBOX_ENABLED=true
+# Categories permitted to reach paths OUTSIDE the workspace (comma-separated:
+# read / write / bash). Empty = confine everything. Default: empty.
+# WORKSPACE_SANDBOX_ALLOW_OUTSIDE=
+
 # SSE keepalive interval in seconds (prevents connection drops during long SDK operations)
 # Set to 0 to disable. Default: 15
 # SSE_KEEPALIVE_INTERVAL=15

--- a/src/backends/claude/client.py
+++ b/src/backends/claude/client.py
@@ -225,14 +225,22 @@ class ClaudeCodeCLI(TokenEstimateMixin):
 
         * ``None`` (env unset) — do **not** set ``options.sandbox`` at all,
           allowing project-level settings (``setting_sources=["project"]``)
-          to take effect.
+          to take effect. As a defense-in-depth backstop, if the per-workspace
+          sandbox is enabled (``WORKSPACE_SANDBOX_ENABLED``) the OS-level bash
+          sandbox is force-enabled here so runtime shell expansions the
+          PreToolUse hook cannot resolve statically are still confined.
         * ``True`` — force-enable sandbox with env-configured parameters.
-        * ``False`` — force-disable sandbox explicitly.
+        * ``False`` — force-disable sandbox explicitly (honored even when the
+          workspace sandbox is on).
         """
-        if CLAUDE_SANDBOX_ENABLED is None:
+        effective_enabled = CLAUDE_SANDBOX_ENABLED
+        if effective_enabled is None and sandbox_enabled():
+            effective_enabled = True
+
+        if effective_enabled is None:
             return  # Respect project-level settings
 
-        if not CLAUDE_SANDBOX_ENABLED:
+        if not effective_enabled:
             options.sandbox = SandboxSettings(enabled=False)
             return
 

--- a/src/backends/claude/client.py
+++ b/src/backends/claude/client.py
@@ -50,6 +50,10 @@ from src.image_handler import ImageHandler
 from src.mcp_config import get_mcp_tool_patterns
 from src.response_models import PermissionMode
 from src.runtime_config import get_default_max_turns
+from src.backends.claude.workspace_sandbox import (
+    make_workspace_sandbox_hook,
+    sandbox_enabled,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -743,14 +747,20 @@ class ClaudeCodeCLI(TokenEstimateMixin):
             extra_env=extra_env,
             _custom_base=_custom_base,
         )
-        options.hooks = {
-            "PreToolUse": [
+        pre_tool_use = [
+            HookMatcher(
+                matcher="AskUserQuestion",
+                hooks=[self._make_ask_user_hook(session)],
+            )
+        ]
+        if cwd and sandbox_enabled():
+            pre_tool_use.append(
                 HookMatcher(
-                    matcher="AskUserQuestion",
-                    hooks=[self._make_ask_user_hook(session)],
+                    matcher="",
+                    hooks=[make_workspace_sandbox_hook(Path(cwd))],
                 )
-            ]
-        }
+            )
+        options.hooks = {"PreToolUse": pre_tool_use}
 
         with self._sdk_env():
             client = ClaudeSDKClient(options=options)

--- a/src/backends/claude/workspace_sandbox.py
+++ b/src/backends/claude/workspace_sandbox.py
@@ -99,23 +99,60 @@ def _deny(reason: str) -> Dict[str, Any]:
     }
 
 
-_ABS_PATH_RE = re.compile(r"(?:^|[\s=:'\"`(])(/[\w./\-+@]+)")
+# Matches path-like substrings beginning with ``/`` (absolute), ``./`` or
+# ``../`` (relative traversal) or ``~`` (home). Used as a fallback for shell
+# constructs ``shlex`` cannot tokenize cleanly (here-docs, ``$(...)``).
+_PATH_RE = re.compile(r"(?:^|[\s=:'\"`(])((?:/|\.\.?/|~/?)[\w./\-+@]*)")
 
 
-def _check_bash(command: str, root: Path) -> Optional[str]:
-    """Return a deny reason if *command* references paths outside *root*."""
-    if not command:
-        return None
-    # shlex catches quoted arguments; fall back to regex for shell constructs
-    # (here-docs, $(...)) that shlex can't tokenize cleanly.
+def _is_path_like(token: str) -> bool:
+    """Whether *token* looks like a filesystem path worth boundary-checking.
+
+    Covers absolute paths, any token containing a separator, bare parent refs
+    (``..``) and home refs (``~``/``~user``). Inside-workspace relative paths
+    also match but resolve within *root*, so checking them is harmless.
+    """
+    return bool(token) and ("/" in token or token == ".." or token.startswith("~"))
+
+
+def _expand_user(path: str) -> str:
+    """Expand a leading ``~`` so home-relative escapes are resolved statically."""
+    return os.path.expanduser(path) if path.startswith("~") else path
+
+
+def _bash_path_candidates(command: str) -> list[str]:
+    """Extract path-like substrings from a Bash *command*.
+
+    ``shlex`` handles quoting and ``--flag=value`` / ``VAR=value`` forms (the
+    value after ``=`` is inspected separately so an escape hidden in a flag is
+    not masked by the flag name). A regex pass over the raw command is layered
+    on top for shell constructs ``shlex`` cannot split cleanly.
+    """
+    candidates: list[str] = []
     try:
         tokens = shlex.split(command, posix=True)
     except ValueError:
         tokens = []
-    candidates = [t for t in tokens if t.startswith("/")]
-    candidates.extend(m.group(1) for m in _ABS_PATH_RE.finditer(command))
-    for path in candidates:
-        if _resolve_within(root, path) is None:
+    for tok in tokens:
+        parts = (tok, tok.split("=", 1)[1]) if "=" in tok else (tok,)
+        candidates.extend(p for p in parts if _is_path_like(p))
+    candidates.extend(m.group(1) for m in _PATH_RE.finditer(command))
+    return candidates
+
+
+def _check_bash(command: str, root: Path) -> Optional[str]:
+    """Return a deny reason if *command* references paths outside *root*.
+
+    Catches absolute paths, ``..`` traversal and ``~`` references — including
+    relative symlink targets such as ``ln -s ../../secret link``. Only
+    statically visible paths are inspected: runtime shell expansions (``$VAR``,
+    command substitution output) cannot be resolved here and are deferred to the
+    OS-level sandbox (``CLAUDE_SANDBOX_ENABLED``).
+    """
+    if not command:
+        return None
+    for path in _bash_path_candidates(command):
+        if _resolve_within(root, _expand_user(path)) is None:
             return (
                 f"Workspace sandbox: Bash referenced path outside workspace "
                 f"({path}). Allowed root: {root}."

--- a/src/backends/claude/workspace_sandbox.py
+++ b/src/backends/claude/workspace_sandbox.py
@@ -1,0 +1,166 @@
+"""PreToolUse hook enforcing per-user workspace boundaries.
+
+Claude Code's ``cwd`` option sets a starting directory but does not constrain
+file operations to it (see anthropic/claude-agent-sdk-python issues #36/#457).
+``acceptEdits`` mode is documented to restrict edits to ``cwd`` +
+``additionalDirectories`` but the current SDK does not enforce that boundary,
+and ``bypassPermissions`` bypasses the check entirely. As a result, absolute
+paths in Read/Write/Edit/Bash calls reach other users' workspaces under the
+shared root.
+
+This hook closes that gap by rejecting any PreToolUse call whose resolved path
+escapes the session's workspace root.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import shlex
+from pathlib import Path
+from typing import Any, Dict, Optional, Set
+
+logger = logging.getLogger(__name__)
+
+
+# Tool → (category, path-key, is_optional)
+# Category groups several tools so users can release a whole class at once via
+# WORKSPACE_SANDBOX_ALLOW_OUTSIDE.
+_TOOL_TABLE: Dict[str, tuple[str, str, bool]] = {
+    "Read": ("read", "file_path", False),
+    "Write": ("write", "file_path", False),
+    "Edit": ("write", "file_path", False),
+    "MultiEdit": ("write", "file_path", False),
+    "NotebookEdit": ("write", "notebook_path", False),
+    "Glob": ("read", "path", True),
+    "Grep": ("read", "path", True),
+}
+_VALID_CATEGORIES = {"read", "write", "bash"}
+
+
+def _env_flag(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def sandbox_enabled() -> bool:
+    return _env_flag("WORKSPACE_SANDBOX_ENABLED", True)
+
+
+def _allow_outside() -> Set[str]:
+    """Categories permitted to reach paths outside the workspace.
+
+    ``WORKSPACE_SANDBOX_ALLOW_OUTSIDE`` is a comma-separated list of
+    ``read`` / ``write`` / ``bash``. Unknown entries are ignored with a warning.
+    """
+    raw = os.getenv("WORKSPACE_SANDBOX_ALLOW_OUTSIDE", "")
+    if not raw.strip():
+        return set()
+    entries = {part.strip().lower() for part in raw.split(",") if part.strip()}
+    invalid = entries - _VALID_CATEGORIES
+    if invalid:
+        logger.warning(
+            "Ignoring unknown WORKSPACE_SANDBOX_ALLOW_OUTSIDE entries: %s",
+            sorted(invalid),
+        )
+    return entries & _VALID_CATEGORIES
+
+
+def _resolve_within(root: Path, candidate: str) -> Optional[Path]:
+    """Return the resolved path if it lies inside *root*, else ``None``.
+
+    Relative paths are resolved against *root* (Claude's cwd). ``resolve()``
+    collapses ``..`` and symlinks so escape attempts via either are caught.
+    """
+    try:
+        p = Path(candidate)
+        if not p.is_absolute():
+            p = root / p
+        resolved = p.resolve()
+    except (OSError, RuntimeError, ValueError):
+        return None
+    try:
+        resolved.relative_to(root)
+    except ValueError:
+        return None
+    return resolved
+
+
+def _deny(reason: str) -> Dict[str, Any]:
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }
+
+
+_ABS_PATH_RE = re.compile(r"(?:^|[\s=:'\"`(])(/[\w./\-+@]+)")
+
+
+def _check_bash(command: str, root: Path) -> Optional[str]:
+    """Return a deny reason if *command* references paths outside *root*."""
+    if not command:
+        return None
+    # shlex catches quoted arguments; fall back to regex for shell constructs
+    # (here-docs, $(...)) that shlex can't tokenize cleanly.
+    try:
+        tokens = shlex.split(command, posix=True)
+    except ValueError:
+        tokens = []
+    candidates = [t for t in tokens if t.startswith("/")]
+    candidates.extend(m.group(1) for m in _ABS_PATH_RE.finditer(command))
+    for path in candidates:
+        if _resolve_within(root, path) is None:
+            return (
+                f"Workspace sandbox: Bash referenced path outside workspace "
+                f"({path}). Allowed root: {root}."
+            )
+    return None
+
+
+def make_workspace_sandbox_hook(workspace_root: Path):
+    """Build a PreToolUse hook that confines tool calls to *workspace_root*.
+
+    The returned callable matches the signature expected by
+    :class:`claude_agent_sdk.types.HookMatcher`. It returns an empty dict to
+    let the call proceed, or a ``deny`` decision to block it.
+    """
+    root = Path(workspace_root).resolve()
+    allowed = _allow_outside()
+
+    async def hook(input_data, _tool_use_id, _context):
+        if not isinstance(input_data, dict):
+            return {}
+        tool_name = input_data.get("tool_name", "")
+        tool_input = input_data.get("tool_input", {}) or {}
+
+        if tool_name in _TOOL_TABLE:
+            category, key, _optional = _TOOL_TABLE[tool_name]
+            if category in allowed:
+                return {}
+            path = tool_input.get(key)
+            if isinstance(path, str) and path:
+                if _resolve_within(root, path) is None:
+                    return _deny(
+                        f"Workspace sandbox: {tool_name} target {path!r} is "
+                        f"outside the session workspace ({root})."
+                    )
+            return {}
+
+        if tool_name == "Bash":
+            if "bash" in allowed:
+                return {}
+            command = tool_input.get("command", "")
+            reason = _check_bash(command, root) if isinstance(command, str) else None
+            if reason:
+                return _deny(reason)
+            return {}
+
+        return {}
+
+    return hook

--- a/src/backends/claude/workspace_sandbox.py
+++ b/src/backends/claude/workspace_sandbox.py
@@ -47,7 +47,7 @@ def _env_flag(name: str, default: bool) -> bool:
 
 
 def sandbox_enabled() -> bool:
-    return _env_flag("WORKSPACE_SANDBOX_ENABLED", True)
+    return _env_flag("WORKSPACE_SANDBOX_ENABLED", False)
 
 
 def _allow_outside() -> Set[str]:

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -5,6 +5,7 @@ import contextlib
 import inspect
 import json
 import logging
+import os
 import secrets
 import uuid
 from pathlib import Path
@@ -41,7 +42,7 @@ from src.response_models import (
 )
 from src.rate_limiter import rate_limit_endpoint
 from src.chunk_processing import classify_error_chunk
-from src.constants import DEFAULT_TIMEOUT_MS, PERMISSION_MODE_BYPASS
+from src.constants import DEFAULT_TIMEOUT_MS
 from src.mcp_config import get_mcp_servers
 from src import streaming_utils
 from src.usage_logger import usage_logger
@@ -822,7 +823,7 @@ async def _ensure_response_session_client(
             session=session,
             model=resolved.provider_model,
             system_prompt=system_prompt if is_new_session else None,
-            permission_mode=body.permission_mode or PERMISSION_MODE_BYPASS,
+            permission_mode=body.permission_mode or os.getenv("PERMISSION_MODE") or None,
             allowed_tools=body.allowed_tools,
             disallowed_tools=body.disallowed_tools,
             mcp_servers=(get_mcp_servers() if resolved.backend in {"claude", "codex"} else None),

--- a/tests/test_claude_cli_unit.py
+++ b/tests/test_claude_cli_unit.py
@@ -1071,8 +1071,43 @@ class TestConfigureHelpers:
 
         opts = ClaudeAgentOptions(max_turns=1, cwd=cli_instance.cwd)
         with patch("src.backends.claude.client.CLAUDE_SANDBOX_ENABLED", None):
-            cli_instance._configure_sandbox(opts)
+            with patch("src.backends.claude.client.sandbox_enabled", return_value=False):
+                cli_instance._configure_sandbox(opts)
         assert getattr(opts, "sandbox", None) is None
+
+    def test_configure_sandbox_unset_enabled_by_workspace(self, cli_instance):
+        """Workspace sandbox force-enables the OS sandbox when env is unset."""
+        from claude_agent_sdk import ClaudeAgentOptions
+
+        opts = ClaudeAgentOptions(max_turns=1, cwd=cli_instance.cwd)
+        with patch("src.backends.claude.client.CLAUDE_SANDBOX_ENABLED", None):
+            with patch("src.backends.claude.client.sandbox_enabled", return_value=True):
+                with patch("src.backends.claude.client.CLAUDE_SANDBOX_AUTO_ALLOW_BASH", True):
+                    with patch("src.backends.claude.client.CLAUDE_SANDBOX_EXCLUDED_COMMANDS", []):
+                        with patch(
+                            "src.backends.claude.client.CLAUDE_SANDBOX_ALLOW_UNSANDBOXED", False
+                        ):
+                            with patch(
+                                "src.backends.claude.client.CLAUDE_SANDBOX_NETWORK_ALLOW_LOCAL",
+                                False,
+                            ):
+                                with patch(
+                                    "src.backends.claude.client.CLAUDE_SANDBOX_WEAKER_NESTED", False
+                                ):
+                                    cli_instance._configure_sandbox(opts)
+        assert opts.sandbox is not None
+        assert opts.sandbox["enabled"] is True
+
+    def test_configure_sandbox_explicit_false_overrides_workspace(self, cli_instance):
+        """Explicit CLAUDE_SANDBOX_ENABLED=False wins over workspace sandbox."""
+        from claude_agent_sdk import ClaudeAgentOptions
+
+        opts = ClaudeAgentOptions(max_turns=1, cwd=cli_instance.cwd)
+        with patch("src.backends.claude.client.CLAUDE_SANDBOX_ENABLED", False):
+            with patch("src.backends.claude.client.sandbox_enabled", return_value=True):
+                cli_instance._configure_sandbox(opts)
+        assert opts.sandbox is not None
+        assert opts.sandbox["enabled"] is False
 
     def test_build_sdk_options_includes_sandbox(self, cli_instance):
         """_build_sdk_options calls _configure_sandbox."""

--- a/tests/test_workspace_sandbox.py
+++ b/tests/test_workspace_sandbox.py
@@ -145,6 +145,38 @@ class TestBash:
         )
         assert result == {}
 
+    async def test_relative_traversal_denied(self, workspace):
+        hook = make_workspace_sandbox_hook(workspace)
+        result = await _call(hook, "Bash", {"command": "cat ../../etc/passwd"})
+        assert _is_deny(result)
+
+    async def test_relative_inside_subdir_allowed(self, workspace):
+        (workspace / "logs").mkdir()
+        hook = make_workspace_sandbox_hook(workspace)
+        result = await _call(hook, "Bash", {"command": "cat logs/app.log"})
+        assert result == {}
+
+    async def test_relative_symlink_target_denied(self, workspace):
+        # ``ln -s`` with a relative target escapes via the parent traversal in
+        # the link target argument, even though no token starts with ``/``.
+        hook = make_workspace_sandbox_hook(workspace)
+        result = await _call(
+            hook, "Bash", {"command": "ln -s ../../etc/passwd shortcut"}
+        )
+        assert _is_deny(result)
+
+    async def test_home_reference_denied(self, workspace):
+        hook = make_workspace_sandbox_hook(workspace)
+        result = await _call(hook, "Bash", {"command": "cat ~/.ssh/id_rsa"})
+        assert _is_deny(result)
+
+    async def test_flag_value_traversal_denied(self, workspace):
+        hook = make_workspace_sandbox_hook(workspace)
+        result = await _call(
+            hook, "Bash", {"command": "tar --file=../../escape.tar ."}
+        )
+        assert _is_deny(result)
+
 
 class TestAllowOutside:
     async def test_read_category_releases_read_glob_grep(

--- a/tests/test_workspace_sandbox.py
+++ b/tests/test_workspace_sandbox.py
@@ -41,9 +41,9 @@ def _is_deny(result: dict) -> bool:
 
 
 class TestEnabledFlag:
-    def test_default_enabled(self, monkeypatch):
+    def test_default_disabled(self, monkeypatch):
         monkeypatch.delenv("WORKSPACE_SANDBOX_ENABLED", raising=False)
-        assert sandbox_enabled() is True
+        assert sandbox_enabled() is False
 
     @pytest.mark.parametrize("value", ["false", "0", "no", "off", "FALSE"])
     def test_explicit_disable(self, monkeypatch, value):

--- a/tests/test_workspace_sandbox.py
+++ b/tests/test_workspace_sandbox.py
@@ -1,0 +1,220 @@
+"""Tests for the per-workspace PreToolUse sandbox hook."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.backends.claude.workspace_sandbox import (
+    make_workspace_sandbox_hook,
+    sandbox_enabled,
+)
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    ws = tmp_path / "kyvhyvn.shim" / "claude"
+    ws.mkdir(parents=True)
+    (ws / "CLAUDE.md").write_text("mine")
+    other = tmp_path / "Perturabo" / "claude"
+    other.mkdir(parents=True)
+    (other / "CLAUDE.md").write_text("not yours")
+    return ws
+
+
+@pytest.fixture
+def other_workspace(tmp_path: Path) -> Path:
+    return tmp_path / "Perturabo" / "claude"
+
+
+async def _call(hook, tool_name: str, tool_input: dict) -> dict:
+    return await hook(
+        {"tool_name": tool_name, "tool_input": tool_input},
+        "tool-use-id",
+        None,
+    )
+
+
+def _is_deny(result: dict) -> bool:
+    return result.get("hookSpecificOutput", {}).get("permissionDecision") == "deny"
+
+
+class TestEnabledFlag:
+    def test_default_enabled(self, monkeypatch):
+        monkeypatch.delenv("WORKSPACE_SANDBOX_ENABLED", raising=False)
+        assert sandbox_enabled() is True
+
+    @pytest.mark.parametrize("value", ["false", "0", "no", "off", "FALSE"])
+    def test_explicit_disable(self, monkeypatch, value):
+        monkeypatch.setenv("WORKSPACE_SANDBOX_ENABLED", value)
+        assert sandbox_enabled() is False
+
+    @pytest.mark.parametrize("value", ["true", "1", "yes", "on"])
+    def test_explicit_enable(self, monkeypatch, value):
+        monkeypatch.setenv("WORKSPACE_SANDBOX_ENABLED", value)
+        assert sandbox_enabled() is True
+
+
+class TestFilePathTools:
+    @pytest.mark.parametrize("tool", ["Read", "Write", "Edit", "MultiEdit"])
+    async def test_inside_workspace_allowed(self, workspace, tool):
+        hook = make_workspace_sandbox_hook(workspace)
+        result = await _call(hook, tool, {"file_path": str(workspace / "CLAUDE.md")})
+        assert result == {}
+
+    @pytest.mark.parametrize("tool", ["Read", "Write", "Edit", "MultiEdit"])
+    async def test_other_workspace_denied(self, workspace, other_workspace, tool):
+        hook = make_workspace_sandbox_hook(workspace)
+        result = await _call(
+            hook, tool, {"file_path": str(other_workspace / "CLAUDE.md")}
+        )
+        assert _is_deny(result)
+
+    async def test_notebook_path(self, workspace, other_workspace):
+        hook = make_workspace_sandbox_hook(workspace)
+        good = await _call(hook, "NotebookEdit", {"notebook_path": str(workspace / "n.ipynb")})
+        assert good == {}
+        bad = await _call(
+            hook, "NotebookEdit", {"notebook_path": str(other_workspace / "n.ipynb")}
+        )
+        assert _is_deny(bad)
+
+    async def test_relative_path_resolved_against_workspace(self, workspace):
+        hook = make_workspace_sandbox_hook(workspace)
+        # Plain filename → workspace-relative, allowed.
+        ok = await _call(hook, "Read", {"file_path": "CLAUDE.md"})
+        assert ok == {}
+        # ../../etc — escapes via parent traversal.
+        bad = await _call(hook, "Read", {"file_path": "../../etc/passwd"})
+        assert _is_deny(bad)
+
+    async def test_symlink_escape_blocked(self, workspace, tmp_path):
+        secret = tmp_path / "secret.txt"
+        secret.write_text("nope")
+        link = workspace / "shortcut"
+        link.symlink_to(secret)
+        hook = make_workspace_sandbox_hook(workspace)
+        result = await _call(hook, "Read", {"file_path": str(link)})
+        assert _is_deny(result)
+
+
+class TestOptionalPathTools:
+    async def test_glob_no_path_allowed(self, workspace):
+        hook = make_workspace_sandbox_hook(workspace)
+        assert await _call(hook, "Glob", {"pattern": "**/*.py"}) == {}
+
+    async def test_glob_outside_denied(self, workspace, other_workspace):
+        hook = make_workspace_sandbox_hook(workspace)
+        result = await _call(hook, "Glob", {"path": str(other_workspace), "pattern": "*"})
+        assert _is_deny(result)
+
+    async def test_grep_outside_denied(self, workspace, other_workspace):
+        hook = make_workspace_sandbox_hook(workspace)
+        result = await _call(hook, "Grep", {"path": str(other_workspace), "pattern": "x"})
+        assert _is_deny(result)
+
+
+class TestBash:
+    async def test_inside_workspace_command_allowed(self, workspace):
+        hook = make_workspace_sandbox_hook(workspace)
+        assert await _call(hook, "Bash", {"command": "ls"}) == {}
+
+    async def test_absolute_outside_path_in_command_denied(self, workspace, other_workspace):
+        hook = make_workspace_sandbox_hook(workspace)
+        result = await _call(
+            hook,
+            "Bash",
+            {"command": f"cat {other_workspace}/CLAUDE.md"},
+        )
+        assert _is_deny(result)
+
+    async def test_quoted_outside_path_denied(self, workspace, other_workspace):
+        hook = make_workspace_sandbox_hook(workspace)
+        result = await _call(
+            hook,
+            "Bash",
+            {"command": f"cat '{other_workspace}/CLAUDE.md'"},
+        )
+        assert _is_deny(result)
+
+    async def test_absolute_inside_workspace_allowed(self, workspace):
+        hook = make_workspace_sandbox_hook(workspace)
+        result = await _call(
+            hook, "Bash", {"command": f"cat {workspace}/CLAUDE.md"}
+        )
+        assert result == {}
+
+
+class TestAllowOutside:
+    async def test_read_category_releases_read_glob_grep(
+        self, monkeypatch, workspace, other_workspace
+    ):
+        monkeypatch.setenv("WORKSPACE_SANDBOX_ALLOW_OUTSIDE", "read")
+        hook = make_workspace_sandbox_hook(workspace)
+        for tool, key in (("Read", "file_path"), ("Glob", "path"), ("Grep", "path")):
+            args = {key: str(other_workspace / "CLAUDE.md")} if tool == "Read" else {
+                key: str(other_workspace), "pattern": "*"
+            }
+            assert await _call(hook, tool, args) == {}
+        bad = await _call(
+            hook, "Write", {"file_path": str(other_workspace / "CLAUDE.md")}
+        )
+        assert _is_deny(bad)
+
+    async def test_write_category_releases_writes_only(
+        self, monkeypatch, workspace, other_workspace
+    ):
+        monkeypatch.setenv("WORKSPACE_SANDBOX_ALLOW_OUTSIDE", "write")
+        hook = make_workspace_sandbox_hook(workspace)
+        for tool in ("Write", "Edit", "MultiEdit"):
+            assert await _call(
+                hook, tool, {"file_path": str(other_workspace / "CLAUDE.md")}
+            ) == {}
+        bad = await _call(
+            hook, "Read", {"file_path": str(other_workspace / "CLAUDE.md")}
+        )
+        assert _is_deny(bad)
+
+    async def test_bash_category_releases_bash(
+        self, monkeypatch, workspace, other_workspace
+    ):
+        monkeypatch.setenv("WORKSPACE_SANDBOX_ALLOW_OUTSIDE", "bash")
+        hook = make_workspace_sandbox_hook(workspace)
+        result = await _call(
+            hook, "Bash", {"command": f"cat {other_workspace}/CLAUDE.md"}
+        )
+        assert result == {}
+
+    async def test_multiple_categories(
+        self, monkeypatch, workspace, other_workspace
+    ):
+        monkeypatch.setenv("WORKSPACE_SANDBOX_ALLOW_OUTSIDE", "read, bash")
+        hook = make_workspace_sandbox_hook(workspace)
+        assert await _call(
+            hook, "Read", {"file_path": str(other_workspace / "CLAUDE.md")}
+        ) == {}
+        assert await _call(
+            hook, "Bash", {"command": f"cat {other_workspace}/CLAUDE.md"}
+        ) == {}
+        bad = await _call(
+            hook, "Write", {"file_path": str(other_workspace / "CLAUDE.md")}
+        )
+        assert _is_deny(bad)
+
+    async def test_unknown_category_ignored(self, monkeypatch, workspace, other_workspace):
+        monkeypatch.setenv("WORKSPACE_SANDBOX_ALLOW_OUTSIDE", "nope,read")
+        hook = make_workspace_sandbox_hook(workspace)
+        assert await _call(
+            hook, "Read", {"file_path": str(other_workspace / "CLAUDE.md")}
+        ) == {}
+
+
+class TestUnknownTool:
+    async def test_unknown_tool_passes_through(self, workspace):
+        hook = make_workspace_sandbox_hook(workspace)
+        assert await _call(hook, "Task", {"prompt": "do stuff"}) == {}
+
+    async def test_mcp_tools_pass_through(self, workspace):
+        hook = make_workspace_sandbox_hook(workspace)
+        assert await _call(hook, "mcp__server__fetch", {"url": "..."}) == {}


### PR DESCRIPTION
## What

Adds best-effort per-user workspace isolation for the Claude backend, freshly branched from `main` with only the core feature (no unrelated commits).

The Claude Agent SDK's `cwd` sets a starting directory but does not confine file operations to it (anthropic/claude-agent-sdk-python #36/#457), and `bypassPermissions` skips the permission check entirely. As a result absolute paths in `Read`/`Write`/`Edit`/`Bash` could reach other users' workspaces under the shared root. This PR closes that gap with a `PreToolUse` hook.

## Changes

- **`src/backends/claude/workspace_sandbox.py`** (new) — `PreToolUse` hook that rejects tool calls whose resolved path escapes the session workspace root.
  - Structured tools (`Read`/`Write`/`Edit`/`MultiEdit`/`NotebookEdit`/`Glob`/`Grep`): resolve the path arg with `resolve()` (collapses `..` and symlinks) and check `relative_to(root)`.
  - `Bash`: extract path-like tokens via `shlex` + a regex fallback and check each; statically-invisible runtime expansions (`$VAR`, `$(...)`) are deferred to the OS-level bash sandbox.
- **`stop hardcoding bypassPermissions`** — honor `settings.json` instead of forcing `bypassPermissions`.
- **`client.py`** — wire the hook in; when `WORKSPACE_SANDBOX_ENABLED` is on and `CLAUDE_SANDBOX_ENABLED` is unset, force-enable the OS-level bash sandbox as a defense-in-depth backstop for runtime expansions the hook can't resolve statically.
- **`.env.example`** — document `WORKSPACE_SANDBOX_ENABLED` (default `false`) and `WORKSPACE_SANDBOX_ALLOW_OUTSIDE` (per-category `read`/`write`/`bash` escape hatch).
- **Tests** — `tests/test_workspace_sandbox.py` (new) + additions to `tests/test_claude_cli_unit.py`.

## Design notes

This is a **defense-in-depth layer**, not a hard security boundary. Structured-tool checks are robust; Bash static parsing is inherently best-effort and is backstopped by the OS-level bash sandbox. For mutually-untrusting multi-tenant deployments, OS-level isolation (per-user containers) is the appropriate primary control.

Disabled by default (`WORKSPACE_SANDBOX_ENABLED=false`) — opt-in.

## Testing

```
uv run pytest tests/test_workspace_sandbox.py tests/test_claude_cli_unit.py -q
# 141 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfyJ4PbC65N5oypkc9EUJL

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfyJ4PbC65N5oypkc9EUJL)_