### PR TITLE
fix(claude): workspace sandbox allows SDK's ~/.claude (#115) + slash-prefixed plain input passes through (#117)

### DIFF
--- a/src/backends/claude/slash_commands.py
+++ b/src/backends/claude/slash_commands.py
@@ -13,17 +13,24 @@ From an OpenAI-compatible API perspective, both outcomes are problematic:
 
 This module validates the prompt before it reaches the SDK:
 
+* Input that only *starts* with ``/`` but is not a command — file paths
+  (``/home/x``), URLs (``/api/v1/users``), a bare ``/`` — is **not** a slash
+  command. The SDK passes it to the model as a plain message, so the gateway
+  lets it through unchanged (issue #117). Only a command-name-shaped token
+  (alphanumeric/kebab, optional ``:namespace``) is treated as a command.
 * A small **blocklist** of destructive built-ins is always rejected with
   ``blocked_command``.
-* For other slash-prefixed prompts, the command name is checked against a
+* For other (command-shaped) slash prompts, the name is checked against a
   **TTL-cached allowlist** pulled from ``ClaudeSDKClient.get_server_info()``.
-  Unknown names are rejected with ``unknown_command``; recognised names are
-  allowed through so that intentional skills (e.g. ``/dev-server``) still work.
+  Unknown names are rejected with ``unknown_command`` (the SDK would otherwise
+  silently return ``"Unknown skill: <name>"`` with 0 tokens); recognised names
+  are allowed through so that intentional skills (e.g. ``/dev-server``) work.
 """
 
 from __future__ import annotations
 
 import asyncio
+import re
 import time
 from pathlib import Path
 from typing import Optional
@@ -32,6 +39,13 @@ from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient
 
 BLOCKED_COMMANDS: frozenset[str] = frozenset({"compact", "init", "heapdump"})
 CACHE_TTL_SECONDS: float = 60.0
+
+# A slash-command name is alphanumeric/kebab-case, optionally namespaced with
+# ``:`` (e.g. ``help``, ``dev-server``, ``superpowers:brainstorming``). Anything
+# else after a leading ``/`` — file paths (``/home/x``), URLs (``/api/v1/users``)
+# — is not a command name; the SDK passes such input to the model as a plain
+# message, so the gateway must not reject it. See issue #117.
+_COMMAND_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+(?::[A-Za-z0-9_-]+)*$")
 
 
 class SlashCommandError(Exception):
@@ -95,7 +109,12 @@ async def get_available_commands(
 
 
 def extract_command_name(prompt: str) -> Optional[str]:
-    """Return the command name (without the leading ``/``) or ``None``.
+    """Return the slash-command name (without the leading ``/``) or ``None``.
+
+    Returns ``None`` for anything that is not a slash command — including
+    slash-prefixed plain messages such as file paths (``/home/x``) and URLs
+    (``/api/v1/users``), a bare ``/``, or ``/ text``. Such input passes through
+    to the model unchanged, matching Claude Code (issue #117).
 
     The SDK itself strips leading whitespace before dispatching, so we do the
     same — ``"  /help"`` is equivalent to ``"/help"``.
@@ -105,13 +124,14 @@ def extract_command_name(prompt: str) -> Optional[str]:
         return None
     rest = stripped[1:]
     if not rest or rest[0].isspace():
-        # A lone "/" or "/ text" — the SDK returns a syntax error; treat as
-        # unknown so the caller sees a proper error response.
-        return ""
+        # A lone "/" or "/ text" is not a command name — plain message.
+        return None
     name = rest.split(None, 1)[0]
-    # Trim any trailing punctuation the user might have attached; the SDK
-    # only dispatches on the bare name.  Keep ``:`` because it's used in
-    # namespaced skills like ``superpowers:brainstorming``.
+    # Only a command-name-shaped token is a slash command. A token carrying a
+    # path separator or other punctuation (``home/ozymandias``, ``etc/passwd``)
+    # is a slash-prefixed plain message, not a command, so let it through.
+    if not _COMMAND_NAME_RE.match(name):
+        return None
     return name
 
 
@@ -123,12 +143,6 @@ async def validate_prompt(prompt: str, cwd: Optional[Path] = None) -> None:
     name = extract_command_name(prompt)
     if name is None:
         return
-
-    if name == "":
-        raise SlashCommandError(
-            code="unknown_command",
-            message="Slash-prefixed input without a command name is not supported.",
-        )
 
     if name in BLOCKED_COMMANDS:
         raise SlashCommandError(

--- a/src/backends/claude/slash_commands.py
+++ b/src/backends/claude/slash_commands.py
@@ -45,7 +45,13 @@ CACHE_TTL_SECONDS: float = 60.0
 # else after a leading ``/`` — file paths (``/home/x``), URLs (``/api/v1/users``)
 # — is not a command name; the SDK passes such input to the model as a plain
 # message, so the gateway must not reject it. See issue #117.
-_COMMAND_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+(?::[A-Za-z0-9_-]+)*$")
+#
+# The character class matches the CLI's own command-shape test
+# (``!/[^a-zA-Z0-9:\-_]/``): any token of these chars is command-shaped and, if
+# unregistered, the CLI returns ``"Unknown skill"`` with 0 tokens — so we keep
+# such tokens on the validated path (→ a clear 400) rather than letting them
+# through to that silent response.
+_COMMAND_NAME_RE = re.compile(r"^[A-Za-z0-9:_-]+$")
 
 
 class SlashCommandError(Exception):

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -25,11 +25,15 @@ def _reset_cache():
         ("/help", "help"),
         ("  /help  ", "help"),
         ("/compact foo bar", "compact"),
-        ("/api/v1/users", "api/v1/users"),
         ("/dev-server status", "dev-server"),
         ("/superpowers:brainstorming", "superpowers:brainstorming"),
-        ("/", ""),
-        ("/ tell me a joke", ""),
+        # Slash-prefixed plain input is not a command (issue #117).
+        ("/api/v1/users", None),
+        ("/home/ozymandias 경로 있음?", None),
+        ("/etc/passwd", None),
+        ("/data/workspaces/x", None),
+        ("/", None),
+        ("/ tell me a joke", None),
     ],
 )
 def test_extract_command_name(prompt, expected):
@@ -90,15 +94,25 @@ async def test_unknown_command_raises(monkeypatch):
     assert calls["n"] == 2
 
 
-async def test_empty_slash_is_unknown(monkeypatch):
+async def test_slash_prefixed_plain_input_is_noop(monkeypatch):
+    """Paths / URLs / bare slash pass through without a command fetch (#117)."""
+    called = {"n": 0}
+
     async def _fake_fetch(cwd):
+        called["n"] += 1
         return {"review"}
 
     monkeypatch.setattr(sc, "_fetch_commands", _fake_fetch)
 
-    with pytest.raises(sc.SlashCommandError) as ei:
-        await sc.validate_prompt("/ hello")
-    assert ei.value.code == "unknown_command"
+    for prompt in (
+        "/home/ozymandias 경로 있음?",
+        "/etc/passwd",
+        "/api/v1/users",
+        "/",
+        "/ hello",
+    ):
+        await sc.validate_prompt(prompt)
+    assert called["n"] == 0  # never treated as a command
 
 
 async def test_ttl_cache_reuses_within_window(monkeypatch):

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -27,6 +27,10 @@ def _reset_cache():
         ("/compact foo bar", "compact"),
         ("/dev-server status", "dev-server"),
         ("/superpowers:brainstorming", "superpowers:brainstorming"),
+        # Command-shaped per the CLI's char class — kept on the validated path
+        # (the CLI would otherwise silently return "Unknown skill").
+        ("/:foo", ":foo"),
+        ("/foo::bar baz", "foo::bar"),
         # Slash-prefixed plain input is not a command (issue #117).
         ("/api/v1/users", None),
         ("/home/ozymandias 경로 있음?", None),


### PR DESCRIPTION
Two related Claude-backend fixes.

## #115 — Workspace sandbox blocks the SDK's own `~/.claude` state dir

`ada6d32` added `~`/`./`/`../` detection to the bash sandbox to catch escape attempts. Side effect: the Claude Code SDK reaches its own internal state dir (`$HOME/.claude/projects/.../tool-results`) via `~/.claude/...`, which resolves outside the single allowed workspace root, so the sandbox denied the SDK's own access and broke normal operation.

**Fix** (`src/backends/claude/workspace_sandbox.py`): switch from one allowed root to a list.
- `_resolve_within` → `_resolve_within_any`: a candidate passes if it lies inside any root; relative paths still resolve against `roots[0]` (the workspace root) to preserve prior behavior.
- `_extra_allowed_roots()` adds `$HOME/.claude` as an always-on root (empty when `$HOME` unset). Only `.claude` is added, so `~/.ssh` and other home paths stay denied.
- `_check_bash` and the file-path tool check take the roots list.

Closes #115

## #117 — Slash-prefixed plain input (file paths, URLs) rejected as `unknown_command`

`validate_prompt` treated **every** prompt starting with `/` as a slash command, so file paths (`/home/x`), URLs (`/api/v1/users`) and a bare `/` returned HTTP 400.

**Fix** (`src/backends/claude/slash_commands.py`): `extract_command_name` now only recognizes command-name-shaped tokens (alphanumeric/kebab, optional `:namespace`). Anything else after `/` — a path separator, a bare slash, `/ text` — returns `None` and passes through to the model, matching Claude Code (the CLI only dispatches command-shaped tokens, so such input reaches the model as plain text).

Command-shaped but unregistered names (e.g. a typo'd `/halp`) **still 400** on purpose: letting them through would make the CLI silently return `Unknown skill: <name>` with 0 tokens — the silent-200 case this module exists to prevent.

Closes #117

## Tests
- `tests/test_workspace_sandbox.py` — `$HOME/.claude` allowed (tilde + absolute, Bash/Read); `~/.ssh` and other workspaces still denied; no-HOME keeps `~/.claude` denied. 46 pass.
- `tests/test_slash_commands.py` — paths/URLs/bare-slash/한글 pass through as no-ops; changed cases updated. 21 pass.
- Source files pass `black`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFsj3J7EAZNr1TKZXYqoqm

---
_Generated by [Claude Code](https://claude.ai/code/session_01LFsj3J7EAZNr1TKZXYqoqm)_