### PR TITLE
feat(admin): manage plugins & marketplaces from the admin panel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -114,6 +114,15 @@
 # and it is never passed to the claude CLI.
 # CLAUDE_PLUGIN_GIT_TOKEN=your-personal-access-token
 #
+# Admin-managed plugin manifest layered on top of the CLAUDE_PLUGIN_* env
+# bootstrap above. The admin panel records plugins/marketplaces it installs (and
+# env-bootstrap plugins it uninstalls) into this JSON file. At startup
+# install_plugins.py reconciles the effective set as
+# (env bootstrap ∪ manifest.added) minus manifest.removed, so admin changes
+# survive container restarts and `docker compose down -v`. In Docker the file
+# lives on the ./data bind mount; default /app/data/gateway-plugins.json.
+# CLAUDE_PLUGIN_MANIFEST=/app/data/gateway-plugins.json
+#
 # Claude SDK setting sources. Non-Docker runtime defaults to project,local.
 # Docker Compose defaults this to user,project,local so user-scope plugins
 # installed at container startup are visible to Claude.

--- a/.env.example
+++ b/.env.example
@@ -122,8 +122,9 @@
 # survive container restarts and `docker compose down -v`. In Docker the file
 # lives on the ./data bind mount; default /app/data/gateway-plugins.json.
 # Note: git tokens are NEVER written to the manifest. A PRIVATE marketplace
-# added via the admin panel only replays on startup if its token is also
-# available via the CLAUDE_PLUGIN_GIT_TOKEN* env above.
+# added via the admin panel replays on startup only if the un-indexed
+# CLAUDE_PLUGIN_GIT_TOKEN (above) is set — manifest entries inherit it as their
+# clone credential. A public marketplace needs no token.
 # CLAUDE_PLUGIN_MANIFEST=/app/data/gateway-plugins.json
 #
 # Claude SDK setting sources. Non-Docker runtime defaults to project,local.

--- a/.env.example
+++ b/.env.example
@@ -127,6 +127,13 @@
 # clone credential. A public marketplace needs no token.
 # CLAUDE_PLUGIN_MANIFEST=/app/data/gateway-plugins.json
 #
+# install_plugins.py also writes an env-bootstrap journal beside the manifest
+# (gateway-plugins-env.json) recording each CLAUDE_PLUGIN_* marketplace's
+# scope/branch/remote — metadata known_marketplaces.json does not persist for a
+# clone-then-add marketplace — so the admin catalog targets the right scope and
+# replays the right branch/repo. Auto-managed; override its path only if needed.
+# CLAUDE_PLUGIN_ENV_JOURNAL=/app/data/gateway-plugins-env.json
+#
 # Claude SDK setting sources. Non-Docker runtime defaults to project,local.
 # Docker Compose defaults this to user,project,local so user-scope plugins
 # installed at container startup are visible to Claude.

--- a/.env.example
+++ b/.env.example
@@ -121,6 +121,9 @@
 # (env bootstrap ∪ manifest.added) minus manifest.removed, so admin changes
 # survive container restarts and `docker compose down -v`. In Docker the file
 # lives on the ./data bind mount; default /app/data/gateway-plugins.json.
+# Note: git tokens are NEVER written to the manifest. A PRIVATE marketplace
+# added via the admin panel only replays on startup if its token is also
+# available via the CLAUDE_PLUGIN_GIT_TOKEN* env above.
 # CLAUDE_PLUGIN_MANIFEST=/app/data/gateway-plugins.json
 #
 # Claude SDK setting sources. Non-Docker runtime defaults to project,local.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ curl http://localhost:8000/v1/responses \
 - **Session continuity**: `previous_response_id` and server-side session tracking.
 - **Workspace isolation**: temporary sessions by default, or per-user directories with `USER_WORKSPACES_DIR`.
 - **MCP support**: shared gateway `MCP_CONFIG`, with optional OpenCode managed-mode config generation.
-- **Admin tools**: `/admin` dashboard, `/admin/chat`, runtime config, sessions, logs, prompts, read-only plugin skills, and diagnostics.
+- **Admin tools**: `/admin` dashboard, `/admin/chat`, runtime config, sessions, logs, prompts, plugin & marketplace management (install/remove), and diagnostics.
 - **Docker support**: Dockerfile and Compose setup with optional usage-log MySQL sidecar.
 
 ## Documentation

--- a/docker-compose.codex.yml
+++ b/docker-compose.codex.yml
@@ -54,6 +54,9 @@ services:
       - CODEX_SANDBOX=${CODEX_SANDBOX:-danger-full-access}
       - CODEX_CONFIG_OVERRIDES=${CODEX_CONFIG_OVERRIDES:-}
       - USER_WORKSPACES_DIR=${USER_WORKSPACES_DIR:-/data/workspaces}
+      # Admin-managed plugin manifest persisted to the ./data bind mount so it
+      # survives image redeploy and `docker compose down -v`.
+      - CLAUDE_PLUGIN_MANIFEST=${CLAUDE_PLUGIN_MANIFEST:-/app/data/gateway-plugins.json}
       # Auto-wire the custom system prompt to the host file mounted above; empty
       # (preset mode) when SYSTEM_PROMPT_HOST_FILE is unset. Overrides .env.
       - SYSTEM_PROMPT_FILE=${SYSTEM_PROMPT_HOST_FILE:+/app/system_prompt.md}

--- a/docker-compose.opencode.yml
+++ b/docker-compose.opencode.yml
@@ -52,6 +52,9 @@ services:
       - OPENCODE_BIN=opencode
       - OPENCODE_HOME=/home/app/.local/share/opencode
       - USER_WORKSPACES_DIR=${USER_WORKSPACES_DIR:-/data/workspaces}
+      # Admin-managed plugin manifest persisted to the ./data bind mount so it
+      # survives image redeploy and `docker compose down -v`.
+      - CLAUDE_PLUGIN_MANIFEST=${CLAUDE_PLUGIN_MANIFEST:-/app/data/gateway-plugins.json}
       # Auto-wire the custom system prompt to the host file mounted above; empty
       # (preset mode) when SYSTEM_PROMPT_HOST_FILE is unset. Overrides .env.
       - SYSTEM_PROMPT_FILE=${SYSTEM_PROMPT_HOST_FILE:+/app/system_prompt.md}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,12 @@ services:
       # Docker installs optional plugins into the container user's ~/.claude,
       # so include user-scope config when the Claude SDK starts.
       - CLAUDE_SETTING_SOURCES=${CLAUDE_SETTING_SOURCES:-user,project,local}
+      # Admin-managed plugin manifest layered on top of the CLAUDE_PLUGIN_* env
+      # bootstrap. Persisted to the ./data bind mount so it survives image
+      # redeploy AND `docker compose down -v` (which wipes claude_home's plugin
+      # cache); install_plugins.py reinstalls manifest.added and reapplies
+      # manifest.removed on next boot (self-healing).
+      - CLAUDE_PLUGIN_MANIFEST=${CLAUDE_PLUGIN_MANIFEST:-/app/data/gateway-plugins.json}
       # Auto-wire the custom system prompt to the host file mounted above.
       # Resolves to /app/system_prompt.md only when SYSTEM_PROMPT_HOST_FILE is
       # set; otherwise empty so the claude_code preset is used. This overrides

--- a/docker/install_plugins.py
+++ b/docker/install_plugins.py
@@ -51,6 +51,7 @@ import subprocess
 import sys
 import tempfile
 from dataclasses import dataclass, field
+from urllib.parse import urlsplit, urlunsplit
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -299,6 +300,31 @@ def env_journal_path() -> Path:
     return manifest_path().with_name("gateway-plugins-env.json")
 
 
+def _strip_url_credentials(repo: str) -> str:
+    """Remove embedded credentials from an http(s) repo URL before journaling.
+
+    A deployment may put a token in ``CLAUDE_PLUGIN_REPO*`` (e.g.
+    ``https://user:token@host/org/repo.git``); git uses it to clone, but it must
+    not be persisted to the journal (which the app reads and replays into the
+    manifest/API). Strip the userinfo here — replay credentials come from
+    ``CLAUDE_PLUGIN_GIT_TOKEN*``. Non-http(s) values are returned unchanged.
+    """
+    repo = (repo or "").strip()
+    scheme = repo.split("://", 1)[0].lower() if "://" in repo else ""
+    if scheme not in ("http", "https"):
+        return repo
+    try:
+        parts = urlsplit(repo)
+    except ValueError:
+        return repo
+    if not (parts.username or parts.password):
+        return repo
+    host = parts.hostname or ""
+    if parts.port:
+        host = f"{host}:{parts.port}"
+    return urlunsplit((parts.scheme, host, parts.path, parts.query, parts.fragment))
+
+
 def _marketplace_name_for(local_path: Path, entry: PluginEntry) -> str:
     """Resolve the name claude keys this marketplace by (its marketplace.json name).
 
@@ -340,7 +366,8 @@ def write_env_journal(entries: List[PluginEntry], root: Path) -> None:
         records[name] = {
             "scope": entry.scope,
             "branch": entry.branch,
-            "repo": entry.repo,
+            # Never persist credentials embedded in the repo URL to the journal.
+            "repo": _strip_url_credentials(entry.repo),
         }
     payload = {"version": 1, "marketplaces": records}
     path = env_journal_path()

--- a/docker/install_plugins.py
+++ b/docker/install_plugins.py
@@ -200,8 +200,9 @@ def manifest_path() -> Path:
 def load_manifest() -> Dict[str, list]:
     """Read the manifest, tolerating a missing/corrupt file.
 
-    Always returns ``{"added": [...], "removed": [...]}`` with ``added``
-    filtered to dicts and ``removed`` filtered to strings; never raises.
+    Always returns ``{"added": [...], "removed": [...]}`` with ``added`` filtered
+    to dicts and ``removed`` normalized to ``{"spec","scope"}`` dicts (scope is
+    part of a plugin's identity); never raises.
     """
     empty: Dict[str, list] = {"added": [], "removed": []}
     try:
@@ -216,13 +217,24 @@ def load_manifest() -> Dict[str, list]:
         return empty
     added = data.get("added")
     removed = data.get("removed")
+    removed_norm = []
+    if isinstance(removed, list):
+        for r in removed:
+            if isinstance(r, dict) and isinstance(r.get("spec"), str) and r["spec"]:
+                scope = r.get("scope")
+                removed_norm.append(
+                    {
+                        "spec": r["spec"],
+                        "scope": scope if isinstance(scope, str) and scope else "user",
+                    }
+                )
+            elif isinstance(r, str) and r:  # legacy spec-only
+                removed_norm.append({"spec": r, "scope": "user"})
     return {
         "added": [e for e in added if isinstance(e, dict)]
         if isinstance(added, list)
         else [],
-        "removed": [s for s in removed if isinstance(s, str)]
-        if isinstance(removed, list)
-        else [],
+        "removed": removed_norm,
     }
 
 
@@ -468,12 +480,21 @@ def process_entry(
 ) -> Tuple[int, int]:
     """Prepare one repo and install/update its plugins. Returns ``(ok, failed)``.
 
-    Any plugin spec present in *removed_set* (the admin-uninstalled set from the
-    manifest) is skipped before any subprocess for that plugin runs.
+    Any (spec, scope) present in *removed_set* (the admin-uninstalled set from the
+    manifest) is skipped before any subprocess for that plugin runs. scope is part
+    of the identity, so an entry is only skipped when its own scope was removed.
     """
     removed_set = removed_set or set()
-    names = [n for n in entry.names if _spec(n, entry.marketplace) not in removed_set]
-    skipped = [n for n in entry.names if _spec(n, entry.marketplace) in removed_set]
+    names = [
+        n
+        for n in entry.names
+        if (_spec(n, entry.marketplace), entry.scope) not in removed_set
+    ]
+    skipped = [
+        n
+        for n in entry.names
+        if (_spec(n, entry.marketplace), entry.scope) in removed_set
+    ]
     for name in skipped:
         log(
             f"{entry.source_label}: skipping {_spec(name, entry.marketplace)!r} "
@@ -540,7 +561,7 @@ def main() -> int:
         )
         return 0  # never block server startup
 
-    removed_set = set(load_manifest()["removed"])
+    removed_set = {(r["spec"], r["scope"]) for r in load_manifest()["removed"]}
 
     root = clone_root()
     total_ok = 0
@@ -562,17 +583,20 @@ def apply_removed(claude_bin: str, removed_set: set) -> None:
     """Best-effort uninstall every spec the admin marked removed.
 
     These specs came from the env bootstrap (so install was skipped above); this
-    actively uninstalls them so a `down -v` plugin-cache wipe stays consistent
-    with the admin's intent. Failures are logged and ignored — uninstalling an
-    already-absent plugin is expected and must never block startup.
+    actively uninstalls them at the scope they were removed from so a `down -v`
+    plugin-cache wipe stays consistent with the admin's intent. Failures are
+    logged and ignored — uninstalling an already-absent plugin is expected and
+    must never block startup.
+
+    *removed_set* is a set of ``(spec, scope)`` tuples.
     """
-    for spec in sorted(removed_set):
+    for spec, scope in sorted(removed_set):
         try:
-            run([claude_bin, "plugin", "uninstall", spec, "--scope", "user"])
-            log(f"uninstalled {spec!r} (marked removed in manifest)")
+            run([claude_bin, "plugin", "uninstall", spec, "--scope", scope])
+            log(f"uninstalled {spec!r} (scope {scope}; marked removed in manifest)")
         except subprocess.CalledProcessError as exc:
             log(
-                f"uninstall for {spec!r} returned rc={exc.returncode}; "
+                f"uninstall for {spec!r} (scope {scope}) returned rc={exc.returncode}; "
                 f"likely already absent, continuing"
             )
 

--- a/docker/install_plugins.py
+++ b/docker/install_plugins.py
@@ -232,7 +232,14 @@ def _manifest_entries() -> List[PluginEntry]:
     Each added record carries its own repo/name/marketplace/scope/branch, so it
     becomes a single-plugin entry. Records missing both a repo and a name are
     dropped (nothing actionable to install).
+
+    The admin panel never persists a git token, so a PRIVATE admin-added
+    marketplace would otherwise clone unauthenticated and fail. As a fallback,
+    manifest entries inherit the un-indexed ``CLAUDE_PLUGIN_GIT_TOKEN`` (the same
+    credential the legacy env-bootstrap entry uses) so a private marketplace
+    replays when that token is provided at startup.
     """
+    manifest_token = os.environ.get("CLAUDE_PLUGIN_GIT_TOKEN", "")
     entries: List[PluginEntry] = []
     for record in load_manifest()["added"]:
         repo = str(record.get("repo", "")).strip()
@@ -249,6 +256,7 @@ def _manifest_entries() -> List[PluginEntry]:
                 marketplace=str(record.get("marketplace", "")).strip(),
                 scope=str(record.get("scope", "")).strip() or "user",
                 branch=str(record.get("branch", "")).strip() or DEFAULT_BRANCH,
+                git_token=manifest_token,
                 source_label="manifest",
             )
         )

--- a/docker/install_plugins.py
+++ b/docker/install_plugins.py
@@ -43,6 +43,7 @@ URL.
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import platform
 import shutil
@@ -51,9 +52,14 @@ import sys
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 LOG_PREFIX = "[install_plugins]"
+
+# Container default for the admin-managed manifest. The app side derives this
+# from the project root; this standalone script can't, so docker-compose pins
+# CLAUDE_PLUGIN_MANIFEST so both sides agree exactly.
+DEFAULT_MANIFEST_PATH = "/app/data/gateway-plugins.json"
 
 # Safety cap on how many indexed entries (CLAUDE_PLUGIN_REPO_1..N) we scan for.
 MAX_INDEX = 64
@@ -152,7 +158,12 @@ def _entry_from_suffix(suffix: str) -> Optional[PluginEntry]:
 
 
 def collect_entries() -> List[PluginEntry]:
-    """Collect the legacy un-indexed entry plus all indexed ``_N`` entries."""
+    """Collect the legacy un-indexed entry plus all indexed ``_N`` entries.
+
+    Entries from the admin-managed manifest (``manifest.added``) are appended
+    after the env bootstrap so admin-installed plugins are reinstalled on every
+    boot (self-healing after a plugin-cache volume wipe).
+    """
     entries: List[PluginEntry] = []
 
     legacy = _entry_from_suffix("")
@@ -170,7 +181,83 @@ def collect_entries() -> List[PluginEntry]:
             f"only indices 1..{MAX_INDEX} are scanned"
         )
 
+    entries.extend(_manifest_entries())
+
     return entries
+
+
+# ---------------------------------------------------------------------------
+# Admin-managed manifest (read inline; stdlib only — never import src)
+# ---------------------------------------------------------------------------
+
+
+def manifest_path() -> Path:
+    """Resolve the manifest path, matching the app side's env override."""
+    configured = os.environ.get("CLAUDE_PLUGIN_MANIFEST", "").strip()
+    return Path(configured) if configured else Path(DEFAULT_MANIFEST_PATH)
+
+
+def load_manifest() -> Dict[str, list]:
+    """Read the manifest, tolerating a missing/corrupt file.
+
+    Always returns ``{"added": [...], "removed": [...]}`` with ``added``
+    filtered to dicts and ``removed`` filtered to strings; never raises.
+    """
+    empty: Dict[str, list] = {"added": [], "removed": []}
+    try:
+        raw = manifest_path().read_text(encoding="utf-8")
+    except (FileNotFoundError, OSError):
+        return empty
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return empty
+    if not isinstance(data, dict):
+        return empty
+    added = data.get("added")
+    removed = data.get("removed")
+    return {
+        "added": [e for e in added if isinstance(e, dict)]
+        if isinstance(added, list)
+        else [],
+        "removed": [s for s in removed if isinstance(s, str)]
+        if isinstance(removed, list)
+        else [],
+    }
+
+
+def _manifest_entries() -> List[PluginEntry]:
+    """Build :class:`PluginEntry` objects from ``manifest.added``.
+
+    Each added record carries its own repo/name/marketplace/scope/branch, so it
+    becomes a single-plugin entry. Records missing both a repo and a name are
+    dropped (nothing actionable to install).
+    """
+    entries: List[PluginEntry] = []
+    for record in load_manifest()["added"]:
+        repo = str(record.get("repo", "")).strip()
+        name = str(record.get("name", "")).strip()
+        if not name:
+            name = _default_name(repo)
+        if not repo or not name:
+            log(f"manifest: skipping entry with no actionable repo/name: {record!r}")
+            continue
+        entries.append(
+            PluginEntry(
+                repo=repo,
+                names=[name],
+                marketplace=str(record.get("marketplace", "")).strip(),
+                scope=str(record.get("scope", "")).strip() or "user",
+                branch=str(record.get("branch", "")).strip() or DEFAULT_BRANCH,
+                source_label="manifest",
+            )
+        )
+    return entries
+
+
+def _spec(name: str, marketplace: str) -> str:
+    """``name@marketplace`` when *marketplace* is truthy, else ``name``."""
+    return f"{name}@{marketplace}" if marketplace else name
 
 
 # ---------------------------------------------------------------------------
@@ -365,8 +452,28 @@ def install_and_update(claude_bin: str, spec: str, scope: str) -> bool:
     return True
 
 
-def process_entry(entry: PluginEntry, claude_bin: str, root: Path) -> Tuple[int, int]:
-    """Prepare one repo and install/update its plugins. Returns ``(ok, failed)``."""
+def process_entry(
+    entry: PluginEntry,
+    claude_bin: str,
+    root: Path,
+    removed_set: Optional[set] = None,
+) -> Tuple[int, int]:
+    """Prepare one repo and install/update its plugins. Returns ``(ok, failed)``.
+
+    Any plugin spec present in *removed_set* (the admin-uninstalled set from the
+    manifest) is skipped before any subprocess for that plugin runs.
+    """
+    removed_set = removed_set or set()
+    names = [n for n in entry.names if _spec(n, entry.marketplace) not in removed_set]
+    skipped = [n for n in entry.names if _spec(n, entry.marketplace) in removed_set]
+    for name in skipped:
+        log(
+            f"{entry.source_label}: skipping {_spec(name, entry.marketplace)!r} "
+            f"(marked removed in manifest)"
+        )
+    if not names:
+        return (0, 0)
+
     try:
         local_path = prepare_repo(entry, root)
     except subprocess.CalledProcessError as exc:
@@ -399,8 +506,8 @@ def process_entry(entry: PluginEntry, claude_bin: str, root: Path) -> Tuple[int,
 
     ok = 0
     failed = 0
-    for name in entry.names:
-        spec = f"{name}@{entry.marketplace}" if entry.marketplace else name
+    for name in names:
+        spec = _spec(name, entry.marketplace)
         if install_and_update(claude_bin, spec, entry.scope):
             ok += 1
         else:
@@ -425,18 +532,41 @@ def main() -> int:
         )
         return 0  # never block server startup
 
+    removed_set = set(load_manifest()["removed"])
+
     root = clone_root()
     total_ok = 0
     total_failed = 0
     for entry in entries:
-        ok, failed = process_entry(entry, claude_bin, root)
+        ok, failed = process_entry(entry, claude_bin, root, removed_set)
         total_ok += ok
         total_failed += failed
+
+    apply_removed(claude_bin, removed_set)
 
     log(
         f"done: {total_ok} plugin(s) ensured, {total_failed} failed, across {len(entries)} repo(s)"
     )
     return 0
+
+
+def apply_removed(claude_bin: str, removed_set: set) -> None:
+    """Best-effort uninstall every spec the admin marked removed.
+
+    These specs came from the env bootstrap (so install was skipped above); this
+    actively uninstalls them so a `down -v` plugin-cache wipe stays consistent
+    with the admin's intent. Failures are logged and ignored — uninstalling an
+    already-absent plugin is expected and must never block startup.
+    """
+    for spec in sorted(removed_set):
+        try:
+            run([claude_bin, "plugin", "uninstall", spec, "--scope", "user"])
+            log(f"uninstalled {spec!r} (marked removed in manifest)")
+        except subprocess.CalledProcessError as exc:
+            log(
+                f"uninstall for {spec!r} returned rc={exc.returncode}; "
+                f"likely already absent, continuing"
+            )
 
 
 if __name__ == "__main__":

--- a/docker/install_plugins.py
+++ b/docker/install_plugins.py
@@ -281,6 +281,79 @@ def _spec(name: str, marketplace: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Env-bootstrap marketplace journal (consumed by the running app)
+# ---------------------------------------------------------------------------
+
+
+def env_journal_path() -> Path:
+    """Path of the env-bootstrap marketplace journal (beside the manifest).
+
+    ``known_marketplaces.json`` persists neither an env marketplace's scope/branch
+    nor its original remote (clone-then-add records only the local path). This
+    journal hands that metadata to the running app, keyed by the marketplace's
+    real ``marketplace.json`` name. Overridable with ``CLAUDE_PLUGIN_ENV_JOURNAL``.
+    """
+    configured = os.environ.get("CLAUDE_PLUGIN_ENV_JOURNAL", "").strip()
+    if configured:
+        return Path(configured)
+    return manifest_path().with_name("gateway-plugins-env.json")
+
+
+def _marketplace_name_for(local_path: Path, entry: PluginEntry) -> str:
+    """Resolve the name claude keys this marketplace by (its marketplace.json name).
+
+    Falls back to the explicit ``CLAUDE_PLUGIN_MARKETPLACE*`` value, then the repo
+    basename, so the journal always has a usable key.
+    """
+    try:
+        raw = (local_path / ".claude-plugin" / "marketplace.json").read_text(
+            encoding="utf-8"
+        )
+        data = json.loads(raw)
+        name = data.get("name") if isinstance(data, dict) else None
+        if isinstance(name, str) and name.strip():
+            return name.strip()
+    except (OSError, ValueError):
+        pass
+    return entry.marketplace or _default_name(entry.repo)
+
+
+def write_env_journal(entries: List[PluginEntry], root: Path) -> None:
+    """Write the env-bootstrap marketplace journal (overwrites fully each run).
+
+    Only ENV-declared entries are recorded; ``manifest.added`` entries are already
+    persisted in the manifest. Best-effort: a write failure is logged, not fatal —
+    the app simply falls back to user/main defaults.
+    """
+    records: Dict[str, Dict[str, str]] = {}
+    for entry in entries:
+        if entry.source_label == "manifest" or not entry.repo:
+            continue
+        local_path = (
+            Path(entry.repo)
+            if Path(entry.repo).exists()
+            else _clone_dir(root, entry.repo)
+        )
+        name = _marketplace_name_for(local_path, entry)
+        if not name:
+            continue
+        records[name] = {
+            "scope": entry.scope,
+            "branch": entry.branch,
+            "repo": entry.repo,
+        }
+    payload = {"version": 1, "marketplaces": records}
+    path = env_journal_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_name(path.name + ".tmp")
+        tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        os.replace(tmp, path)
+    except OSError as exc:
+        log(f"could not write env journal {path}: {exc}")
+
+
+# ---------------------------------------------------------------------------
 # claude CLI discovery
 # ---------------------------------------------------------------------------
 
@@ -547,6 +620,7 @@ def process_entry(
 def main() -> int:
     entries = collect_entries()
     if not entries:
+        write_env_journal([], clone_root())  # clear any stale journal
         return 0  # nothing configured — no-op, same as the legacy installer
 
     total_plugins = sum(len(entry.names) for entry in entries)
@@ -572,6 +646,7 @@ def main() -> int:
         total_failed += failed
 
     apply_removed(claude_bin, removed_set)
+    write_env_journal(entries, root)
 
     log(
         f"done: {total_ok} plugin(s) ensured, {total_failed} failed, across {len(entries)} repo(s)"

--- a/src/admin_html_plugins.py
+++ b/src/admin_html_plugins.py
@@ -136,7 +136,7 @@ def get_plugins_html() -> str:
                       <td class="text-xs text-muted" x-text="(p.skills?.length || 0)"></td>
                       <td>
                         <button class="btn btn-sm btn-ghost" style="color:var(--red)"
-                          @click="uninstallPlugin(p.id)" aria-label="Uninstall plugin">[DEL]</button>
+                          @click="uninstallPlugin(p.id, p.scope)" aria-label="Uninstall plugin">[DEL]</button>
                       </td>
                     </tr>
                   </template>

--- a/src/admin_html_plugins.py
+++ b/src/admin_html_plugins.py
@@ -121,11 +121,12 @@ def get_plugins_html() -> str:
 
             <div class="table-wrapper mb-md">
               <table>
-                <thead><tr><th>PLUGIN</th><th>ORIGIN</th><th>VERSION</th><th>SKILLS</th><th></th></tr></thead>
+                <thead><tr><th>PLUGIN</th><th>SCOPE</th><th>ORIGIN</th><th>VERSION</th><th>SKILLS</th><th></th></tr></thead>
                 <tbody>
-                  <template x-for="p in plugins" :key="p.id">
+                  <template x-for="p in plugins" :key="p.id + '@' + p.scope">
                     <tr>
                       <td style="color:var(--amber); font-weight:600" x-text="p.name"></td>
+                      <td class="text-xs text-muted" x-text="p.scope || 'user'"></td>
                       <td>
                         <span class="badge text-xs" x-show="p.origin === 'managed'"
                           style="border-color:var(--cyan); color:var(--cyan)">MANAGED</span>
@@ -141,7 +142,7 @@ def get_plugins_html() -> str:
                     </tr>
                   </template>
                   <tr x-show="plugins.length === 0">
-                    <td colspan="5" class="text-sm text-muted">[ NO PLUGINS ]</td>
+                    <td colspan="6" class="text-sm text-muted">[ NO PLUGINS ]</td>
                   </tr>
                 </tbody>
               </table>

--- a/src/admin_html_plugins.py
+++ b/src/admin_html_plugins.py
@@ -1,0 +1,176 @@
+"""Admin plugins tab HTML (manage marketplaces + plugins at runtime)."""
+
+
+def get_plugins_html() -> str:
+    """Return the admin plugins management tab html."""
+    return """      <!-- Plugins Tab -->
+      <div x-show="tab==='plugins'" role="tabpanel">
+        <p class="text-xs text-muted" style="margin:0 0 12px 0">
+          // admin-managed layer on top of the CLAUDE_PLUGIN_* env bootstrap. changes persist via the gateway manifest.
+        </p>
+        <div class="grid-2">
+
+          <!-- Browse / Catalog section -->
+          <div class="card">
+            <div class="flex-between mb-sm">
+              <h3 style="margin:0; color:var(--cyan)">Browse Marketplaces</h3>
+              <button class="btn btn-sm btn-ghost" @click="loadCatalog()" :disabled="catalogLoading" aria-label="Reload catalog">
+                <span x-text="catalogLoading ? 'LOADING...' : '[RELOAD]'"></span>
+              </button>
+            </div>
+
+            <!-- Search / filter across all marketplaces -->
+            <div class="flex-gap-sm mb-sm" style="align-items:center">
+              <input type="text" x-model="catalogFilter" placeholder="filter plugins by name / description..."
+                style="flex:1" aria-label="Filter catalog plugins">
+              <button x-show="catalogFilter" class="btn btn-sm btn-ghost" @click="catalogFilter=''" aria-label="Clear filter">[X]</button>
+            </div>
+
+            <div class="file-tree" style="max-height:62vh; overflow-y:auto">
+              <template x-for="m in marketplaces" :key="m.name">
+                <div x-show="marketplaceVisible(m)">
+                  <!-- Marketplace group header (expandable) -->
+                  <div class="file-item" style="cursor:pointer" @click="toggleMarketplace(m)">
+                    <span class="text-xs" style="color:var(--amber); margin-right:4px"
+                      x-text="(m._expanded || catalogFilter) ? '[-]' : '[+]'"></span>
+                    <div style="flex:1; min-width:0">
+                      <div class="flex-gap-sm" style="align-items:center">
+                        <span style="font-size:var(--fs-sm); font-weight:600; color:var(--amber)" x-text="m.name"></span>
+                        <span class="badge text-xs" x-text="m.source_type"></span>
+                      </div>
+                      <div class="text-mono text-xs" style="color:var(--text-dim); overflow:hidden; text-overflow:ellipsis; white-space:nowrap"
+                        :title="m.repo" x-text="m.repo"></div>
+                    </div>
+                    <span class="text-xs text-muted" style="margin-right:8px" x-text="m.plugin_count + ' plugins'"></span>
+                    <button class="btn btn-sm btn-ghost" style="color:var(--red)"
+                      @click.stop="removeMarketplace(m.name)" aria-label="Remove marketplace">[DEL]</button>
+                  </div>
+
+                  <!-- Catalog plugins (expandable; force-open while filtering) -->
+                  <template x-if="m._expanded || catalogFilter">
+                    <div>
+                      <template x-for="plug in filteredCatalogPlugins(m)" :key="plug.id">
+                        <div class="file-item" style="padding-left:28px; align-items:flex-start">
+                          <span class="icon" style="color:var(--cyan); margin-top:2px">&#9670;</span>
+                          <div style="flex:1; min-width:0">
+                            <div class="flex-gap-sm" style="align-items:center">
+                              <span style="font-size:var(--fs-sm); color:var(--text); font-weight:600" x-text="plug.name"></span>
+                              <span class="text-xs text-muted" x-text="plug.version ? 'v' + plug.version : ''"></span>
+                              <span class="text-xs text-muted" x-text="(plug.skill_count || 0) + ' skills'"></span>
+                              <span x-show="plug.installed" class="badge text-xs"
+                                style="border-color:var(--green); color:var(--green)">INSTALLED</span>
+                            </div>
+                            <div x-show="plug.description" class="text-xs text-muted"
+                              style="white-space:nowrap; overflow:hidden; text-overflow:ellipsis" x-text="plug.description"></div>
+                          </div>
+                          <button x-show="!plug.installed" class="btn btn-sm btn-primary"
+                            @click="installFromCatalog(m, plug)" :disabled="catalogBusy[plug.id]"
+                            aria-label="Install plugin">
+                            <span x-text="catalogBusy[plug.id] ? '...' : 'INSTALL'"></span>
+                          </button>
+                          <button x-show="plug.installed" class="btn btn-sm btn-ghost" style="color:var(--red)"
+                            @click="uninstallFromCatalog(plug)" :disabled="catalogBusy[plug.id]"
+                            aria-label="Uninstall plugin">
+                            <span x-text="catalogBusy[plug.id] ? '...' : 'UNINSTALL'"></span>
+                          </button>
+                        </div>
+                      </template>
+                      <div x-show="filteredCatalogPlugins(m).length === 0" class="text-xs text-muted" style="padding:4px 12px 4px 28px">
+                        (no plugins)
+                      </div>
+                    </div>
+                  </template>
+                </div>
+              </template>
+              <div x-show="marketplaces.length === 0" class="text-sm text-muted" style="padding:4px 12px">
+                [ NO MARKETPLACES ]
+              </div>
+              <div x-show="marketplaces.length > 0 && catalogVisibleCount() === 0" class="text-sm text-muted" style="padding:4px 12px">
+                [ NO PLUGINS MATCH FILTER ]
+              </div>
+            </div>
+
+            <!-- Add marketplace (collapsible) -->
+            <details style="margin-top:12px">
+              <summary class="text-xs text-dim" style="cursor:pointer">+ add marketplace</summary>
+              <form @submit.prevent="addMarketplace()" style="margin-top:8px">
+                <input type="text" x-model="mpForm.repo" placeholder="https://github.com/owner/repo (or local path)"
+                  style="width:100%; margin-bottom:8px" required>
+                <div class="flex-gap-sm" style="margin-bottom:8px">
+                  <input type="text" x-model="mpForm.branch" placeholder="branch (main)" style="flex:1">
+                  <select x-model="mpForm.scope" style="flex:1">
+                    <option value="user">user</option>
+                    <option value="project">project</option>
+                  </select>
+                </div>
+                <input type="password" x-model="mpForm.git_token" placeholder="git token (optional, private repos)"
+                  style="width:100%; margin-bottom:8px">
+                <button class="btn btn-sm btn-primary" type="submit" :disabled="pluginBusy" style="width:100%">
+                  <span x-text="pluginBusy ? 'WORKING...' : 'ADD MARKETPLACE'"></span>
+                </button>
+              </form>
+            </details>
+          </div>
+
+          <!-- Installed Plugins section -->
+          <div class="card">
+            <div class="flex-between mb-sm">
+              <h3 style="margin:0; color:var(--cyan)">Installed Plugins</h3>
+              <button class="btn btn-sm btn-ghost" @click="loadPlugins()" aria-label="Refresh plugins">[RELOAD]</button>
+            </div>
+
+            <div class="table-wrapper mb-md">
+              <table>
+                <thead><tr><th>PLUGIN</th><th>ORIGIN</th><th>VERSION</th><th>SKILLS</th><th></th></tr></thead>
+                <tbody>
+                  <template x-for="p in plugins" :key="p.id">
+                    <tr>
+                      <td style="color:var(--amber); font-weight:600" x-text="p.name"></td>
+                      <td>
+                        <span class="badge text-xs" x-show="p.origin === 'managed'"
+                          style="border-color:var(--cyan); color:var(--cyan)">MANAGED</span>
+                        <span class="badge text-xs" x-show="p.origin !== 'managed'"
+                          style="border-color:var(--amber); color:var(--amber); opacity:0.7">ENV</span>
+                      </td>
+                      <td class="text-xs text-muted" x-text="p.version ? 'v' + p.version : '-'"></td>
+                      <td class="text-xs text-muted" x-text="(p.skills?.length || 0)"></td>
+                      <td>
+                        <button class="btn btn-sm btn-ghost" style="color:var(--red)"
+                          @click="uninstallPlugin(p.id)" aria-label="Uninstall plugin">[DEL]</button>
+                      </td>
+                    </tr>
+                  </template>
+                  <tr x-show="plugins.length === 0">
+                    <td colspan="5" class="text-sm text-muted">[ NO PLUGINS ]</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <!-- Advanced: install by name (de-emphasized; browse+click is primary) -->
+            <details>
+              <summary class="text-xs text-dim" style="cursor:pointer">advanced: install by name</summary>
+              <form @submit.prevent="installPlugin()" style="margin-top:8px">
+                <input type="text" x-model="pluginForm.name" placeholder="plugin name"
+                  style="width:100%; margin-bottom:8px" required>
+                <div class="flex-gap-sm" style="margin-bottom:8px">
+                  <select x-model="pluginForm.marketplace" style="flex:1">
+                    <option value="">(marketplace)</option>
+                    <template x-for="m in marketplaces" :key="m.name">
+                      <option :value="m.name" x-text="m.name"></option>
+                    </template>
+                  </select>
+                  <select x-model="pluginForm.scope" style="flex:1">
+                    <option value="user">user</option>
+                    <option value="project">project</option>
+                  </select>
+                </div>
+                <button class="btn btn-sm btn-primary" type="submit" :disabled="pluginBusy" style="width:100%">
+                  <span x-text="pluginBusy ? 'WORKING...' : 'INSTALL PLUGIN'"></span>
+                </button>
+              </form>
+            </details>
+          </div>
+
+        </div>
+      </div>"""

--- a/src/admin_html_plugins.py
+++ b/src/admin_html_plugins.py
@@ -43,7 +43,7 @@ def get_plugins_html() -> str:
                     </div>
                     <span class="text-xs text-muted" style="margin-right:8px" x-text="m.plugin_count + ' plugins'"></span>
                     <button class="btn btn-sm btn-ghost" style="color:var(--red)"
-                      @click.stop="removeMarketplace(m.name)" aria-label="Remove marketplace">[DEL]</button>
+                      @click.stop="removeMarketplace(m.name, m.scope)" aria-label="Remove marketplace">[DEL]</button>
                   </div>
 
                   <!-- Catalog plugins (expandable; force-open while filtering) -->

--- a/src/admin_html_skills.py
+++ b/src/admin_html_skills.py
@@ -13,7 +13,7 @@ def get_skills_html() -> str:
             <p class="text-xs text-muted" style="padding-left:12px; margin:0 0 8px 0">// read-only. managed by CLI plugin system.</p>
 
             <!-- Plugin skills section -->
-            <template x-for="p in plugins" :key="p.id">
+            <template x-for="p in plugins" :key="p.id + '@' + p.scope">
               <div>
                 <!-- Plugin group header -->
                 <div class="file-item" style="cursor:pointer; opacity:0.8" @click="p._expanded = !p._expanded">
@@ -21,6 +21,7 @@ def get_skills_html() -> str:
                   <div style="flex:1; min-width:0">
                     <div class="flex-gap-sm">
                       <span style="font-size:var(--fs-sm); font-weight:600; color:var(--amber)" x-text="p.name"></span>
+                      <span class="text-xs text-muted" x-text="p.scope || 'user'"></span>
                       <span class="text-xs text-muted" x-text="p.version ? 'v' + p.version : ''"></span>
                     </div>
                     <div class="text-xs text-muted" x-text="(p.skills?.length || 0) + ' skills'"></div>
@@ -29,9 +30,9 @@ def get_skills_html() -> str:
                 <!-- Plugin skills (expandable) -->
                 <template x-if="p._expanded">
                   <div>
-                    <template x-for="sk in (p.skills || [])" :key="p.id + ':' + sk.name">
+                    <template x-for="sk in (p.skills || [])" :key="p.id + '@' + p.scope + ':' + sk.name">
                       <div class="file-item" style="padding-left:28px"
-                        :class="{ active: pluginSkillView && pluginSkillView.pluginId === p.id && pluginSkillView.skillName === sk.name }"
+                        :class="{ active: pluginSkillView && pluginSkillView.pluginId === p.id && pluginSkillView.scope === p.scope && pluginSkillView.skillName === sk.name }"
                         @click="openPluginSkill(p, sk.name)">
                         <span class="icon" style="color:var(--cyan)">&#9670;</span>
                         <div style="flex:1; min-width:0">

--- a/src/admin_js.py
+++ b/src/admin_js.py
@@ -694,12 +694,12 @@ def get_admin_js() -> str:
       finally { this.pluginBusy = false; }
     },
 
-    async removeMarketplace(name) {
+    async removeMarketplace(name, scope) {
       if (!confirm('Remove marketplace "' + name + '"?')) return;
       this.pluginBusy = true;
       try {
         const r = await this.api('/admin/api/marketplaces/' + encodeURIComponent(name) +
-          '?scope=' + encodeURIComponent(this.mpForm.scope), { method: 'DELETE' });
+          '?scope=' + encodeURIComponent(scope || 'user'), { method: 'DELETE' });
         if (r.ok) {
           this.showToast('MARKETPLACE REMOVED', 'ok');
           await this.loadMarketplaces();

--- a/src/admin_js.py
+++ b/src/admin_js.py
@@ -656,7 +656,7 @@ def get_admin_js() -> str:
       this.catalogBusy[plug.id] = true;
       try {
         const r = await this.api('/admin/api/plugins/' + encodeURIComponent(plug.id) +
-          '?scope=user', { method: 'DELETE' });
+          '?scope=' + encodeURIComponent(plug.scope || 'user'), { method: 'DELETE' });
         if (r.ok) {
           this.showToast('PLUGIN UNINSTALLED', 'ok');
           await this.refreshPluginViews();
@@ -737,12 +737,12 @@ def get_admin_js() -> str:
       finally { this.pluginBusy = false; }
     },
 
-    async uninstallPlugin(pluginId) {
+    async uninstallPlugin(pluginId, scope) {
       if (!confirm('Uninstall plugin "' + pluginId + '"?')) return;
       this.pluginBusy = true;
       try {
         const r = await this.api('/admin/api/plugins/' + encodeURIComponent(pluginId) +
-          '?scope=' + encodeURIComponent(this.pluginForm.scope), { method: 'DELETE' });
+          '?scope=' + encodeURIComponent(scope || 'user'), { method: 'DELETE' });
         if (r.ok) {
           this.showToast('PLUGIN UNINSTALLED', 'ok');
           await this.refreshPluginViews();

--- a/src/admin_js.py
+++ b/src/admin_js.py
@@ -638,7 +638,7 @@ def get_admin_js() -> str:
       try {
         const r = await this.api('/admin/api/plugins', {
           method: 'POST', headers: {'Content-Type': 'application/json'},
-          body: JSON.stringify({ name: plug.name, marketplace: m.name, scope: 'user' })
+          body: JSON.stringify({ name: plug.name, marketplace: m.name, scope: m.scope || 'user' })
         });
         if (r.ok) {
           this.showToast('PLUGIN INSTALLED: ' + plug.name, 'ok');

--- a/src/admin_js.py
+++ b/src/admin_js.py
@@ -558,15 +558,15 @@ def get_admin_js() -> str:
         const r = await this.api('/admin/api/plugins');
         if (r.ok) {
           const d = await r.json();
-          const wasExpanded = new Set(this.plugins.filter(p => p._expanded).map(p => p.id));
-          this.plugins = (d.plugins || []).map(p => ({ ...p, _expanded: wasExpanded.has(p.id) }));
+          const wasExpanded = new Set(this.plugins.filter(p => p._expanded).map(p => p.id + '@' + p.scope));
+          this.plugins = (d.plugins || []).map(p => ({ ...p, _expanded: wasExpanded.has(p.id + '@' + p.scope) }));
         }
       } catch(e) { console.error('Failed to load plugins', e); this.showToast('Failed to load plugins', 'err'); }
     },
     async openPluginSkill(plugin, skillName) {
-      this.pluginSkillView = { pluginId: plugin.id, skillName, pluginName: plugin.name, version: plugin.version, content: '' };
+      this.pluginSkillView = { pluginId: plugin.id, scope: plugin.scope, skillName, pluginName: plugin.name, version: plugin.version, content: '' };
       try {
-        const r = await this.api('/admin/api/plugins/' + encodeURIComponent(plugin.id) + '/skills/' + encodeURIComponent(skillName));
+        const r = await this.api('/admin/api/plugins/' + encodeURIComponent(plugin.id) + '/skills/' + encodeURIComponent(skillName) + '?scope=' + encodeURIComponent(plugin.scope || 'user'));
         if (r.ok) {
           const d = await r.json();
           this.pluginSkillView.content = d.content || '';

--- a/src/admin_js.py
+++ b/src/admin_js.py
@@ -29,6 +29,14 @@ def get_admin_js() -> str:
     runtimeConfig: {},
     plugins: [],
     pluginSkillView: null,
+    marketplaces: [],
+    pluginBusy: false,
+    catalogFilter: '',
+    catalogBusy: {},
+    catalogLoading: false,
+    showAdvancedInstall: false,
+    mpForm: { repo: '', branch: 'main', scope: 'user', git_token: '' },
+    pluginForm: { name: '', marketplace: '', scope: 'user' },
     toolsRegistry: {},
     sandboxConfig: {},
     systemPrompt: { mode: 'preset', prompt: null, resolved_prompt: null, preset_text: null, char_count: 0, active_name: null },
@@ -567,6 +575,183 @@ def get_admin_js() -> str:
           this.pluginSkillView = null;
         }
       } catch(e) { this.showToast('Connection error', 'err'); this.pluginSkillView = null; }
+    },
+
+    // --- Plugin management (PLUGINS tab) ---
+    async loadPlugins() { await this.loadSkills(); },
+
+    // Browse catalog: load every marketplace + its plugins in one call.
+    async loadCatalog() {
+      this.catalogLoading = true;
+      try {
+        const r = await this.api('/admin/api/marketplaces/catalog');
+        if (r.ok) {
+          const d = await r.json();
+          const wasExpanded = new Set(this.marketplaces.filter(m => m._expanded).map(m => m.name));
+          this.marketplaces = (d.marketplaces || []).map(m => ({
+            ...m, _expanded: wasExpanded.has(m.name),
+          }));
+        } else {
+          const d = await r.json().catch(() => ({}));
+          this.showToast(d.error || 'Failed to load catalog', 'err');
+        }
+      } catch(e) {
+        console.error('Failed to load catalog', e);
+        this.showToast('Failed to load catalog', 'err');
+      } finally { this.catalogLoading = false; }
+    },
+
+    // Refresh both the catalog and the installed list so installed flags
+    // and origin badges update immediately after a mutation.
+    async refreshPluginViews() {
+      await Promise.all([this.loadCatalog(), this.loadPlugins()]);
+    },
+
+    // Legacy plain marketplace list (kept for the advanced install form's
+    // dropdown); catalog also populates this.marketplaces with names.
+    async loadMarketplaces() { await this.loadCatalog(); },
+
+    toggleMarketplace(m) { m._expanded = !m._expanded; },
+
+    // Client-side filter across all marketplaces by name/description.
+    filteredCatalogPlugins(m) {
+      const q = this.catalogFilter.trim().toLowerCase();
+      const list = m.plugins || [];
+      if (!q) return list;
+      return list.filter(p =>
+        (p.name || '').toLowerCase().includes(q) ||
+        (p.description || '').toLowerCase().includes(q));
+    },
+
+    // A marketplace is hidden while filtering if it has no matching plugins.
+    marketplaceVisible(m) {
+      if (!this.catalogFilter.trim()) return true;
+      return this.filteredCatalogPlugins(m).length > 0;
+    },
+
+    catalogVisibleCount() {
+      return this.marketplaces.filter(m => this.marketplaceVisible(m)).length;
+    },
+
+    async installFromCatalog(m, plug) {
+      this.catalogBusy[plug.id] = true;
+      try {
+        const r = await this.api('/admin/api/plugins', {
+          method: 'POST', headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({ name: plug.name, marketplace: m.name, scope: 'user' })
+        });
+        if (r.ok) {
+          this.showToast('PLUGIN INSTALLED: ' + plug.name, 'ok');
+          await this.refreshPluginViews();
+        } else {
+          const d = await r.json().catch(() => ({}));
+          this.showToast(d.error || 'Install failed', 'err');
+        }
+      } catch(e) { this.showToast('Connection error', 'err'); }
+      finally { delete this.catalogBusy[plug.id]; }
+    },
+
+    async uninstallFromCatalog(plug) {
+      if (!confirm('Uninstall plugin "' + plug.name + '"?')) return;
+      this.catalogBusy[plug.id] = true;
+      try {
+        const r = await this.api('/admin/api/plugins/' + encodeURIComponent(plug.id) +
+          '?scope=user', { method: 'DELETE' });
+        if (r.ok) {
+          this.showToast('PLUGIN UNINSTALLED', 'ok');
+          await this.refreshPluginViews();
+        } else {
+          const d = await r.json().catch(() => ({}));
+          this.showToast(d.error || 'Uninstall failed', 'err');
+        }
+      } catch(e) { this.showToast('Connection error', 'err'); }
+      finally { delete this.catalogBusy[plug.id]; }
+    },
+
+    async addMarketplace() {
+      const repo = this.mpForm.repo.trim();
+      if (!repo) return;
+      this.pluginBusy = true;
+      try {
+        const r = await this.api('/admin/api/marketplaces', {
+          method: 'POST', headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({
+            repo,
+            branch: this.mpForm.branch.trim() || 'main',
+            scope: this.mpForm.scope,
+            git_token: this.mpForm.git_token,
+          })
+        });
+        if (r.ok) {
+          this.showToast('MARKETPLACE ADDED', 'ok');
+          this.mpForm = { repo: '', branch: 'main', scope: 'user', git_token: '' };
+          await this.loadMarketplaces();
+        } else {
+          const d = await r.json().catch(() => ({}));
+          this.showToast(d.error || 'Add failed', 'err');
+        }
+      } catch(e) { this.showToast('Connection error', 'err'); }
+      finally { this.pluginBusy = false; }
+    },
+
+    async removeMarketplace(name) {
+      if (!confirm('Remove marketplace "' + name + '"?')) return;
+      this.pluginBusy = true;
+      try {
+        const r = await this.api('/admin/api/marketplaces/' + encodeURIComponent(name) +
+          '?scope=' + encodeURIComponent(this.mpForm.scope), { method: 'DELETE' });
+        if (r.ok) {
+          this.showToast('MARKETPLACE REMOVED', 'ok');
+          await this.loadMarketplaces();
+          await this.loadPlugins();
+        } else {
+          const d = await r.json().catch(() => ({}));
+          this.showToast(d.error || 'Remove failed', 'err');
+        }
+      } catch(e) { this.showToast('Connection error', 'err'); }
+      finally { this.pluginBusy = false; }
+    },
+
+    async installPlugin() {
+      const name = this.pluginForm.name.trim();
+      if (!name) return;
+      this.pluginBusy = true;
+      try {
+        const r = await this.api('/admin/api/plugins', {
+          method: 'POST', headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({
+            name,
+            marketplace: this.pluginForm.marketplace,
+            scope: this.pluginForm.scope,
+          })
+        });
+        if (r.ok) {
+          this.showToast('PLUGIN INSTALLED: ' + name, 'ok');
+          this.pluginForm = { name: '', marketplace: '', scope: 'user' };
+          await this.refreshPluginViews();
+        } else {
+          const d = await r.json().catch(() => ({}));
+          this.showToast(d.error || 'Install failed', 'err');
+        }
+      } catch(e) { this.showToast('Connection error', 'err'); }
+      finally { this.pluginBusy = false; }
+    },
+
+    async uninstallPlugin(pluginId) {
+      if (!confirm('Uninstall plugin "' + pluginId + '"?')) return;
+      this.pluginBusy = true;
+      try {
+        const r = await this.api('/admin/api/plugins/' + encodeURIComponent(pluginId) +
+          '?scope=' + encodeURIComponent(this.pluginForm.scope), { method: 'DELETE' });
+        if (r.ok) {
+          this.showToast('PLUGIN UNINSTALLED', 'ok');
+          await this.refreshPluginViews();
+        } else {
+          const d = await r.json().catch(() => ({}));
+          this.showToast(d.error || 'Uninstall failed', 'err');
+        }
+      } catch(e) { this.showToast('Connection error', 'err'); }
+      finally { this.pluginBusy = false; }
     },
 
     async toggleSessionHistory(sessionId) {

--- a/src/admin_page.py
+++ b/src/admin_page.py
@@ -11,6 +11,7 @@ from functools import lru_cache
 from src.admin_html_config import get_config_html
 from src.admin_html_dashboard import get_dashboard_html
 from src.admin_html_logs import get_logs_html
+from src.admin_html_plugins import get_plugins_html
 from src.admin_html_ratelimits import get_ratelimits_html
 from src.admin_html_sessions import get_sessions_html
 from src.admin_html_skills import get_skills_html
@@ -116,6 +117,7 @@ def build_admin_page() -> str:
         <button role="tab" :aria-selected="tab === 'usage'" @click="tab='usage'; loadUsage()">USAGE</button>
         <button role="tab" :aria-selected="tab === 'ratelimits'" @click="tab='ratelimits'; loadRateLimits()">LIMITS</button>
         <button role="tab" :aria-selected="tab === 'skills'" @click="tab='skills'; loadSkills()">SKILLS</button>
+        <button role="tab" :aria-selected="tab === 'plugins'" @click="tab='plugins'; loadPlugins(); loadCatalog()">PLUGINS</button>
         <button role="tab" :aria-selected="tab === 'config'" @click="tab='config'; loadConfig(); loadRuntimeConfig(); loadSystemPrompt(); loadTools(); loadSandbox()">CONFIG</button>
         <a href="/admin/chat" role="tab" style="color:var(--cyan);text-decoration:none;padding:var(--gap-sm) var(--gap-lg);font-size:var(--fs-sm);letter-spacing:0.08em;border-bottom:2px solid transparent;display:flex;align-items:center;gap:4px;white-space:nowrap;">CHAT ↗</a>
       </nav>
@@ -130,6 +132,8 @@ def build_admin_page() -> str:
         + get_ratelimits_html()
         + "\n\n"
         + get_skills_html()
+        + "\n\n"
+        + get_plugins_html()
         + "\n\n"
         + get_sessions_html()
         + "\n\n"

--- a/src/plugin_admin_service.py
+++ b/src/plugin_admin_service.py
@@ -1,0 +1,492 @@
+"""Runtime plugin / marketplace mutations via the ``claude`` CLI.
+
+The admin panel uses this module to add/remove Claude Code marketplaces and
+install/uninstall plugins at runtime. Every successful mutation is recorded in
+the persistent managed manifest (:mod:`src.plugin_manifest`) so the startup
+installer (:mod:`docker.install_plugins`) can replay it after a plugin-cache
+volume wipe (manifest ``added`` is reinstalled, ``removed`` is reapplied).
+
+Behavior mirrors ``docker/install_plugins.py``:
+
+* A **remote** repo is fresh-cloned into the shared clone root
+  (``CLAUDE_PLUGIN_CLONE_ROOT`` or ``$HOME/.claude/plugin-marketplaces``) and
+  then registered with ``claude plugin marketplace add <local_path>``.
+* A **local-path** repo is added in place (no clone).
+* Plugins are installed with ``claude plugin install <spec> --scope`` followed
+  by ``claude plugin update``; uninstall is ``claude plugin uninstall``.
+
+Security:
+
+* The git token reaches git only through a temporary ``GIT_ASKPASS`` helper; it
+  never appears on a command line, in a registered marketplace URL, or in a log.
+* Every child runs with ``CLAUDE_PLUGIN_GIT_TOKEN*`` stripped and
+  ``GIT_TERMINAL_PROMPT=0``.
+* All inputs are validated before any subprocess runs; commands use arg lists
+  (never ``shell=True``).
+
+All functions here are synchronous; routes wrap them in
+``fastapi.concurrency.run_in_threadpool``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import platform
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import List, Optional
+
+from . import plugin_manifest
+
+# Branch fresh-cloned from a remote marketplace repo when none is given.
+DEFAULT_BRANCH = "main"
+
+# Bound every git/claude call so a stuck clone or credential challenge can never
+# wedge the request thread. Override with CLAUDE_PLUGIN_TIMEOUT_SECONDS.
+DEFAULT_TIMEOUT_SECONDS = 300
+
+# Allowed scopes for marketplace/plugin declarations.
+_VALID_SCOPES = frozenset({"user", "project", "local"})
+
+# Plugin / marketplace names: letters, digits and a small punctuation set. No
+# whitespace, no shell metacharacters.
+_NAME_RE = re.compile(r"^[A-Za-z0-9._@/-]+$")
+
+# A spec is name[@marketplace]; the "@" is allowed by _NAME_RE itself, so the
+# whole spec validates with the same pattern.
+
+# Helper that answers git's credential prompts using a token supplied via the
+# CLAUDE_PLUGIN_ASKPASS_TOKEN environment variable. The token itself never
+# appears on a command line or in the marketplace URL handed to ``claude``.
+_ASKPASS_SCRIPT = (
+    "#!/bin/sh\n"
+    'case "$1" in\n'
+    "    *Username*) printf '%s\\n' \"x-access-token\" ;;\n"
+    "    *Password*) printf '%s\\n' \"$CLAUDE_PLUGIN_ASKPASS_TOKEN\" ;;\n"
+    "    *) printf '\\n' ;;\n"
+    "esac\n"
+)
+
+
+class PluginAdminError(ValueError):
+    """Raised on invalid input or a failed ``claude``/``git`` invocation."""
+
+
+# ---------------------------------------------------------------------------
+# claude CLI discovery (mirrors docker/install_plugins.py)
+# ---------------------------------------------------------------------------
+
+
+def _is_executable(path: str) -> bool:
+    return bool(path) and os.path.isfile(path) and os.access(path, os.X_OK)
+
+
+def _bundled_claude() -> Optional[str]:
+    """Locate the ``claude`` CLI bundled with ``claude_agent_sdk``."""
+    try:
+        import claude_agent_sdk  # type: ignore
+    except Exception:  # pragma: no cover - import failure path
+        return None
+    cli_name = "claude.exe" if platform.system() == "Windows" else "claude"
+    candidate = Path(claude_agent_sdk.__file__).parent / "_bundled" / cli_name
+    return str(candidate) if candidate.is_file() else None
+
+
+def resolve_claude_bin() -> Optional[str]:
+    """Resolve the claude CLI: explicit override, then PATH, then bundled SDK."""
+    override = os.environ.get("CLAUDE_PLUGIN_CLAUDE_BIN", "").strip()
+    if override:
+        if _is_executable(override):
+            return override
+        return shutil.which(override) or override
+
+    on_path = shutil.which("claude")
+    if on_path:
+        return on_path
+
+    return _bundled_claude()
+
+
+def _require_claude_bin() -> str:
+    claude_bin = resolve_claude_bin()
+    if not _is_executable(claude_bin or ""):
+        raise PluginAdminError(
+            "claude CLI not found or not executable; set CLAUDE_PLUGIN_CLAUDE_BIN "
+            "or install claude-agent-sdk with its bundled CLI"
+        )
+    return claude_bin  # type: ignore[return-value]
+
+
+# ---------------------------------------------------------------------------
+# Command execution (mirrors docker/install_plugins.py)
+# ---------------------------------------------------------------------------
+
+
+def _write_askpass(token: str, env: dict) -> str:
+    """Write a temporary GIT_ASKPASS helper and wire it into *env*."""
+    fd, path = tempfile.mkstemp(prefix="git-askpass-", suffix=".sh")
+    with os.fdopen(fd, "w") as handle:
+        handle.write(_ASKPASS_SCRIPT)
+    os.chmod(path, 0o700)
+    env["GIT_ASKPASS"] = path
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    env["CLAUDE_PLUGIN_ASKPASS_TOKEN"] = token
+    return path
+
+
+def _timeout_seconds() -> int:
+    raw = os.environ.get("CLAUDE_PLUGIN_TIMEOUT_SECONDS", "").strip()
+    if raw:
+        try:
+            value = int(raw)
+            if value > 0:
+                return value
+        except ValueError:
+            pass
+    return DEFAULT_TIMEOUT_SECONDS
+
+
+def run(cmd: List[str], *, token: str = "") -> subprocess.CompletedProcess:
+    """Run *cmd* as an arg list and capture its output.
+
+    The git token reaches git only through a per-call ``GIT_ASKPASS`` helper.
+    Every child runs with the persistent ``CLAUDE_PLUGIN_GIT_TOKEN*`` vars
+    stripped and ``GIT_TERMINAL_PROMPT=0`` so a missing credential fails fast.
+    A timeout bounds the call. Raises :class:`subprocess.CalledProcessError` on
+    a non-zero exit or timeout.
+    """
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if not k.startswith("CLAUDE_PLUGIN_GIT_TOKEN")
+    }
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    askpass_path = _write_askpass(token, env) if token else None
+    try:
+        proc = subprocess.run(
+            cmd,
+            env=env,
+            timeout=_timeout_seconds(),
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise subprocess.CalledProcessError(124, cmd) from exc
+    finally:
+        if askpass_path is not None:
+            try:
+                os.unlink(askpass_path)
+            except OSError:
+                pass
+
+    if proc.returncode != 0:
+        raise subprocess.CalledProcessError(
+            proc.returncode, cmd, output=proc.stdout, stderr=proc.stderr
+        )
+    return proc
+
+
+# ---------------------------------------------------------------------------
+# Input validation (runs before ANY subprocess)
+# ---------------------------------------------------------------------------
+
+
+def _validate_name(value: str, *, what: str) -> str:
+    value = (value or "").strip()
+    if not value:
+        raise PluginAdminError(f"{what} is required")
+    if not _NAME_RE.match(value):
+        raise PluginAdminError(
+            f"invalid {what} {value!r}: only letters, digits and ._@/- are allowed"
+        )
+    return value
+
+
+def _validate_scope(scope: str) -> str:
+    scope = (scope or "").strip() or "user"
+    if scope not in _VALID_SCOPES:
+        raise PluginAdminError(
+            f"invalid scope {scope!r}: expected one of {sorted(_VALID_SCOPES)}"
+        )
+    return scope
+
+
+def _validate_branch(branch: str) -> str:
+    branch = (branch or "").strip() or DEFAULT_BRANCH
+    if not _NAME_RE.match(branch):
+        raise PluginAdminError(
+            f"invalid branch {branch!r}: only letters, digits and ._@/- are allowed"
+        )
+    return branch
+
+
+def _has_shell_metacharacters(value: str) -> bool:
+    # Whitespace or any of the usual shell-injection characters.
+    if any(c.isspace() for c in value):
+        return True
+    return bool(re.search(r"""[;&|`$<>(){}\[\]'"\\!*?~]""", value))
+
+
+def _validate_repo(repo: str) -> str:
+    """Validate *repo* is an http(s)/git/ssh URL or an existing local path."""
+    repo = (repo or "").strip()
+    if not repo:
+        raise PluginAdminError("repo is required")
+
+    # An existing local path is always accepted (it is used in place; never
+    # interpolated into a shell).
+    if Path(repo).exists():
+        return repo
+
+    if _has_shell_metacharacters(repo):
+        raise PluginAdminError(f"invalid repo {repo!r}: contains illegal characters")
+
+    # Accept common remote forms: http(s)://, git://, ssh://, and scp-like
+    # git@host:org/repo.git.
+    if re.match(r"^(https?|git|ssh)://[A-Za-z0-9._~:/?#@!$&'()*+,;=%-]+$", repo):
+        return repo
+    if re.match(r"^[A-Za-z0-9._-]+@[A-Za-z0-9._-]+:[A-Za-z0-9._/~-]+$", repo):
+        return repo
+
+    raise PluginAdminError(
+        f"invalid repo {repo!r}: expected an http(s)/git/ssh URL or an existing "
+        "local path"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Repo preparation (mirrors docker/install_plugins.py)
+# ---------------------------------------------------------------------------
+
+
+def _default_name(repo: str) -> str:
+    """Infer a marketplace/plugin name from a repo URL/path basename."""
+    base = repo.rstrip("/").split("/")[-1]
+    base = base.split("#", 1)[0]
+    base = base.split("@", 1)[0]
+    if base.endswith(".git"):
+        base = base[: -len(".git")]
+    return base
+
+
+def clone_root() -> Path:
+    """Resolve the directory remote marketplace repos are cloned into."""
+    configured = os.environ.get("CLAUDE_PLUGIN_CLONE_ROOT", "").strip()
+    if configured:
+        return Path(configured)
+    home = os.environ.get("HOME", "").strip() or tempfile.gettempdir()
+    return Path(home) / ".claude" / "plugin-marketplaces"
+
+
+def _clone_dir(root: Path, repo: str) -> Path:
+    """Return a collision-free per-repo clone directory under *root*."""
+    base = _default_name(repo) or "marketplace"
+    digest = hashlib.sha1(repo.encode("utf-8")).hexdigest()[:8]
+    return root / f"{base}-{digest}"
+
+
+def prepare_repo(repo: str, *, branch: str, token: str, root: Path) -> Path:
+    """Return the local marketplace path for *repo*, fresh-cloning if remote.
+
+    A local-path repo is used in place (*branch* is ignored). A remote repo is
+    cloned into a staging dir and swapped in only on success, so a failed
+    re-clone leaves any previous clone intact.
+    """
+    if Path(repo).exists():
+        return Path(repo)
+
+    dest = _clone_dir(root, repo)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    staging = dest.with_name(dest.name + ".new")
+    if staging.exists():
+        shutil.rmtree(staging)
+    try:
+        run(
+            [
+                "git",
+                "clone",
+                "--depth",
+                "1",
+                "--branch",
+                branch,
+                repo,
+                str(staging),
+            ],
+            token=token,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise PluginAdminError(
+            f"git clone failed for {repo!r} (branch {branch}): rc={exc.returncode}"
+        ) from exc
+    if dest.exists():
+        shutil.rmtree(dest)
+    os.replace(staging, dest)
+    return dest
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def add_marketplace(
+    repo: str,
+    *,
+    branch: str = "main",
+    scope: str = "user",
+    git_token: str = "",
+) -> dict:
+    """Register a marketplace from *repo* (clone-then-add for a remote repo)."""
+    repo = _validate_repo(repo)
+    branch = _validate_branch(branch)
+    scope = _validate_scope(scope)
+    claude_bin = _require_claude_bin()
+
+    local_path = prepare_repo(repo, branch=branch, token=git_token, root=clone_root())
+    try:
+        run(
+            [
+                claude_bin,
+                "plugin",
+                "marketplace",
+                "add",
+                str(local_path),
+                "--scope",
+                scope,
+            ]
+        )
+    except subprocess.CalledProcessError as exc:
+        raise PluginAdminError(
+            f"claude plugin marketplace add failed for {local_path} "
+            f"(scope {scope}): rc={exc.returncode}"
+        ) from exc
+
+    return {
+        "status": "added",
+        "repo": repo,
+        "path": str(local_path),
+        "branch": branch,
+        "scope": scope,
+    }
+
+
+def remove_marketplace(name: str, *, scope: str = "user") -> dict:
+    """Remove a configured marketplace and drop its managed ``added`` entries."""
+    name = _validate_name(name, what="marketplace name")
+    scope = _validate_scope(scope)
+    claude_bin = _require_claude_bin()
+
+    try:
+        run(
+            [
+                claude_bin,
+                "plugin",
+                "marketplace",
+                "remove",
+                name,
+                "--scope",
+                scope,
+            ]
+        )
+    except subprocess.CalledProcessError as exc:
+        raise PluginAdminError(
+            f"claude plugin marketplace remove failed for {name!r} "
+            f"(scope {scope}): rc={exc.returncode}"
+        ) from exc
+
+    plugin_manifest.remove_marketplace_entries(name)
+
+    return {"status": "removed", "marketplace": name, "scope": scope}
+
+
+def install_plugin(
+    name: str,
+    *,
+    marketplace: str = "",
+    scope: str = "user",
+    repo: str = "",
+    branch: str = "main",
+) -> dict:
+    """Install (and update) a plugin, recording it in the managed manifest.
+
+    If *repo* is given it is registered as a marketplace first (clone-then-add
+    for a remote repo), exactly like the startup installer.
+    """
+    name = _validate_name(name, what="plugin name")
+    scope = _validate_scope(scope)
+    if marketplace:
+        marketplace = _validate_name(marketplace, what="marketplace name")
+    branch = _validate_branch(branch)
+    if repo:
+        # add_marketplace validates repo/branch/scope itself and resolves the
+        # claude bin; let it raise PluginAdminError before we install.
+        add_marketplace(repo, branch=branch, scope=scope, git_token="")
+
+    claude_bin = _require_claude_bin()
+    spec = plugin_manifest.spec_for(name, marketplace)
+
+    try:
+        run([claude_bin, "plugin", "install", spec, "--scope", scope])
+    except subprocess.CalledProcessError as exc:
+        raise PluginAdminError(
+            f"claude plugin install failed for {spec!r} (scope {scope}): "
+            f"rc={exc.returncode}"
+        ) from exc
+
+    # Update is best-effort: the plugin is installed even if no newer version
+    # exists, so a non-zero update rc is not fatal.
+    try:
+        run([claude_bin, "plugin", "update", spec, "--scope", scope])
+    except subprocess.CalledProcessError:
+        pass
+
+    plugin_manifest.add_plugin(
+        repo=repo,
+        name=name,
+        marketplace=marketplace,
+        scope=scope,
+        branch=branch,
+    )
+
+    return {
+        "status": "installed",
+        "plugin": name,
+        "marketplace": marketplace,
+        "spec": spec,
+        "scope": scope,
+    }
+
+
+def uninstall_plugin(plugin_id: str, *, scope: str = "user") -> dict:
+    """Uninstall *plugin_id* (registry key ``name@marketplace``).
+
+    If the spec is an admin-managed ``added`` entry it is dropped from the
+    manifest; otherwise it is marked ``removed`` (it came from env bootstrap, so
+    startup must skip reinstalling it).
+    """
+    spec = _validate_name(plugin_id, what="plugin id")
+    scope = _validate_scope(scope)
+    claude_bin = _require_claude_bin()
+
+    try:
+        run([claude_bin, "plugin", "uninstall", spec, "--scope", scope])
+    except subprocess.CalledProcessError as exc:
+        raise PluginAdminError(
+            f"claude plugin uninstall failed for {spec!r} (scope {scope}): "
+            f"rc={exc.returncode}"
+        ) from exc
+
+    added_specs = {
+        plugin_manifest.spec_for(e.get("name", ""), e.get("marketplace", ""))
+        for e in plugin_manifest.list_added()
+    }
+    if spec in added_specs:
+        plugin_manifest.remove_added(spec)
+    else:
+        plugin_manifest.mark_removed(spec)
+
+    return {"status": "uninstalled", "plugin": spec, "scope": scope}

--- a/src/plugin_admin_service.py
+++ b/src/plugin_admin_service.py
@@ -574,13 +574,19 @@ def uninstall_plugin(plugin_id: str, *, scope: str = "user") -> dict:
             f"rc={exc.returncode}"
         ) from exc
 
-    added_specs = {
-        plugin_manifest.spec_for(e.get("name", ""), e.get("marketplace", ""))
+    # scope is part of the identity: only drop the managed entry for THIS scope,
+    # and mark removed at THIS scope (so startup uninstalls it at the right scope
+    # and leaves any other-scope install of the same plugin untouched).
+    added_keys = {
+        (
+            plugin_manifest.spec_for(e.get("name", ""), e.get("marketplace", "")),
+            e.get("scope"),
+        )
         for e in plugin_manifest.list_added()
     }
-    if spec in added_specs:
-        plugin_manifest.remove_added(spec)
+    if (spec, scope) in added_keys:
+        plugin_manifest.remove_added(spec, scope)
     else:
-        plugin_manifest.mark_removed(spec)
+        plugin_manifest.mark_removed(spec, scope)
 
     return {"status": "uninstalled", "plugin": spec, "scope": scope}

--- a/src/plugin_admin_service.py
+++ b/src/plugin_admin_service.py
@@ -31,6 +31,8 @@ All functions here are synchronous; routes wrap them in
 from __future__ import annotations
 
 import hashlib
+import json
+import logging
 import os
 import platform
 import re
@@ -41,6 +43,8 @@ from pathlib import Path
 from typing import List, Optional
 
 from . import plugin_manifest
+
+logger = logging.getLogger(__name__)
 
 # Branch fresh-cloned from a remote marketplace repo when none is given.
 DEFAULT_BRANCH = "main"
@@ -333,6 +337,46 @@ def prepare_repo(repo: str, *, branch: str, token: str, root: Path) -> Path:
 # ---------------------------------------------------------------------------
 
 
+def _resolve_marketplace_repo(marketplace: str) -> str:
+    """Best-effort: resolve a registered marketplace name to a clonable repo.
+
+    Used so a plugin installed from a *catalog* (where the caller supplies only a
+    marketplace name, not a repo) still records a replayable ``repo`` in the
+    manifest. Reads ``~/.claude/plugins/known_marketplaces.json`` and converts a
+    GitHub ``owner/repo`` shorthand into a full clone URL. Returns ``""`` when the
+    marketplace is unknown or its source cannot be turned into something the
+    startup installer can clone/add. Never raises.
+    """
+    if not marketplace:
+        return ""
+    home = os.environ.get("HOME", "").strip() or str(Path.home())
+    known = Path(home) / ".claude" / "plugins" / "known_marketplaces.json"
+    try:
+        data = json.loads(known.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return ""
+    entry = data.get(marketplace) if isinstance(data, dict) else None
+    if not isinstance(entry, dict):
+        return ""
+    source = entry.get("source") if isinstance(entry.get("source"), dict) else {}
+    url = str(source.get("url", "")).strip()
+    if url:
+        return url
+    repo = str(source.get("repo", "")).strip()
+    if repo:
+        if "://" in repo or repo.startswith("git@"):
+            return repo
+        # GitHub owner/repo shorthand -> clonable HTTPS URL.
+        if source.get("source") == "github" or re.match(r"^[\w.-]+/[\w.-]+$", repo):
+            return f"https://github.com/{repo}.git"
+        return repo
+    # Local marketplace: replayable only if the path still exists at startup.
+    loc = str(entry.get("installLocation", "")).strip()
+    if loc and Path(loc).is_dir():
+        return loc
+    return ""
+
+
 def add_marketplace(
     repo: str,
     *,
@@ -444,8 +488,20 @@ def install_plugin(
     except subprocess.CalledProcessError:
         pass
 
+    # For a catalog install the caller passes only a marketplace name; resolve
+    # its repo so the manifest entry is replayable by the startup installer
+    # (which skips entries that carry no repo).
+    manifest_repo = repo or _resolve_marketplace_repo(marketplace)
+    if not manifest_repo:
+        logger.warning(
+            "could not resolve a repo for marketplace %r; manifest entry for %r "
+            "may not be reinstalled on startup after a plugin-cache wipe",
+            marketplace,
+            spec,
+        )
+
     plugin_manifest.add_plugin(
-        repo=repo,
+        repo=manifest_repo,
         name=name,
         marketplace=marketplace,
         scope=scope,

--- a/src/plugin_admin_service.py
+++ b/src/plugin_admin_service.py
@@ -41,6 +41,7 @@ import subprocess
 import tempfile
 from pathlib import Path
 from typing import List, Optional
+from urllib.parse import urlsplit
 
 from . import plugin_manifest
 
@@ -249,6 +250,22 @@ def _validate_repo(repo: str) -> str:
     if _has_shell_metacharacters(repo):
         raise PluginAdminError(f"invalid repo {repo!r}: contains illegal characters")
 
+    # Reject credentials embedded in an http(s) URL (e.g.
+    # https://user:token@host/... or https://TOKEN@host/...). The repo string is
+    # stored in the manifest, returned in the API response, and printed in clone
+    # error logs, so a secret there would leak; use the git_token field instead.
+    scheme = repo.split("://", 1)[0].lower() if "://" in repo else ""
+    if scheme in ("http", "https"):
+        try:
+            parts = urlsplit(repo)
+        except ValueError:
+            parts = None
+        if parts is not None and (parts.username or parts.password):
+            raise PluginAdminError(
+                "invalid repo: credentials must not be embedded in the URL; "
+                "use the git_token field for a private repo"
+            )
+
     # Accept common remote forms: http(s)://, git://, ssh://, and scp-like
     # git@host:org/repo.git.
     if re.match(r"^(https?|git|ssh)://[A-Za-z0-9._~:/?#@!$&'()*+,;=%-]+$", repo):
@@ -451,32 +468,37 @@ def add_marketplace(
 
 
 def remove_marketplace(name: str, *, scope: str = "user") -> dict:
-    """Remove a configured marketplace and drop its managed ``added`` entries."""
+    """Remove a configured marketplace and drop its managed ``added`` entries.
+
+    known_marketplaces.json does not record a marketplace's scope, so an
+    env-added project/local marketplace has no manifest record and the UI can
+    only guess ``user``. Try the requested scope first, then the others, so a
+    ``[DEL]`` on such a marketplace still removes it at its real scope.
+    """
     name = _validate_name(name, what="marketplace name")
     scope = _validate_scope(scope)
     claude_bin = _require_claude_bin()
 
-    try:
-        run(
-            [
-                claude_bin,
-                "plugin",
-                "marketplace",
-                "remove",
-                name,
-                "--scope",
-                scope,
-            ]
-        )
-    except subprocess.CalledProcessError as exc:
+    scopes = [scope] + [s for s in ("user", "project", "local") if s != scope]
+    last_rc = None
+    removed_scope = None
+    for sc in scopes:
+        try:
+            run([claude_bin, "plugin", "marketplace", "remove", name, "--scope", sc])
+            removed_scope = sc
+            break
+        except subprocess.CalledProcessError as exc:
+            last_rc = exc.returncode
+
+    if removed_scope is None:
         raise PluginAdminError(
             f"claude plugin marketplace remove failed for {name!r} "
-            f"(scope {scope}): rc={exc.returncode}"
-        ) from exc
+            f"(tried scopes {scopes}): rc={last_rc}"
+        )
 
     plugin_manifest.remove_marketplace_entries(name)
 
-    return {"status": "removed", "marketplace": name, "scope": scope}
+    return {"status": "removed", "marketplace": name, "scope": removed_scope}
 
 
 def install_plugin(
@@ -574,19 +596,11 @@ def uninstall_plugin(plugin_id: str, *, scope: str = "user") -> dict:
             f"rc={exc.returncode}"
         ) from exc
 
-    # scope is part of the identity: only drop the managed entry for THIS scope,
-    # and mark removed at THIS scope (so startup uninstalls it at the right scope
-    # and leaves any other-scope install of the same plugin untouched).
-    added_keys = {
-        (
-            plugin_manifest.spec_for(e.get("name", ""), e.get("marketplace", "")),
-            e.get("scope"),
-        )
-        for e in plugin_manifest.list_added()
-    }
-    if (spec, scope) in added_keys:
-        plugin_manifest.remove_added(spec, scope)
-    else:
-        plugin_manifest.mark_removed(spec, scope)
+    # scope is part of the identity. Drop any managed entry for THIS (spec,
+    # scope) AND always record the removal: if the same plugin is also declared
+    # by the env bootstrap, only the recorded removal stops startup from
+    # resurrecting it. A later admin re-install clears the mark via add_plugin.
+    plugin_manifest.remove_added(spec, scope)
+    plugin_manifest.mark_removed(spec, scope)
 
     return {"status": "uninstalled", "plugin": spec, "scope": scope}

--- a/src/plugin_admin_service.py
+++ b/src/plugin_admin_service.py
@@ -374,6 +374,23 @@ def _marketplace_name_from_clone(local_path: Path, repo: str) -> str:
     return _default_name(repo)
 
 
+def _env_marketplace_record(marketplace: str) -> dict:
+    """Env-bootstrap journal record (``{scope, branch, repo}``) for *marketplace*.
+
+    Returns ``{}`` when there is no env-bootstrapped marketplace by that name or
+    the journal is unavailable; never raises.
+    """
+    if not marketplace:
+        return {}
+    try:
+        from . import plugin_service
+
+        rec = plugin_service.env_bootstrap_records().get(marketplace)
+        return rec if isinstance(rec, dict) else {}
+    except Exception:
+        return {}
+
+
 def _resolve_marketplace_repo(marketplace: str) -> str:
     """Best-effort: resolve a registered marketplace name to a clonable repo.
 
@@ -391,6 +408,11 @@ def _resolve_marketplace_repo(marketplace: str) -> str:
     record = plugin_manifest.get_marketplace(marketplace)
     if record.get("repo", "").strip():
         return record["repo"].strip()
+    # Env-bootstrapped marketplace: the startup installer journals its remote,
+    # which known_marketplaces.json (source: directory) does not preserve.
+    env = _env_marketplace_record(marketplace)
+    if env.get("repo", "").strip():
+        return env["repo"].strip()
     home = os.environ.get("HOME", "").strip() or str(Path.home())
     known = Path(home) / ".claude" / "plugins" / "known_marketplaces.json"
     try:
@@ -552,6 +574,12 @@ def install_plugin(
         record = plugin_manifest.get_marketplace(marketplace)
         if record.get("branch", "").strip():
             manifest_branch = record["branch"].strip()
+        else:
+            # Env-bootstrapped marketplace: replay the branch it was cloned at,
+            # not the default, so a `down -v` self-heal clones the same content.
+            env = _env_marketplace_record(marketplace)
+            if env.get("branch", "").strip():
+                manifest_branch = env["branch"].strip()
     if not manifest_repo:
         logger.warning(
             "could not resolve a repo for marketplace %r; manifest entry for %r "

--- a/src/plugin_admin_service.py
+++ b/src/plugin_admin_service.py
@@ -41,7 +41,7 @@ import subprocess
 import tempfile
 from pathlib import Path
 from typing import List, Optional
-from urllib.parse import urlsplit
+from urllib.parse import urlsplit, urlunsplit
 
 from . import plugin_manifest
 
@@ -374,6 +374,34 @@ def _marketplace_name_from_clone(local_path: Path, repo: str) -> str:
     return _default_name(repo)
 
 
+def _strip_url_credentials(repo: str) -> str:
+    """Remove embedded credentials from an http(s) repo URL.
+
+    ``_validate_repo`` rejects credential URLs on the interactive admin-add path,
+    but env-bootstrap (``CLAUDE_PLUGIN_REPO*``) and ``known_marketplaces.json``
+    fallbacks are not validated, so a ``https://user:token@host/...`` value could
+    otherwise be persisted to the journal/manifest and returned by the admin API.
+    Strip the userinfo before storing/returning; replay credentials must come
+    from ``CLAUDE_PLUGIN_GIT_TOKEN*``, never the URL. Non-http(s) values (ssh,
+    scp-like ``git@host:org/repo``, local paths) are returned unchanged — their
+    userinfo is the ssh login, not a secret. Never raises.
+    """
+    repo = (repo or "").strip()
+    scheme = repo.split("://", 1)[0].lower() if "://" in repo else ""
+    if scheme not in ("http", "https"):
+        return repo
+    try:
+        parts = urlsplit(repo)
+    except ValueError:
+        return repo
+    if not (parts.username or parts.password):
+        return repo
+    host = parts.hostname or ""
+    if parts.port:
+        host = f"{host}:{parts.port}"
+    return urlunsplit((parts.scheme, host, parts.path, parts.query, parts.fragment))
+
+
 def _env_marketplace_record(marketplace: str) -> dict:
     """Env-bootstrap journal record (``{scope, branch, repo}``) for *marketplace*.
 
@@ -402,7 +430,14 @@ def _resolve_marketplace_repo(marketplace: str) -> str:
     ``~/.claude/plugins/known_marketplaces.json`` (converting a GitHub
     ``owner/repo`` shorthand to a clone URL) for env/externally-added
     marketplaces. Returns ``""`` when nothing replayable is found. Never raises.
+
+    Any embedded http(s) credential is stripped before returning, since the
+    result is persisted to the manifest and surfaced by the admin API.
     """
+    return _strip_url_credentials(_resolve_marketplace_repo_raw(marketplace))
+
+
+def _resolve_marketplace_repo_raw(marketplace: str) -> str:
     if not marketplace:
         return ""
     record = plugin_manifest.get_marketplace(marketplace)

--- a/src/plugin_admin_service.py
+++ b/src/plugin_admin_service.py
@@ -337,18 +337,43 @@ def prepare_repo(repo: str, *, branch: str, token: str, root: Path) -> Path:
 # ---------------------------------------------------------------------------
 
 
+def _marketplace_name_from_clone(local_path: Path, repo: str) -> str:
+    """Read the marketplace name from a clone's ``marketplace.json``.
+
+    This is the name ``claude`` keys the marketplace under, so it matches what a
+    catalog install passes. Falls back to the repo basename. Never raises.
+    """
+    try:
+        catalog = json.loads(
+            (local_path / ".claude-plugin" / "marketplace.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        name = str(catalog.get("name", "")).strip()
+        if name:
+            return name
+    except (OSError, ValueError, AttributeError):
+        pass
+    return _default_name(repo)
+
+
 def _resolve_marketplace_repo(marketplace: str) -> str:
     """Best-effort: resolve a registered marketplace name to a clonable repo.
 
     Used so a plugin installed from a *catalog* (where the caller supplies only a
     marketplace name, not a repo) still records a replayable ``repo`` in the
-    manifest. Reads ``~/.claude/plugins/known_marketplaces.json`` and converts a
-    GitHub ``owner/repo`` shorthand into a full clone URL. Returns ``""`` when the
-    marketplace is unknown or its source cannot be turned into something the
-    startup installer can clone/add. Never raises.
+    manifest. The admin-managed manifest record is authoritative — it preserves
+    the original remote even though ``claude plugin marketplace add`` is handed a
+    local clone path and records ``source: directory``. Falls back to
+    ``~/.claude/plugins/known_marketplaces.json`` (converting a GitHub
+    ``owner/repo`` shorthand to a clone URL) for env/externally-added
+    marketplaces. Returns ``""`` when nothing replayable is found. Never raises.
     """
     if not marketplace:
         return ""
+    record = plugin_manifest.get_marketplace(marketplace)
+    if record.get("repo", "").strip():
+        return record["repo"].strip()
     home = os.environ.get("HOME", "").strip() or str(Path.home())
     known = Path(home) / ".claude" / "plugins" / "known_marketplaces.json"
     try:
@@ -409,9 +434,16 @@ def add_marketplace(
             f"(scope {scope}): rc={exc.returncode}"
         ) from exc
 
+    # Record the ORIGINAL repo/branch/scope keyed by the marketplace's own name.
+    # claude only persists the local clone path (source: directory), so this is
+    # the only place the remote survives a `docker compose down -v`.
+    name = _marketplace_name_from_clone(Path(local_path), repo)
+    plugin_manifest.set_marketplace(name, repo=repo, branch=branch, scope=scope)
+
     return {
         "status": "added",
         "repo": repo,
+        "marketplace": name,
         "path": str(local_path),
         "branch": branch,
         "scope": scope,
@@ -489,9 +521,15 @@ def install_plugin(
         pass
 
     # For a catalog install the caller passes only a marketplace name; resolve
-    # its repo so the manifest entry is replayable by the startup installer
-    # (which skips entries that carry no repo).
-    manifest_repo = repo or _resolve_marketplace_repo(marketplace)
+    # its repo (and branch) from the manifest record so the entry is replayable
+    # by the startup installer (which skips entries that carry no repo).
+    manifest_repo = repo
+    manifest_branch = branch
+    if not manifest_repo and marketplace:
+        manifest_repo = _resolve_marketplace_repo(marketplace)
+        record = plugin_manifest.get_marketplace(marketplace)
+        if record.get("branch", "").strip():
+            manifest_branch = record["branch"].strip()
     if not manifest_repo:
         logger.warning(
             "could not resolve a repo for marketplace %r; manifest entry for %r "
@@ -505,7 +543,7 @@ def install_plugin(
         name=name,
         marketplace=marketplace,
         scope=scope,
-        branch=branch,
+        branch=manifest_branch,
     )
 
     return {

--- a/src/plugin_manifest.py
+++ b/src/plugin_manifest.py
@@ -8,6 +8,11 @@ container start). The admin panel mutates it at runtime; startup replays it.
   them (survives a wipe of the plugin cache volume).
 - ``removed`` = specs the admin uninstalled that ALSO came from the env
   bootstrap, so startup uninstalls them and skips reinstall.
+- ``marketplaces`` = the original remote/branch/scope the admin used to add each
+  marketplace, keyed by marketplace name. ``claude plugin marketplace add`` is
+  given a local clone path and records ``source: directory`` (losing the
+  remote), so this map is the authoritative record for replay and for telling
+  the UI a marketplace's scope.
 
 The file is JSON at ``CLAUDE_PLUGIN_MANIFEST`` (or ``<project>/data/
 gateway-plugins.json``). ``load()`` never raises; ``save()`` is atomic
@@ -39,7 +44,7 @@ def manifest_path() -> Path:
 
 
 def _defaults() -> dict:
-    return {"version": 1, "added": [], "removed": []}
+    return {"version": 1, "added": [], "removed": [], "marketplaces": {}}
 
 
 def load() -> dict:
@@ -65,10 +70,22 @@ def load() -> dict:
         removed = []
     else:
         removed = [s for s in removed if isinstance(s, str)]
+    marketplaces = data.get("marketplaces")
+    if not isinstance(marketplaces, dict):
+        marketplaces = {}
+    else:
+        marketplaces = {
+            k: v for k, v in marketplaces.items() if isinstance(v, dict)
+        }
     version = data.get("version")
     if not isinstance(version, int):
         version = 1
-    return {"version": version, "added": added, "removed": removed}
+    return {
+        "version": version,
+        "added": added,
+        "removed": removed,
+        "marketplaces": marketplaces,
+    }
 
 
 def save(data: dict) -> None:
@@ -147,10 +164,34 @@ def unmark_removed(spec: str) -> None:
 
 
 def remove_marketplace_entries(marketplace: str) -> None:
-    """Drop all ``added`` entries belonging to ``marketplace``."""
+    """Drop a marketplace's ``added`` entries and its marketplace record."""
     data = load()
     data["added"] = [e for e in data["added"] if e.get("marketplace") != marketplace]
+    data["marketplaces"].pop(marketplace, None)
     save(data)
+
+
+def set_marketplace(name: str, *, repo: str, branch: str, scope: str) -> None:
+    """Record the original remote/branch/scope an admin used to add a marketplace.
+
+    This preserves the remote even though ``claude plugin marketplace add`` is
+    given a local clone path (and records ``source: directory``), so startup can
+    re-clone it after a volume wipe and the UI knows the marketplace's scope.
+    """
+    data = load()
+    data["marketplaces"][name] = {"repo": repo, "branch": branch, "scope": scope}
+    save(data)
+
+
+def get_marketplace(name: str) -> dict:
+    """Return the marketplace record for ``name`` (empty dict if absent)."""
+    rec = load()["marketplaces"].get(name)
+    return rec if isinstance(rec, dict) else {}
+
+
+def list_marketplace_records() -> dict:
+    """Return the full marketplace-name -> record map."""
+    return load()["marketplaces"]
 
 
 def list_added() -> list:

--- a/src/plugin_manifest.py
+++ b/src/plugin_manifest.py
@@ -25,11 +25,15 @@ import logging
 import os
 import tempfile
 from pathlib import Path
-from threading import Lock
+from threading import RLock
 
 logger = logging.getLogger(__name__)
 
-_lock = Lock()
+# Reentrant so a mutator can hold the lock across its whole read-modify-write
+# while still calling save() (which re-acquires it). This serializes concurrent
+# admin mutations — run_in_threadpool can issue several at once — so two requests
+# can't both read the same manifest and clobber each other's entry.
+_lock = RLock()
 
 _DATA_DIR = Path(__file__).resolve().parent.parent / "data"
 _DEFAULT_PATH = _DATA_DIR / "gateway-plugins.json"
@@ -125,50 +129,57 @@ def add_plugin(
         "scope": scope,
         "branch": branch,
     }
-    data = load()
-    added = [
-        e
-        for e in data["added"]
-        if spec_for(e.get("name", ""), e.get("marketplace", "")) != spec
-    ]
-    added.append(entry)
-    data["added"] = added
-    data["removed"] = [s for s in data["removed"] if s != spec]
-    save(data)
+    with _lock:
+        data = load()
+        added = [
+            e
+            for e in data["added"]
+            if spec_for(e.get("name", ""), e.get("marketplace", "")) != spec
+        ]
+        added.append(entry)
+        data["added"] = added
+        data["removed"] = [s for s in data["removed"] if s != spec]
+        save(data)
 
 
 def remove_added(spec: str) -> None:
     """Drop the ``added`` entry matching ``spec`` (no-op if absent)."""
-    data = load()
-    data["added"] = [
-        e
-        for e in data["added"]
-        if spec_for(e.get("name", ""), e.get("marketplace", "")) != spec
-    ]
-    save(data)
+    with _lock:
+        data = load()
+        data["added"] = [
+            e
+            for e in data["added"]
+            if spec_for(e.get("name", ""), e.get("marketplace", "")) != spec
+        ]
+        save(data)
 
 
 def mark_removed(spec: str) -> None:
     """Record ``spec`` as admin-removed (idempotent)."""
-    data = load()
-    if spec not in data["removed"]:
-        data["removed"].append(spec)
-    save(data)
+    with _lock:
+        data = load()
+        if spec not in data["removed"]:
+            data["removed"].append(spec)
+        save(data)
 
 
 def unmark_removed(spec: str) -> None:
     """Clear the admin-removed mark for ``spec`` (idempotent)."""
-    data = load()
-    data["removed"] = [s for s in data["removed"] if s != spec]
-    save(data)
+    with _lock:
+        data = load()
+        data["removed"] = [s for s in data["removed"] if s != spec]
+        save(data)
 
 
 def remove_marketplace_entries(marketplace: str) -> None:
     """Drop a marketplace's ``added`` entries and its marketplace record."""
-    data = load()
-    data["added"] = [e for e in data["added"] if e.get("marketplace") != marketplace]
-    data["marketplaces"].pop(marketplace, None)
-    save(data)
+    with _lock:
+        data = load()
+        data["added"] = [
+            e for e in data["added"] if e.get("marketplace") != marketplace
+        ]
+        data["marketplaces"].pop(marketplace, None)
+        save(data)
 
 
 def set_marketplace(name: str, *, repo: str, branch: str, scope: str) -> None:
@@ -178,9 +189,10 @@ def set_marketplace(name: str, *, repo: str, branch: str, scope: str) -> None:
     given a local clone path (and records ``source: directory``), so startup can
     re-clone it after a volume wipe and the UI knows the marketplace's scope.
     """
-    data = load()
-    data["marketplaces"][name] = {"repo": repo, "branch": branch, "scope": scope}
-    save(data)
+    with _lock:
+        data = load()
+        data["marketplaces"][name] = {"repo": repo, "branch": branch, "scope": scope}
+        save(data)
 
 
 def get_marketplace(name: str) -> dict:

--- a/src/plugin_manifest.py
+++ b/src/plugin_manifest.py
@@ -51,6 +51,26 @@ def _defaults() -> dict:
     return {"version": 1, "added": [], "removed": [], "marketplaces": {}}
 
 
+def _normalize_removed(removed) -> list:
+    """Coerce ``removed`` into a list of ``{"spec","scope"}`` dicts.
+
+    scope is part of a plugin's identity (claude stores one registry entry per
+    scope), so a removal must remember which scope it targeted. Legacy spec-only
+    strings are read as ``user`` scope for backward tolerance.
+    """
+    if not isinstance(removed, list):
+        return []
+    out = []
+    for r in removed:
+        if isinstance(r, dict) and isinstance(r.get("spec"), str) and r["spec"]:
+            scope = r.get("scope")
+            scope = scope if isinstance(scope, str) and scope else "user"
+            out.append({"spec": r["spec"], "scope": scope})
+        elif isinstance(r, str) and r:
+            out.append({"spec": r, "scope": "user"})
+    return out
+
+
 def load() -> dict:
     """Return a well-formed manifest; corrupt/missing -> defaults, never raises."""
     path = manifest_path()
@@ -70,10 +90,7 @@ def load() -> dict:
         added = []
     else:
         added = [e for e in added if isinstance(e, dict)]
-    if not isinstance(removed, list):
-        removed = []
-    else:
-        removed = [s for s in removed if isinstance(s, str)]
+    removed = _normalize_removed(removed)
     marketplaces = data.get("marketplaces")
     if not isinstance(marketplaces, dict):
         marketplaces = {}
@@ -134,40 +151,60 @@ def add_plugin(
         added = [
             e
             for e in data["added"]
-            if spec_for(e.get("name", ""), e.get("marketplace", "")) != spec
+            if not (
+                spec_for(e.get("name", ""), e.get("marketplace", "")) == spec
+                and e.get("scope") == scope
+            )
         ]
         added.append(entry)
         data["added"] = added
-        data["removed"] = [s for s in data["removed"] if s != spec]
+        data["removed"] = [
+            r
+            for r in data["removed"]
+            if not (r["spec"] == spec and r["scope"] == scope)
+        ]
         save(data)
 
 
-def remove_added(spec: str) -> None:
-    """Drop the ``added`` entry matching ``spec`` (no-op if absent)."""
+def remove_added(spec: str, scope: str) -> None:
+    """Drop the ``added`` entry matching (``spec``, ``scope``); no-op if absent.
+
+    scope is part of the identity: the same plugin can be installed at more than
+    one scope, each a distinct managed entry.
+    """
     with _lock:
         data = load()
         data["added"] = [
             e
             for e in data["added"]
-            if spec_for(e.get("name", ""), e.get("marketplace", "")) != spec
+            if not (
+                spec_for(e.get("name", ""), e.get("marketplace", "")) == spec
+                and e.get("scope") == scope
+            )
         ]
         save(data)
 
 
-def mark_removed(spec: str) -> None:
-    """Record ``spec`` as admin-removed (idempotent)."""
+def mark_removed(spec: str, scope: str) -> None:
+    """Record (``spec``, ``scope``) as admin-removed (idempotent)."""
     with _lock:
         data = load()
-        if spec not in data["removed"]:
-            data["removed"].append(spec)
+        if not any(
+            r["spec"] == spec and r["scope"] == scope for r in data["removed"]
+        ):
+            data["removed"].append({"spec": spec, "scope": scope})
         save(data)
 
 
-def unmark_removed(spec: str) -> None:
-    """Clear the admin-removed mark for ``spec`` (idempotent)."""
+def unmark_removed(spec: str, scope: str) -> None:
+    """Clear the admin-removed mark for (``spec``, ``scope``) (idempotent)."""
     with _lock:
         data = load()
-        data["removed"] = [s for s in data["removed"] if s != spec]
+        data["removed"] = [
+            r
+            for r in data["removed"]
+            if not (r["spec"] == spec and r["scope"] == scope)
+        ]
         save(data)
 
 

--- a/src/plugin_manifest.py
+++ b/src/plugin_manifest.py
@@ -1,0 +1,163 @@
+"""Persistent managed plugin manifest.
+
+The manifest is the admin-managed layer that sits on top of the env-var
+bootstrap (``CLAUDE_PLUGIN_*`` read by ``docker/install_plugins.py`` at
+container start). The admin panel mutates it at runtime; startup replays it.
+
+- ``added``  = plugins the admin explicitly installed, so startup reinstalls
+  them (survives a wipe of the plugin cache volume).
+- ``removed`` = specs the admin uninstalled that ALSO came from the env
+  bootstrap, so startup uninstalls them and skips reinstall.
+
+The file is JSON at ``CLAUDE_PLUGIN_MANIFEST`` (or ``<project>/data/
+gateway-plugins.json``). ``load()`` never raises; ``save()`` is atomic
+(temp file in the same directory + ``os.replace``) so a partial write can
+never corrupt the manifest under a Docker bind mount.
+"""
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+from threading import Lock
+
+logger = logging.getLogger(__name__)
+
+_lock = Lock()
+
+_DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+_DEFAULT_PATH = _DATA_DIR / "gateway-plugins.json"
+
+
+def manifest_path() -> Path:
+    """Resolve the manifest path (env override > project ``data/`` default)."""
+    override = os.getenv("CLAUDE_PLUGIN_MANIFEST")
+    if override:
+        return Path(override)
+    return _DEFAULT_PATH
+
+
+def _defaults() -> dict:
+    return {"version": 1, "added": [], "removed": []}
+
+
+def load() -> dict:
+    """Return a well-formed manifest; corrupt/missing -> defaults, never raises."""
+    path = manifest_path()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return _defaults()
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning("Failed to load plugin manifest, using defaults: %s", e)
+        return _defaults()
+    if not isinstance(data, dict):
+        logger.warning("Plugin manifest is not an object, using defaults")
+        return _defaults()
+    added = data.get("added")
+    removed = data.get("removed")
+    if not isinstance(added, list):
+        added = []
+    else:
+        added = [e for e in added if isinstance(e, dict)]
+    if not isinstance(removed, list):
+        removed = []
+    else:
+        removed = [s for s in removed if isinstance(s, str)]
+    version = data.get("version")
+    if not isinstance(version, int):
+        version = 1
+    return {"version": version, "added": added, "removed": removed}
+
+
+def save(data: dict) -> None:
+    """Atomically persist the manifest (temp file in the same dir + replace)."""
+    path = manifest_path()
+    with _lock:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(
+            dir=str(path.parent), prefix=path.name + ".", suffix=".tmp"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(data, f, ensure_ascii=False, indent=2)
+            os.replace(tmp, path)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+
+
+def spec_for(name: str, marketplace: str) -> str:
+    """``name@marketplace`` when marketplace is truthy, else ``name``."""
+    return f"{name}@{marketplace}" if marketplace else name
+
+
+def add_plugin(
+    *, repo: str, name: str, marketplace: str, scope: str, branch: str
+) -> None:
+    """Upsert an entry into ``added`` keyed by spec; clears any ``removed`` mark."""
+    spec = spec_for(name, marketplace)
+    entry = {
+        "repo": repo,
+        "name": name,
+        "marketplace": marketplace,
+        "scope": scope,
+        "branch": branch,
+    }
+    data = load()
+    added = [
+        e
+        for e in data["added"]
+        if spec_for(e.get("name", ""), e.get("marketplace", "")) != spec
+    ]
+    added.append(entry)
+    data["added"] = added
+    data["removed"] = [s for s in data["removed"] if s != spec]
+    save(data)
+
+
+def remove_added(spec: str) -> None:
+    """Drop the ``added`` entry matching ``spec`` (no-op if absent)."""
+    data = load()
+    data["added"] = [
+        e
+        for e in data["added"]
+        if spec_for(e.get("name", ""), e.get("marketplace", "")) != spec
+    ]
+    save(data)
+
+
+def mark_removed(spec: str) -> None:
+    """Record ``spec`` as admin-removed (idempotent)."""
+    data = load()
+    if spec not in data["removed"]:
+        data["removed"].append(spec)
+    save(data)
+
+
+def unmark_removed(spec: str) -> None:
+    """Clear the admin-removed mark for ``spec`` (idempotent)."""
+    data = load()
+    data["removed"] = [s for s in data["removed"] if s != spec]
+    save(data)
+
+
+def remove_marketplace_entries(marketplace: str) -> None:
+    """Drop all ``added`` entries belonging to ``marketplace``."""
+    data = load()
+    data["added"] = [e for e in data["added"] if e.get("marketplace") != marketplace]
+    save(data)
+
+
+def list_added() -> list:
+    """Return the list of admin-installed plugin entries."""
+    return load()["added"]
+
+
+def list_removed() -> list:
+    """Return the list of admin-removed specs."""
+    return load()["removed"]

--- a/src/plugin_service.py
+++ b/src/plugin_service.py
@@ -214,19 +214,21 @@ def _load_installed_registry() -> Dict[str, Any]:
 
 
 def _managed_plugin_ids() -> set:
-    """Return the set of admin-managed plugin ids (``name@marketplace``).
+    """Return the set of admin-managed ``(spec, scope)`` keys.
 
-    Sourced from :mod:`src.plugin_manifest`'s ``list_added``.  Imported
-    lazily so a manifest import/load failure never breaks plugin listing;
-    returns an empty set on any error (callers then default origin to
-    ``"env"``).
+    ``spec`` is ``name@marketplace``; scope is included because the same plugin
+    can be managed at one scope and env-installed at another. Sourced from
+    :mod:`src.plugin_manifest`'s ``list_added``. Imported lazily so a manifest
+    import/load failure never breaks plugin listing; returns an empty set on any
+    error (callers then default origin to ``"env"``).
     """
     try:
         from src import plugin_manifest
 
         return {
-            plugin_manifest.spec_for(
-                r.get("name", ""), r.get("marketplace", "")
+            (
+                plugin_manifest.spec_for(r.get("name", ""), r.get("marketplace", "")),
+                r.get("scope", "user"),
             )
             for r in plugin_manifest.list_added()
             if isinstance(r, dict)
@@ -306,15 +308,21 @@ def _parse_plugin_id(plugin_key: str) -> Tuple[str, str]:
     return plugin_key, "unknown"
 
 
-def _resolve_plugin_entry(key: str, entries: list) -> Optional[Dict[str, Any]]:
+def _resolve_plugin_entry(
+    key: str, entries: list, entry_index: int = 0
+) -> Optional[Dict[str, Any]]:
     """Resolve and validate a single plugin registry entry.
 
-    Returns a dict with common fields or ``None`` if invalid.
-    Shared by :func:`list_plugins` and :func:`get_plugin_detail`.
+    The registry stores one entry per scope under a plugin id; *entry_index*
+    selects which (default the first). Returns a dict with common fields or
+    ``None`` if invalid. Shared by :func:`list_plugins` and
+    :func:`get_plugin_detail`.
     """
     if not isinstance(entries, list) or not entries:
         return None
-    entry = entries[0]
+    if entry_index < 0 or entry_index >= len(entries):
+        return None
+    entry = entries[entry_index]
     name, marketplace = _parse_plugin_id(key)
     raw_path = Path(entry.get("installPath", ""))
     install_path = _validate_install_path(raw_path)
@@ -356,26 +364,35 @@ def list_plugins() -> List[Dict[str, Any]]:
     managed = _managed_plugin_ids()
     results: List[Dict[str, Any]] = []
     for key, entries in plugins_data.items():
-        resolved = _resolve_plugin_entry(key, entries)
-        if resolved is None:
+        # claude stores one entry per scope under a plugin id; emit one row each
+        # so multi-scope installs are visible and removable at their real scope.
+        if not isinstance(entries, list):
             continue
-        results.append(
-            {
-                "id": resolved["id"],
-                "name": resolved["name"],
-                "marketplace": resolved["marketplace"],
-                "version": resolved["version"],
-                "description": resolved["description"],
-                "author": resolved["author"],
-                "scope": resolved["scope"],
-                "installed_at": resolved["installed_at"],
-                "last_updated": resolved["last_updated"],
-                "origin": "managed" if resolved["id"] in managed else "env",
-                "skills": resolved["skills"],
-                "skill_count": len(resolved["skills"]),
-                "command_count": len(resolved["commands"]),
-            }
-        )
+        for idx in range(len(entries)):
+            resolved = _resolve_plugin_entry(key, entries, idx)
+            if resolved is None:
+                continue
+            results.append(
+                {
+                    "id": resolved["id"],
+                    "name": resolved["name"],
+                    "marketplace": resolved["marketplace"],
+                    "version": resolved["version"],
+                    "description": resolved["description"],
+                    "author": resolved["author"],
+                    "scope": resolved["scope"],
+                    "installed_at": resolved["installed_at"],
+                    "last_updated": resolved["last_updated"],
+                    "origin": (
+                        "managed"
+                        if (resolved["id"], resolved["scope"]) in managed
+                        else "env"
+                    ),
+                    "skills": resolved["skills"],
+                    "skill_count": len(resolved["skills"]),
+                    "command_count": len(resolved["commands"]),
+                }
+            )
 
     return results
 
@@ -434,7 +451,9 @@ def get_plugin_detail(plugin_id: str) -> Optional[Dict[str, Any]]:
         "last_updated": resolved["last_updated"],
         "git_commit_sha": resolved["git_commit_sha"],
         "origin": (
-            "managed" if resolved["id"] in _managed_plugin_ids() else "env"
+            "managed"
+            if (resolved["id"], resolved["scope"]) in _managed_plugin_ids()
+            else "env"
         ),
         "skills": resolved["skills"],
         "commands": resolved["commands"],

--- a/src/plugin_service.py
+++ b/src/plugin_service.py
@@ -309,16 +309,21 @@ def _parse_plugin_id(plugin_key: str) -> Tuple[str, str]:
 
 
 def _entry_index_for_scope(entries: list, scope: Optional[str]) -> int:
-    """Index of the registry entry matching *scope*, or 0 when unspecified/absent.
+    """Index of the registry entry matching *scope*.
 
-    The registry stores one entry per scope under a plugin id, so a scope-aware
-    caller picks the right one rather than always reading ``entries[0]``.
+    The registry stores one entry per scope under a plugin id. With no *scope*,
+    returns the first entry (``0``). With an explicit *scope*, returns the
+    matching entry's index, or ``-1`` when no entry has that scope — so a
+    scope-specific request 404s instead of silently reading another scope's
+    install path/content.
     """
-    if scope and isinstance(entries, list):
+    if not scope:
+        return 0
+    if isinstance(entries, list):
         for i, e in enumerate(entries):
             if isinstance(e, dict) and e.get("scope") == scope:
                 return i
-    return 0
+    return -1
 
 
 def _resolve_plugin_entry(
@@ -538,12 +543,78 @@ def _marketplace_records() -> Dict[str, Any]:
         return {}
 
 
-def _marketplace_scope(marketplace_name: str, records: Optional[Dict] = None) -> str:
-    """Scope a marketplace was added at (from the manifest), defaulting to user."""
+def _env_journal_path() -> Optional[Path]:
+    """Path of the startup installer's env-bootstrap marketplace journal.
+
+    Lives beside the managed manifest; overridable with
+    ``CLAUDE_PLUGIN_ENV_JOURNAL`` (kept in sync with ``docker/install_plugins.py``).
+    """
+    configured = os.environ.get("CLAUDE_PLUGIN_ENV_JOURNAL", "").strip()
+    if configured:
+        return Path(configured)
+    try:
+        from src import plugin_manifest
+
+        return plugin_manifest.manifest_path().with_name("gateway-plugins-env.json")
+    except Exception:
+        logger.debug("Failed to resolve env journal path", exc_info=True)
+        return None
+
+
+def env_bootstrap_records() -> Dict[str, Dict[str, str]]:
+    """Marketplace name -> ``{scope, branch, repo}`` from the startup installer.
+
+    Env-bootstrapped marketplaces (``CLAUDE_PLUGIN_*``) have no admin manifest
+    record, and ``known_marketplaces.json`` persists neither their scope/branch
+    nor their original remote (a clone-then-add marketplace records only the
+    local path). ``docker/install_plugins.py`` journals that metadata, keyed by
+    the marketplace's real ``marketplace.json`` name, so the app can recover it
+    for catalog availability, install scope, and replay branch/repo. Returns
+    ``{}`` when the journal is absent/corrupt; never raises.
+    """
+    path = _env_journal_path()
+    if path is None:
+        return {}
+    data = _read_json(path)
+    if not isinstance(data, dict):
+        return {}
+    records = data.get("marketplaces")
+    if not isinstance(records, dict):
+        return {}
+    out: Dict[str, Dict[str, str]] = {}
+    for name, rec in records.items():
+        if isinstance(name, str) and name and isinstance(rec, dict):
+            out[name] = {
+                "scope": str(rec.get("scope") or "user"),
+                "branch": str(rec.get("branch") or "main"),
+                "repo": str(rec.get("repo") or ""),
+            }
+    return out
+
+
+def _marketplace_scope(
+    marketplace_name: str,
+    records: Optional[Dict] = None,
+    env_records: Optional[Dict] = None,
+) -> str:
+    """Scope a marketplace was added at, defaulting to user.
+
+    The admin manifest is authoritative; for an env-bootstrapped marketplace
+    (no manifest record) the startup installer's journal supplies the scope it
+    was added with, so catalog install/availability/delete target the right
+    scope instead of always assuming ``user``.
+    """
     if records is None:
         records = _marketplace_records()
     record = records.get(marketplace_name)
-    return record.get("scope", "user") if isinstance(record, dict) else "user"
+    if isinstance(record, dict) and record.get("scope"):
+        return record["scope"]
+    if env_records is None:
+        env_records = env_bootstrap_records()
+    env = env_records.get(marketplace_name)
+    if isinstance(env, dict) and env.get("scope"):
+        return env["scope"]
+    return "user"
 
 
 def list_marketplaces() -> List[Dict[str, Any]]:
@@ -556,12 +627,13 @@ def list_marketplaces() -> List[Dict[str, Any]]:
         return []
 
     records = _marketplace_records()
+    env_records = env_bootstrap_records()
     results: List[Dict[str, Any]] = []
     for name, info in data.items():
         if not isinstance(info, dict):
             continue
         source = info.get("source", {})
-        scope = _marketplace_scope(name, records)
+        scope = _marketplace_scope(name, records, env_records)
         results.append(
             {
                 "name": name,

--- a/src/plugin_service.py
+++ b/src/plugin_service.py
@@ -457,17 +457,31 @@ def list_marketplaces() -> List[Dict[str, Any]]:
     if not isinstance(data, dict):
         return []
 
+    # Marketplace scope is not stored in known_marketplaces.json; the admin-
+    # managed manifest is the only source of truth for it (so the UI can remove
+    # a marketplace at its real scope rather than guessing).
+    records: Dict[str, Any] = {}
+    try:
+        from src import plugin_manifest
+
+        records = plugin_manifest.list_marketplace_records()
+    except Exception:
+        logger.debug("Failed to read manifest marketplace records", exc_info=True)
+
     results: List[Dict[str, Any]] = []
     for name, info in data.items():
         if not isinstance(info, dict):
             continue
         source = info.get("source", {})
+        record = records.get(name) if isinstance(records, dict) else None
+        scope = record.get("scope", "user") if isinstance(record, dict) else "user"
         results.append(
             {
                 "name": name,
                 "source_type": source.get("source", "unknown"),
                 "repo": source.get("repo", source.get("url", "")),
                 "last_updated": info.get("lastUpdated"),
+                "scope": scope,
             }
         )
     return results

--- a/src/plugin_service.py
+++ b/src/plugin_service.py
@@ -123,6 +123,48 @@ def _validate_install_path(install_path: Path) -> Optional[Path]:
     return resolved if resolved.is_dir() else None
 
 
+def _validate_marketplace_path(install_location: Path) -> Optional[Path]:
+    """Validate *install_location* resolves within ``plugins/marketplaces``.
+
+    Analogous to :func:`_validate_install_path` but anchored at
+    ``~/.claude/plugins/marketplaces``.  Returns the resolved path, or
+    ``None`` if the path is a symlink (leaf or parent), escapes the
+    marketplaces tree, or does not exist as a directory.
+    """
+    root = _plugins_root()
+    if root is None:
+        return None
+    mkt_dir = root / "marketplaces"
+    try:
+        resolved = install_location.resolve()
+        resolved.relative_to(mkt_dir.resolve())
+    except (ValueError, OSError):
+        logger.warning(
+            "Marketplace installLocation outside marketplaces: %s",
+            install_location,
+        )
+        return None
+    if install_location.is_symlink():
+        return None
+    # Reject a symlinked PARENT component (see _validate_install_path).
+    try:
+        mkt_anchor = mkt_dir.resolve()
+    except OSError:
+        return None
+    for parent in install_location.parents:
+        try:
+            if parent.resolve() == mkt_anchor:
+                break
+        except OSError:
+            return None
+        if parent.is_symlink():
+            logger.warning(
+                "Marketplace installLocation has symlinked parent: %s", parent
+            )
+            return None
+    return resolved if resolved.is_dir() else None
+
+
 # ---------------------------------------------------------------------------
 # Installed plugins registry
 # ---------------------------------------------------------------------------
@@ -137,6 +179,29 @@ def _load_installed_registry() -> Dict[str, Any]:
     if not isinstance(data, dict):
         return {}
     return data
+
+
+def _managed_plugin_ids() -> set:
+    """Return the set of admin-managed plugin ids (``name@marketplace``).
+
+    Sourced from :mod:`src.plugin_manifest`'s ``list_added``.  Imported
+    lazily so a manifest import/load failure never breaks plugin listing;
+    returns an empty set on any error (callers then default origin to
+    ``"env"``).
+    """
+    try:
+        from src import plugin_manifest
+
+        return {
+            plugin_manifest.spec_for(
+                r.get("name", ""), r.get("marketplace", "")
+            )
+            for r in plugin_manifest.list_added()
+            if isinstance(r, dict)
+        }
+    except Exception:  # pragma: no cover - defensive
+        logger.debug("Failed to load managed plugin manifest", exc_info=True)
+        return set()
 
 
 def _load_manifest(install_path: Path) -> Dict[str, Any]:
@@ -256,6 +321,7 @@ def list_plugins() -> List[Dict[str, Any]]:
     if not isinstance(plugins_data, dict):
         return []
 
+    managed = _managed_plugin_ids()
     results: List[Dict[str, Any]] = []
     for key, entries in plugins_data.items():
         resolved = _resolve_plugin_entry(key, entries)
@@ -272,6 +338,7 @@ def list_plugins() -> List[Dict[str, Any]]:
                 "scope": resolved["scope"],
                 "installed_at": resolved["installed_at"],
                 "last_updated": resolved["last_updated"],
+                "origin": "managed" if resolved["id"] in managed else "env",
                 "skills": resolved["skills"],
                 "skill_count": len(resolved["skills"]),
                 "command_count": len(resolved["commands"]),
@@ -334,6 +401,9 @@ def get_plugin_detail(plugin_id: str) -> Optional[Dict[str, Any]]:
         "installed_at": resolved["installed_at"],
         "last_updated": resolved["last_updated"],
         "git_commit_sha": resolved["git_commit_sha"],
+        "origin": (
+            "managed" if resolved["id"] in _managed_plugin_ids() else "env"
+        ),
         "skills": resolved["skills"],
         "commands": resolved["commands"],
         "has_hooks": has_hooks,
@@ -400,6 +470,81 @@ def list_marketplaces() -> List[Dict[str, Any]]:
                 "last_updated": info.get("lastUpdated"),
             }
         )
+    return results
+
+
+def list_marketplace_plugins(marketplace_name: str) -> List[Dict[str, Any]]:
+    """Return the plugins a marketplace offers in its catalog.
+
+    Resolves ``installLocation`` from ``known_marketplaces.json``, validates
+    it, and parses ``<installLocation>/.claude-plugin/marketplace.json``.
+    Each returned dict marks whether the catalog entry is already installed
+    (against ``installed_plugins.json``).  Tolerates a missing marketplace,
+    missing/corrupt catalog, or bad paths by returning ``[]`` — never raises.
+    """
+    root = _plugins_root()
+    if root is None:
+        return []
+    known = _read_json(root / "known_marketplaces.json")
+    if not isinstance(known, dict):
+        return []
+    info = known.get(marketplace_name)
+    if not isinstance(info, dict):
+        return []
+    raw_location = info.get("installLocation")
+    if not isinstance(raw_location, str) or not raw_location:
+        return []
+    location = _validate_marketplace_path(Path(raw_location))
+    if location is None:
+        return []
+
+    catalog = _read_json(location / ".claude-plugin" / "marketplace.json")
+    if not isinstance(catalog, dict):
+        return []
+    plugins = catalog.get("plugins")
+    if not isinstance(plugins, list):
+        return []
+
+    installed_keys = set()
+    registry = _load_installed_registry()
+    plugins_data = registry.get("plugins", {})
+    if isinstance(plugins_data, dict):
+        installed_keys = set(plugins_data.keys())
+
+    results: List[Dict[str, Any]] = []
+    for entry in plugins:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        version = entry.get("version")
+        skills = entry.get("skills")
+        plugin_id = f"{name}@{marketplace_name}"
+        results.append(
+            {
+                "name": name,
+                "description": entry.get("description", ""),
+                "version": version if isinstance(version, str) else "",
+                "skill_count": len(skills) if isinstance(skills, list) else 0,
+                "id": plugin_id,
+                "installed": plugin_id in installed_keys,
+            }
+        )
+    return results
+
+
+def get_marketplaces_with_plugins() -> List[Dict[str, Any]]:
+    """Return each marketplace augmented with its catalog plugins.
+
+    Convenience aggregate the admin UI can render in one call: every
+    :func:`list_marketplaces` entry gets a ``plugins`` list (from
+    :func:`list_marketplace_plugins`) and a ``plugin_count``.
+    """
+    results: List[Dict[str, Any]] = []
+    for mkt in list_marketplaces():
+        plugins = list_marketplace_plugins(mkt["name"])
+        results.append({**mkt, "plugins": plugins, "plugin_count": len(plugins)})
     return results
 
 

--- a/src/plugin_service.py
+++ b/src/plugin_service.py
@@ -617,6 +617,34 @@ def _marketplace_scope(
     return "user"
 
 
+def _strip_url_credentials(repo: str) -> str:
+    """Remove embedded credentials from an http(s) repo URL before returning it.
+
+    ``known_marketplaces.json`` may hold a ``https://user:token@host/...`` source
+    (e.g. an externally-run ``claude plugin marketplace add`` with a credential
+    URL). The marketplace listing/catalog API surfaces this ``repo`` field, so the
+    userinfo must be stripped — a secret must never appear in an API response.
+    Non-http(s) values (ssh, scp-like ``git@host:org/repo``, local paths) are
+    returned unchanged; their userinfo is the ssh login, not a secret.
+    """
+    repo = (repo or "").strip()
+    scheme = repo.split("://", 1)[0].lower() if "://" in repo else ""
+    if scheme not in ("http", "https"):
+        return repo
+    try:
+        from urllib.parse import urlsplit, urlunsplit
+
+        parts = urlsplit(repo)
+    except ValueError:
+        return repo
+    if not (parts.username or parts.password):
+        return repo
+    host = parts.hostname or ""
+    if parts.port:
+        host = f"{host}:{parts.port}"
+    return urlunsplit((parts.scheme, host, parts.path, parts.query, parts.fragment))
+
+
 def list_marketplaces() -> List[Dict[str, Any]]:
     """Return registered marketplace sources."""
     root = _plugins_root()
@@ -638,7 +666,9 @@ def list_marketplaces() -> List[Dict[str, Any]]:
             {
                 "name": name,
                 "source_type": source.get("source", "unknown"),
-                "repo": source.get("repo", source.get("url", "")),
+                "repo": _strip_url_credentials(
+                    source.get("repo", source.get("url", ""))
+                ),
                 "last_updated": info.get("lastUpdated"),
                 "scope": scope,
             }

--- a/src/plugin_service.py
+++ b/src/plugin_service.py
@@ -511,6 +511,13 @@ def list_marketplace_plugins(marketplace_name: str) -> List[Dict[str, Any]]:
     if isinstance(plugins_data, dict):
         installed_keys = set(plugins_data.keys())
 
+    def _installed_scope(key: str) -> str:
+        """Scope of an installed plugin from the registry, defaulting to user."""
+        entries = plugins_data.get(key) if isinstance(plugins_data, dict) else None
+        if isinstance(entries, list) and entries and isinstance(entries[0], dict):
+            return entries[0].get("scope", "user")
+        return "user"
+
     results: List[Dict[str, Any]] = []
     for entry in plugins:
         if not isinstance(entry, dict):
@@ -521,6 +528,7 @@ def list_marketplace_plugins(marketplace_name: str) -> List[Dict[str, Any]]:
         version = entry.get("version")
         skills = entry.get("skills")
         plugin_id = f"{name}@{marketplace_name}"
+        installed = plugin_id in installed_keys
         results.append(
             {
                 "name": name,
@@ -528,7 +536,8 @@ def list_marketplace_plugins(marketplace_name: str) -> List[Dict[str, Any]]:
                 "version": version if isinstance(version, str) else "",
                 "skill_count": len(skills) if isinstance(skills, list) else 0,
                 "id": plugin_id,
-                "installed": plugin_id in installed_keys,
+                "installed": installed,
+                "scope": _installed_scope(plugin_id) if installed else "user",
             }
         )
     return results

--- a/src/plugin_service.py
+++ b/src/plugin_service.py
@@ -308,6 +308,19 @@ def _parse_plugin_id(plugin_key: str) -> Tuple[str, str]:
     return plugin_key, "unknown"
 
 
+def _entry_index_for_scope(entries: list, scope: Optional[str]) -> int:
+    """Index of the registry entry matching *scope*, or 0 when unspecified/absent.
+
+    The registry stores one entry per scope under a plugin id, so a scope-aware
+    caller picks the right one rather than always reading ``entries[0]``.
+    """
+    if scope and isinstance(entries, list):
+        for i, e in enumerate(entries):
+            if isinstance(e, dict) and e.get("scope") == scope:
+                return i
+    return 0
+
+
 def _resolve_plugin_entry(
     key: str, entries: list, entry_index: int = 0
 ) -> Optional[Dict[str, Any]]:
@@ -397,16 +410,21 @@ def list_plugins() -> List[Dict[str, Any]]:
     return results
 
 
-def get_plugin_detail(plugin_id: str) -> Optional[Dict[str, Any]]:
+def get_plugin_detail(
+    plugin_id: str, scope: Optional[str] = None
+) -> Optional[Dict[str, Any]]:
     """Return full detail for a single installed plugin.
 
-    *plugin_id* is the registry key (e.g. ``octo@nyldn-plugins``).
+    *plugin_id* is the registry key (e.g. ``octo@nyldn-plugins``); *scope*
+    selects which per-scope registry entry to read (defaults to the first).
     Returns ``None`` if the plugin is not found.
     """
     registry = _load_installed_registry()
     plugins_data = registry.get("plugins", {})
     entries = plugins_data.get(plugin_id)
-    resolved = _resolve_plugin_entry(plugin_id, entries)
+    resolved = _resolve_plugin_entry(
+        plugin_id, entries, _entry_index_for_scope(entries, scope)
+    )
     if resolved is None:
         return None
 
@@ -463,19 +481,24 @@ def get_plugin_detail(plugin_id: str) -> Optional[Dict[str, Any]]:
     }
 
 
-def get_plugin_skill_content(plugin_id: str, skill_name: str) -> Optional[Dict[str, Any]]:
+def get_plugin_skill_content(
+    plugin_id: str, skill_name: str, scope: Optional[str] = None
+) -> Optional[Dict[str, Any]]:
     """Read the content of a specific skill from a plugin.
 
-    Returns ``None`` if plugin or skill not found.
+    *scope* selects which per-scope registry entry to read from (the install
+    path can differ by scope). Returns ``None`` if plugin or skill not found.
     """
-    detail = get_plugin_detail(plugin_id)
+    detail = get_plugin_detail(plugin_id, scope)
     if detail is None:
         return None
 
     # Re-resolve install_path through validation
     registry = _load_installed_registry()
     entries = registry.get("plugins", {}).get(plugin_id)
-    resolved = _resolve_plugin_entry(plugin_id, entries)
+    resolved = _resolve_plugin_entry(
+        plugin_id, entries, _entry_index_for_scope(entries, scope)
+    )
     if resolved is None or resolved["install_path"] is None:
         return None
     install_path = resolved["install_path"]
@@ -499,6 +522,30 @@ def get_plugin_skill_content(plugin_id: str, skill_name: str) -> Optional[Dict[s
     }
 
 
+def _marketplace_records() -> Dict[str, Any]:
+    """Return the manifest's marketplace-name -> record map (``{}`` on failure).
+
+    The admin-managed manifest is the only source of truth for a marketplace's
+    scope — ``known_marketplaces.json`` does not store it.
+    """
+    try:
+        from src import plugin_manifest
+
+        records = plugin_manifest.list_marketplace_records()
+        return records if isinstance(records, dict) else {}
+    except Exception:
+        logger.debug("Failed to read manifest marketplace records", exc_info=True)
+        return {}
+
+
+def _marketplace_scope(marketplace_name: str, records: Optional[Dict] = None) -> str:
+    """Scope a marketplace was added at (from the manifest), defaulting to user."""
+    if records is None:
+        records = _marketplace_records()
+    record = records.get(marketplace_name)
+    return record.get("scope", "user") if isinstance(record, dict) else "user"
+
+
 def list_marketplaces() -> List[Dict[str, Any]]:
     """Return registered marketplace sources."""
     root = _plugins_root()
@@ -508,24 +555,13 @@ def list_marketplaces() -> List[Dict[str, Any]]:
     if not isinstance(data, dict):
         return []
 
-    # Marketplace scope is not stored in known_marketplaces.json; the admin-
-    # managed manifest is the only source of truth for it (so the UI can remove
-    # a marketplace at its real scope rather than guessing).
-    records: Dict[str, Any] = {}
-    try:
-        from src import plugin_manifest
-
-        records = plugin_manifest.list_marketplace_records()
-    except Exception:
-        logger.debug("Failed to read manifest marketplace records", exc_info=True)
-
+    records = _marketplace_records()
     results: List[Dict[str, Any]] = []
     for name, info in data.items():
         if not isinstance(info, dict):
             continue
         source = info.get("source", {})
-        record = records.get(name) if isinstance(records, dict) else None
-        scope = record.get("scope", "user") if isinstance(record, dict) else "user"
+        scope = _marketplace_scope(name, records)
         results.append(
             {
                 "name": name,
@@ -543,9 +579,11 @@ def list_marketplace_plugins(marketplace_name: str) -> List[Dict[str, Any]]:
 
     Resolves ``installLocation`` from ``known_marketplaces.json``, validates
     it, and parses ``<installLocation>/.claude-plugin/marketplace.json``.
-    Each returned dict marks whether the catalog entry is already installed
-    (against ``installed_plugins.json``).  Tolerates a missing marketplace,
-    missing/corrupt catalog, or bad paths by returning ``[]`` — never raises.
+    ``installed`` is judged at the marketplace's OWN scope (the scope a catalog
+    install would target), so a plugin present only at another scope still shows
+    as available; ``scope`` echoes that marketplace scope. Tolerates a missing
+    marketplace, missing/corrupt catalog, or bad paths by returning ``[]`` —
+    never raises.
     """
     root = _plugins_root()
     if root is None:
@@ -570,18 +608,18 @@ def list_marketplace_plugins(marketplace_name: str) -> List[Dict[str, Any]]:
     if not isinstance(plugins, list):
         return []
 
-    installed_keys = set()
+    # Availability is judged at the marketplace's own scope (the scope a catalog
+    # install targets), since scope is part of a plugin's identity.
+    mkt_scope = _marketplace_scope(marketplace_name)
+    installed_scoped = set()
     registry = _load_installed_registry()
     plugins_data = registry.get("plugins", {})
     if isinstance(plugins_data, dict):
-        installed_keys = set(plugins_data.keys())
-
-    def _installed_scope(key: str) -> str:
-        """Scope of an installed plugin from the registry, defaulting to user."""
-        entries = plugins_data.get(key) if isinstance(plugins_data, dict) else None
-        if isinstance(entries, list) and entries and isinstance(entries[0], dict):
-            return entries[0].get("scope", "user")
-        return "user"
+        for key, entries in plugins_data.items():
+            if isinstance(entries, list):
+                for e in entries:
+                    if isinstance(e, dict):
+                        installed_scoped.add((key, e.get("scope", "user")))
 
     results: List[Dict[str, Any]] = []
     for entry in plugins:
@@ -593,7 +631,6 @@ def list_marketplace_plugins(marketplace_name: str) -> List[Dict[str, Any]]:
         version = entry.get("version")
         skills = entry.get("skills")
         plugin_id = f"{name}@{marketplace_name}"
-        installed = plugin_id in installed_keys
         results.append(
             {
                 "name": name,
@@ -601,8 +638,8 @@ def list_marketplace_plugins(marketplace_name: str) -> List[Dict[str, Any]]:
                 "version": version if isinstance(version, str) else "",
                 "skill_count": len(skills) if isinstance(skills, list) else 0,
                 "id": plugin_id,
-                "installed": installed,
-                "scope": _installed_scope(plugin_id) if installed else "user",
+                "installed": (plugin_id, mkt_scope) in installed_scoped,
+                "scope": mkt_scope,
             }
         )
     return results

--- a/src/plugin_service.py
+++ b/src/plugin_service.py
@@ -18,6 +18,7 @@ Key data sources:
 
 import json
 import logging
+import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -123,37 +124,68 @@ def _validate_install_path(install_path: Path) -> Optional[Path]:
     return resolved if resolved.is_dir() else None
 
 
-def _validate_marketplace_path(install_location: Path) -> Optional[Path]:
-    """Validate *install_location* resolves within ``plugins/marketplaces``.
+def _marketplace_anchors() -> List[Path]:
+    """Directories a marketplace ``installLocation`` may legitimately live under.
 
-    Analogous to :func:`_validate_install_path` but anchored at
-    ``~/.claude/plugins/marketplaces``.  Returns the resolved path, or
-    ``None`` if the path is a symlink (leaf or parent), escapes the
-    marketplaces tree, or does not exist as a directory.
+    ``claude plugin marketplace add`` stores the exact path it was handed:
+    ``~/.claude/plugins/marketplaces/<name>`` when added by a remote shorthand,
+    or the clone-root path when added from a local clone — which is how BOTH this
+    gateway's admin ``add_marketplace`` and the startup installer register remote
+    repos (clone to the clone root, then add that local path). So both roots are
+    valid anchors. The clone root mirrors
+    ``plugin_admin_service.clone_root()`` / ``docker/install_plugins.py``.
     """
+    anchors: List[Path] = []
     root = _plugins_root()
-    if root is None:
-        return None
-    mkt_dir = root / "marketplaces"
+    if root is not None:
+        anchors.append(root / "marketplaces")
+    configured = os.environ.get("CLAUDE_PLUGIN_CLONE_ROOT", "").strip()
+    if configured:
+        anchors.append(Path(configured))
+    else:
+        home = os.environ.get("HOME", "").strip() or str(Path.home())
+        anchors.append(Path(home) / ".claude" / "plugin-marketplaces")
+    return anchors
+
+
+def _validate_marketplace_path(install_location: Path) -> Optional[Path]:
+    """Validate *install_location* resolves within an allowed marketplace root.
+
+    Allowed roots are ``~/.claude/plugins/marketplaces`` and the clone root
+    (see :func:`_marketplace_anchors`). Returns the resolved path, or ``None`` if
+    the path is a symlink (leaf or parent), escapes every allowed root, or does
+    not exist as a directory.
+    """
     try:
         resolved = install_location.resolve()
-        resolved.relative_to(mkt_dir.resolve())
-    except (ValueError, OSError):
+    except OSError:
+        return None
+
+    anchor: Optional[Path] = None
+    for candidate in _marketplace_anchors():
+        try:
+            resolved.relative_to(candidate.resolve())
+            anchor = candidate
+            break
+        except (ValueError, OSError):
+            continue
+    if anchor is None:
         logger.warning(
-            "Marketplace installLocation outside marketplaces: %s",
+            "Marketplace installLocation outside allowed roots: %s",
             install_location,
         )
         return None
+
     if install_location.is_symlink():
         return None
     # Reject a symlinked PARENT component (see _validate_install_path).
     try:
-        mkt_anchor = mkt_dir.resolve()
+        anchor_resolved = anchor.resolve()
     except OSError:
         return None
     for parent in install_location.parents:
         try:
-            if parent.resolve() == mkt_anchor:
+            if parent.resolve() == anchor_resolved:
                 break
         except OSError:
             return None

--- a/src/routes/admin.py
+++ b/src/routes/admin.py
@@ -22,7 +22,14 @@ Named prompts:  GET/PUT/DELETE /admin/api/prompts/{name}
 Plugins:        GET  /admin/api/plugins
 Plugin detail:  GET  /admin/api/plugins/{id}
 Plugin skills:  GET  /admin/api/plugins/{id}/skills/{name}
+Plugin install: POST /admin/api/plugins
+Plugin remove:  DELETE /admin/api/plugins/{id}
+Plugin manifest: GET /admin/api/plugins/manifest
 Marketplaces:   GET  /admin/api/marketplaces
+                POST /admin/api/marketplaces
+                GET  /admin/api/marketplaces/catalog
+                GET  /admin/api/marketplaces/{name}/plugins
+                DELETE /admin/api/marketplaces/{name}
 Blocklist:      GET  /admin/api/plugins/blocklist
 """
 
@@ -75,6 +82,21 @@ class SystemPromptUpdate(BaseModel):
 
 class NamedPromptWrite(BaseModel):
     content: str
+
+
+class MarketplaceAddRequest(BaseModel):
+    repo: str
+    branch: str = "main"
+    scope: str = "user"
+    git_token: str = ""
+
+
+class PluginInstallRequest(BaseModel):
+    name: str
+    marketplace: str = ""
+    scope: str = "user"
+    repo: str = ""
+    branch: str = "main"
 
 
 # ---------------------------------------------------------------------------
@@ -655,6 +677,117 @@ async def get_blocklist_endpoint(_=Depends(require_admin)):
     return {"blocklist": get_plugin_blocklist()}
 
 
+# --- Plugin / marketplace mutations (admin-managed) -----------------------
+#
+# These static / method-specific routes MUST be declared before the catch-all
+# GET /api/plugins/{plugin_id:path} below. FastAPI matches in declaration
+# order: a later GET /api/plugins/{plugin_id:path} would otherwise capture
+# "manifest" as a plugin_id. (POST and DELETE are method-distinct and would not
+# be shadowed by the GET catch-all, but they are kept here for clarity.)
+
+
+@router.get("/api/plugins/manifest")
+async def get_plugin_manifest_endpoint(_=Depends(require_admin)):
+    """Return the admin-managed plugin manifest (added / removed specs)."""
+    from src import plugin_manifest
+
+    return {
+        "added": plugin_manifest.list_added(),
+        "removed": plugin_manifest.list_removed(),
+    }
+
+
+@router.post("/api/marketplaces")
+async def add_marketplace_endpoint(
+    body: MarketplaceAddRequest,
+    _=Depends(require_admin),
+):
+    """Register a plugin marketplace from a repo URL or local path."""
+    from fastapi.concurrency import run_in_threadpool
+
+    from src import plugin_admin_service
+
+    try:
+        result = await run_in_threadpool(
+            plugin_admin_service.add_marketplace,
+            body.repo,
+            branch=body.branch,
+            scope=body.scope,
+            git_token=body.git_token,
+        )
+    except plugin_admin_service.PluginAdminError as e:
+        return JSONResponse(status_code=400, content={"error": str(e)})
+    return result
+
+
+@router.delete("/api/marketplaces/{name}")
+async def remove_marketplace_endpoint(
+    name: str,
+    scope: str = "user",
+    _=Depends(require_admin),
+):
+    """Remove a configured marketplace and drop its managed entries."""
+    from fastapi.concurrency import run_in_threadpool
+
+    from src import plugin_admin_service
+
+    try:
+        result = await run_in_threadpool(
+            plugin_admin_service.remove_marketplace,
+            name,
+            scope=scope,
+        )
+    except plugin_admin_service.PluginAdminError as e:
+        return JSONResponse(status_code=400, content={"error": str(e)})
+    return result
+
+
+@router.post("/api/plugins")
+async def install_plugin_endpoint(
+    body: PluginInstallRequest,
+    _=Depends(require_admin),
+):
+    """Install a plugin (optionally registering its marketplace first)."""
+    from fastapi.concurrency import run_in_threadpool
+
+    from src import plugin_admin_service
+
+    try:
+        result = await run_in_threadpool(
+            plugin_admin_service.install_plugin,
+            body.name,
+            marketplace=body.marketplace,
+            scope=body.scope,
+            repo=body.repo,
+            branch=body.branch,
+        )
+    except plugin_admin_service.PluginAdminError as e:
+        return JSONResponse(status_code=400, content={"error": str(e)})
+    return result
+
+
+@router.delete("/api/plugins/{plugin_id:path}")
+async def uninstall_plugin_endpoint(
+    plugin_id: str,
+    scope: str = "user",
+    _=Depends(require_admin),
+):
+    """Uninstall a plugin by its registry key (e.g. ``octo@nyldn-plugins``)."""
+    from fastapi.concurrency import run_in_threadpool
+
+    from src import plugin_admin_service
+
+    try:
+        result = await run_in_threadpool(
+            plugin_admin_service.uninstall_plugin,
+            plugin_id,
+            scope=scope,
+        )
+    except plugin_admin_service.PluginAdminError as e:
+        return JSONResponse(status_code=400, content={"error": str(e)})
+    return result
+
+
 @router.get("/api/plugins/{plugin_id:path}/skills/{skill_name}")
 async def get_plugin_skill_endpoint(
     plugin_id: str,
@@ -687,6 +820,30 @@ async def list_marketplaces_endpoint(_=Depends(require_admin)):
     from src.plugin_service import list_marketplaces
 
     return {"marketplaces": list_marketplaces()}
+
+
+# --- Marketplace catalog (read-only, one-click install UI) ----------------
+#
+# Route ordering: the literal /api/marketplaces/catalog MUST be declared
+# before the parametrised /api/marketplaces/{name}/plugins (and before the
+# existing DELETE /api/marketplaces/{name}). FastAPI resolves in declaration
+# order, so a single-segment {name} would otherwise capture "catalog".
+
+
+@router.get("/api/marketplaces/catalog")
+async def marketplaces_catalog_endpoint(_=Depends(require_admin)):
+    """All marketplaces with their offered plugins (one-shot for the UI)."""
+    from src.plugin_service import get_marketplaces_with_plugins
+
+    return {"marketplaces": get_marketplaces_with_plugins()}
+
+
+@router.get("/api/marketplaces/{name}/plugins")
+async def marketplace_plugins_endpoint(name: str, _=Depends(require_admin)):
+    """Catalog plugins offered by a single marketplace."""
+    from src.plugin_service import list_marketplace_plugins
+
+    return {"plugins": list_marketplace_plugins(name)}
 
 
 # ---------------------------------------------------------------------------

--- a/src/routes/admin.py
+++ b/src/routes/admin.py
@@ -792,23 +792,30 @@ async def uninstall_plugin_endpoint(
 async def get_plugin_skill_endpoint(
     plugin_id: str,
     skill_name: str,
+    scope: Optional[str] = None,
     _=Depends(require_admin),
 ):
-    """Read a specific skill's content from an installed plugin."""
+    """Read a specific skill's content from an installed plugin.
+
+    *scope* picks the right per-scope registry entry when a plugin is installed
+    at more than one scope.
+    """
     from src.plugin_service import get_plugin_skill_content
 
-    result = get_plugin_skill_content(plugin_id, skill_name)
+    result = get_plugin_skill_content(plugin_id, skill_name, scope)
     if result is None:
         return JSONResponse(status_code=404, content={"error": "Plugin or skill not found"})
     return result
 
 
 @router.get("/api/plugins/{plugin_id:path}")
-async def get_plugin_detail_endpoint(plugin_id: str, _=Depends(require_admin)):
-    """Return full detail for a single installed plugin."""
+async def get_plugin_detail_endpoint(
+    plugin_id: str, scope: Optional[str] = None, _=Depends(require_admin)
+):
+    """Return full detail for a single installed plugin (optionally per scope)."""
     from src.plugin_service import get_plugin_detail
 
-    detail = get_plugin_detail(plugin_id)
+    detail = get_plugin_detail(plugin_id, scope)
     if detail is None:
         return JSONResponse(status_code=404, content={"error": "Plugin not found"})
     return detail

--- a/tests/test_admin_plugins.py
+++ b/tests/test_admin_plugins.py
@@ -1,0 +1,283 @@
+"""Tests for the admin plugin / marketplace management routes.
+
+The service layer (``src.plugin_admin_service``) is mocked — these tests cover
+the route wiring: admin gating, request-model plumbing, success pass-through,
+and ``PluginAdminError`` -> HTTP 400.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from src.plugin_admin_service import PluginAdminError
+
+
+@pytest.fixture
+def admin_client():
+    """FastAPI TestClient with admin auth bypassed."""
+    from fastapi.testclient import TestClient
+
+    with patch.dict(os.environ, {"ADMIN_API_KEY": "test-key"}):
+        from src.admin_auth import require_admin
+        from src.main import app
+
+        app.dependency_overrides[require_admin] = lambda: True
+        client = TestClient(app)
+        yield client
+        app.dependency_overrides.pop(require_admin, None)
+
+
+@pytest.fixture
+def anon_client():
+    """FastAPI TestClient with admin auth ENFORCED (no override)."""
+    from fastapi.testclient import TestClient
+
+    with patch.dict(os.environ, {"ADMIN_API_KEY": "test-key"}):
+        from src.main import app
+
+        yield TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Auth gating
+# ---------------------------------------------------------------------------
+
+
+class TestAuthGating:
+    def test_add_marketplace_requires_admin(self, anon_client):
+        r = anon_client.post(
+            "/admin/api/marketplaces", json={"repo": "https://x/y.git"}
+        )
+        assert r.status_code in (401, 403)
+
+    def test_remove_marketplace_requires_admin(self, anon_client):
+        r = anon_client.delete("/admin/api/marketplaces/foo")
+        assert r.status_code in (401, 403)
+
+    def test_install_plugin_requires_admin(self, anon_client):
+        r = anon_client.post("/admin/api/plugins", json={"name": "octo"})
+        assert r.status_code in (401, 403)
+
+    def test_uninstall_plugin_requires_admin(self, anon_client):
+        r = anon_client.delete("/admin/api/plugins/octo@mp")
+        assert r.status_code in (401, 403)
+
+    def test_manifest_requires_admin(self, anon_client):
+        r = anon_client.get("/admin/api/plugins/manifest")
+        assert r.status_code in (401, 403)
+
+    def test_catalog_requires_admin(self, anon_client):
+        r = anon_client.get("/admin/api/marketplaces/catalog")
+        assert r.status_code in (401, 403)
+
+    def test_marketplace_plugins_requires_admin(self, anon_client):
+        r = anon_client.get("/admin/api/marketplaces/mp/plugins")
+        assert r.status_code in (401, 403)
+
+
+# ---------------------------------------------------------------------------
+# Route ordering: manifest must not be shadowed by the catch-all detail route
+# ---------------------------------------------------------------------------
+
+
+class TestRouteOrdering:
+    def test_manifest_not_shadowed_by_detail(self, admin_client):
+        with patch("src.plugin_manifest.list_added", return_value=[{"name": "octo"}]):
+            with patch("src.plugin_manifest.list_removed", return_value=["old@mp"]):
+                r = admin_client.get("/admin/api/plugins/manifest")
+        assert r.status_code == 200
+        data = r.json()
+        assert data == {"added": [{"name": "octo"}], "removed": ["old@mp"]}
+
+    def test_catalog_not_shadowed_by_name_param(self, admin_client):
+        """`/marketplaces/catalog` resolves to the literal route, not {name}."""
+        with patch(
+            "src.plugin_service.get_marketplaces_with_plugins",
+            return_value=[{"name": "mp", "plugins": [], "plugin_count": 0}],
+        ) as mock_catalog:
+            with patch(
+                "src.plugin_service.list_marketplace_plugins"
+            ) as mock_one:
+                r = admin_client.get("/admin/api/marketplaces/catalog")
+        assert r.status_code == 200
+        mock_catalog.assert_called_once_with()
+        mock_one.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Marketplace catalog (read-only)
+# ---------------------------------------------------------------------------
+
+
+class TestMarketplacesCatalog:
+    def test_happy_path(self, admin_client):
+        catalog = [
+            {
+                "name": "mp",
+                "source_type": "github",
+                "repo": "owner/repo",
+                "last_updated": "2026-01-01T00:00:00Z",
+                "plugins": [
+                    {
+                        "name": "octo",
+                        "description": "d",
+                        "version": "1.0",
+                        "skill_count": 2,
+                        "id": "octo@mp",
+                        "installed": True,
+                    }
+                ],
+                "plugin_count": 1,
+            }
+        ]
+        with patch(
+            "src.plugin_service.get_marketplaces_with_plugins",
+            return_value=catalog,
+        ) as mock_catalog:
+            r = admin_client.get("/admin/api/marketplaces/catalog")
+        assert r.status_code == 200
+        assert r.json() == {"marketplaces": catalog}
+        mock_catalog.assert_called_once_with()
+
+
+class TestMarketplacePlugins:
+    def test_happy_path(self, admin_client):
+        plugins = [
+            {
+                "name": "octo",
+                "description": "d",
+                "version": "1.0",
+                "skill_count": 0,
+                "id": "octo@mp",
+                "installed": False,
+            }
+        ]
+        with patch(
+            "src.plugin_service.list_marketplace_plugins",
+            return_value=plugins,
+        ) as mock_list:
+            r = admin_client.get("/admin/api/marketplaces/mp/plugins")
+        assert r.status_code == 200
+        assert r.json() == {"plugins": plugins}
+        mock_list.assert_called_once_with("mp")
+
+
+# ---------------------------------------------------------------------------
+# add_marketplace
+# ---------------------------------------------------------------------------
+
+
+class TestAddMarketplace:
+    def test_happy_path(self, admin_client):
+        with patch(
+            "src.plugin_admin_service.add_marketplace",
+            return_value={"status": "added", "repo": "https://x/y.git"},
+        ) as mock_add:
+            r = admin_client.post(
+                "/admin/api/marketplaces",
+                json={
+                    "repo": "https://x/y.git",
+                    "branch": "dev",
+                    "scope": "project",
+                },
+            )
+        assert r.status_code == 200
+        assert r.json()["status"] == "added"
+        mock_add.assert_called_once_with(
+            "https://x/y.git", branch="dev", scope="project", git_token=""
+        )
+
+    def test_plugin_admin_error_400(self, admin_client):
+        with patch(
+            "src.plugin_admin_service.add_marketplace",
+            side_effect=PluginAdminError("bad repo"),
+        ):
+            r = admin_client.post(
+                "/admin/api/marketplaces", json={"repo": "bogus"}
+            )
+        assert r.status_code == 400
+        assert r.json() == {"error": "bad repo"}
+
+
+# ---------------------------------------------------------------------------
+# remove_marketplace
+# ---------------------------------------------------------------------------
+
+
+class TestRemoveMarketplace:
+    def test_happy_path(self, admin_client):
+        with patch(
+            "src.plugin_admin_service.remove_marketplace",
+            return_value={"status": "removed", "marketplace": "mp"},
+        ) as mock_rm:
+            r = admin_client.delete("/admin/api/marketplaces/mp?scope=local")
+        assert r.status_code == 200
+        assert r.json()["status"] == "removed"
+        mock_rm.assert_called_once_with("mp", scope="local")
+
+    def test_plugin_admin_error_400(self, admin_client):
+        with patch(
+            "src.plugin_admin_service.remove_marketplace",
+            side_effect=PluginAdminError("no such marketplace"),
+        ):
+            r = admin_client.delete("/admin/api/marketplaces/mp")
+        assert r.status_code == 400
+        assert r.json() == {"error": "no such marketplace"}
+
+
+# ---------------------------------------------------------------------------
+# install_plugin
+# ---------------------------------------------------------------------------
+
+
+class TestInstallPlugin:
+    def test_happy_path(self, admin_client):
+        with patch(
+            "src.plugin_admin_service.install_plugin",
+            return_value={"status": "installed", "spec": "octo@mp"},
+        ) as mock_install:
+            r = admin_client.post(
+                "/admin/api/plugins",
+                json={"name": "octo", "marketplace": "mp", "scope": "user"},
+            )
+        assert r.status_code == 200
+        assert r.json()["spec"] == "octo@mp"
+        mock_install.assert_called_once_with(
+            "octo", marketplace="mp", scope="user", repo="", branch="main"
+        )
+
+    def test_plugin_admin_error_400(self, admin_client):
+        with patch(
+            "src.plugin_admin_service.install_plugin",
+            side_effect=PluginAdminError("install failed"),
+        ):
+            r = admin_client.post("/admin/api/plugins", json={"name": "octo"})
+        assert r.status_code == 400
+        assert r.json() == {"error": "install failed"}
+
+
+# ---------------------------------------------------------------------------
+# uninstall_plugin (catch-all DELETE)
+# ---------------------------------------------------------------------------
+
+
+class TestUninstallPlugin:
+    def test_happy_path(self, admin_client):
+        with patch(
+            "src.plugin_admin_service.uninstall_plugin",
+            return_value={"status": "uninstalled", "plugin": "octo@mp"},
+        ) as mock_uninstall:
+            r = admin_client.delete("/admin/api/plugins/octo@mp?scope=user")
+        assert r.status_code == 200
+        assert r.json()["status"] == "uninstalled"
+        mock_uninstall.assert_called_once_with("octo@mp", scope="user")
+
+    def test_plugin_admin_error_400(self, admin_client):
+        with patch(
+            "src.plugin_admin_service.uninstall_plugin",
+            side_effect=PluginAdminError("uninstall failed"),
+        ):
+            r = admin_client.delete("/admin/api/plugins/octo@mp")
+        assert r.status_code == 400
+        assert r.json() == {"error": "uninstall failed"}

--- a/tests/test_install_plugins_script.py
+++ b/tests/test_install_plugins_script.py
@@ -309,6 +309,35 @@ def test_write_env_journal_records_real_name_scope_branch_repo(tmp_path, monkeyp
     }
 
 
+def test_strip_url_credentials_installer():
+    f = installer._strip_url_credentials
+    assert f("https://user:tok@host/o/r.git") == "https://host/o/r.git"
+    assert f("https://tok@host/o/r.git") == "https://host/o/r.git"
+    assert f("ssh://git@host/o/r.git") == "ssh://git@host/o/r.git"
+    assert f("/clones/local") == "/clones/local"
+
+
+def test_write_env_journal_strips_credentials_from_repo(tmp_path, monkeypatch):
+    # A token in CLAUDE_PLUGIN_REPO* is used to clone but must NEVER land in the
+    # journal (which the app replays into the manifest/API).
+    journal = tmp_path / "env.json"
+    monkeypatch.setenv("CLAUDE_PLUGIN_ENV_JOURNAL", str(journal))
+    entry = installer.PluginEntry(
+        repo="https://user:secret-token@host/org/private.git",
+        names=["p"],
+        marketplace="priv",
+        scope="user",
+        branch="main",
+        source_label="CLAUDE_PLUGIN_REPO_1",
+    )
+    installer.write_env_journal([entry], tmp_path)
+    raw = journal.read_text()
+    assert "secret-token" not in raw
+    assert json.loads(raw)["marketplaces"]["priv"]["repo"] == (
+        "https://host/org/private.git"
+    )
+
+
 def test_write_env_journal_skips_manifest_entries_and_clears(tmp_path, monkeypatch):
     journal = tmp_path / "env.json"
     monkeypatch.setenv("CLAUDE_PLUGIN_ENV_JOURNAL", str(journal))

--- a/tests/test_install_plugins_script.py
+++ b/tests/test_install_plugins_script.py
@@ -595,6 +595,177 @@ def test_missing_claude_cli_skips_without_blocking_startup(tmp_path):
     assert _read(tmp_path / "claude.log") == ""
 
 
+# ---------------------------------------------------------------------------
+# Integration tests — admin-managed manifest reconciliation
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_added_entries_are_installed(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_claude(bin_dir)
+    _write_fake_git(bin_dir)
+
+    manifest = tmp_path / "gateway-plugins.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "added": [
+                    {
+                        "repo": "https://example/admin/mkt.git",
+                        "name": "adminplug",
+                        "marketplace": "adminmkt",
+                        "scope": "user",
+                        "branch": "main",
+                    }
+                ],
+                "removed": [],
+            }
+        )
+    )
+
+    env = {
+        **_base_env(tmp_path, bin_dir),
+        "CLAUDE_PLUGIN_MANIFEST": str(manifest),
+        # An env-bootstrap entry alongside the manifest entry.
+        "CLAUDE_PLUGIN_REPO_1": "https://example/env/mkt.git",
+        "CLAUDE_PLUGIN_NAME_1": "envplug",
+        "CLAUDE_PLUGIN_MARKETPLACE_1": "envmkt",
+    }
+
+    result = _run_installer(env)
+    assert result.returncode == 0, result.stderr
+
+    claude_log = _read(tmp_path / "claude.log")
+    # Env bootstrap entry still installed.
+    assert "plugin install envplug@envmkt --scope user" in claude_log
+    # Manifest-added entry installed (and updated) too.
+    assert "plugin install adminplug@adminmkt --scope user" in claude_log
+    assert "plugin update adminplug@adminmkt --scope user" in claude_log
+
+    git_log = _read(tmp_path / "git.log")
+    assert "clone --depth 1 --branch main https://example/admin/mkt.git" in git_log
+
+
+def test_manifest_removed_spec_is_skipped_and_uninstalled(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_claude(bin_dir)
+    _write_fake_git(bin_dir)
+
+    manifest = tmp_path / "gateway-plugins.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "added": [],
+                "removed": ["envplug@envmkt"],
+            }
+        )
+    )
+
+    env = {
+        **_base_env(tmp_path, bin_dir),
+        "CLAUDE_PLUGIN_MANIFEST": str(manifest),
+        # The env bootstrap still names a plugin the admin has removed, plus a
+        # second one that must remain installed.
+        "CLAUDE_PLUGIN_REPO_1": "https://example/env/mkt.git",
+        "CLAUDE_PLUGIN_NAME_1": "envplug,keepplug",
+        "CLAUDE_PLUGIN_MARKETPLACE_1": "envmkt",
+    }
+
+    result = _run_installer(env)
+    assert result.returncode == 0, result.stderr
+
+    claude_log = _read(tmp_path / "claude.log")
+    # The removed spec is never (re)installed...
+    assert "plugin install envplug@envmkt" not in claude_log
+    assert "plugin update envplug@envmkt" not in claude_log
+    # ...but it IS actively uninstalled.
+    assert "plugin uninstall envplug@envmkt --scope user" in claude_log
+    # The sibling plugin from the same repo is unaffected.
+    assert "plugin install keepplug@envmkt --scope user" in claude_log
+
+
+def test_manifest_removed_uninstall_failure_does_not_block_startup(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_claude(bin_dir)
+    _write_fake_git(bin_dir)
+
+    manifest = tmp_path / "gateway-plugins.json"
+    # FAILPLUGIN makes the fake claude exit 1 on the uninstall call.
+    manifest.write_text(
+        json.dumps({"version": 1, "added": [], "removed": ["FAILPLUGIN@x"]})
+    )
+
+    env = {
+        **_base_env(tmp_path, bin_dir),
+        "CLAUDE_PLUGIN_MANIFEST": str(manifest),
+        "CLAUDE_PLUGIN_REPO_1": "https://example/env/mkt.git",
+        "CLAUDE_PLUGIN_NAME_1": "keepplug",
+        "CLAUDE_PLUGIN_MARKETPLACE_1": "envmkt",
+    }
+
+    result = _run_installer(env)
+    # A failing uninstall must never block the run / server startup.
+    assert result.returncode == 0, result.stderr
+
+    claude_log = _read(tmp_path / "claude.log")
+    assert "plugin uninstall FAILPLUGIN@x --scope user" in claude_log
+    assert "plugin install keepplug@envmkt --scope user" in claude_log
+
+
+def test_no_manifest_file_behaves_as_before(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_claude(bin_dir)
+    _write_fake_git(bin_dir)
+
+    env = {
+        **_base_env(tmp_path, bin_dir),
+        # Point at a path that does not exist; the installer must tolerate it.
+        "CLAUDE_PLUGIN_MANIFEST": str(tmp_path / "missing.json"),
+        "CLAUDE_PLUGIN_REPO_1": "https://example/env/mkt.git",
+        "CLAUDE_PLUGIN_NAME_1": "envplug",
+        "CLAUDE_PLUGIN_MARKETPLACE_1": "envmkt",
+    }
+
+    result = _run_installer(env)
+    assert result.returncode == 0, result.stderr
+
+    claude_log = _read(tmp_path / "claude.log")
+    # Behaves exactly as before: env entry installed, no uninstall calls.
+    assert "plugin install envplug@envmkt --scope user" in claude_log
+    assert "plugin uninstall" not in claude_log
+
+
+def test_corrupt_manifest_is_tolerated(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_claude(bin_dir)
+    _write_fake_git(bin_dir)
+
+    manifest = tmp_path / "gateway-plugins.json"
+    manifest.write_text("{not valid json")
+
+    env = {
+        **_base_env(tmp_path, bin_dir),
+        "CLAUDE_PLUGIN_MANIFEST": str(manifest),
+        "CLAUDE_PLUGIN_REPO_1": "https://example/env/mkt.git",
+        "CLAUDE_PLUGIN_NAME_1": "envplug",
+        "CLAUDE_PLUGIN_MARKETPLACE_1": "envmkt",
+    }
+
+    result = _run_installer(env)
+    assert result.returncode == 0, result.stderr
+
+    claude_log = _read(tmp_path / "claude.log")
+    assert "plugin install envplug@envmkt --scope user" in claude_log
+    assert "plugin uninstall" not in claude_log
+
+
 def test_marketplace_install_registers_cli_usable_plugin_from_local_directory(tmp_path):
     """End-to-end against the real Claude CLI when it is available."""
     if shutil.which("claude") is None:

--- a/tests/test_install_plugins_script.py
+++ b/tests/test_install_plugins_script.py
@@ -740,6 +740,43 @@ def test_manifest_removed_spec_is_skipped_and_uninstalled(tmp_path):
     assert "plugin install keepplug@envmkt --scope user" in claude_log
 
 
+def test_manifest_removed_honors_scope(tmp_path):
+    # A project-scope env plugin removed via the admin panel must be uninstalled
+    # at --scope project on startup (a --scope user uninstall would fail and
+    # leave it installed), and skipped from reinstall only at that scope.
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_claude(bin_dir)
+    _write_fake_git(bin_dir)
+
+    manifest = tmp_path / "gateway-plugins.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "added": [],
+                "removed": [{"spec": "envplug@envmkt", "scope": "project"}],
+            }
+        )
+    )
+
+    env = {
+        **_base_env(tmp_path, bin_dir),
+        "CLAUDE_PLUGIN_MANIFEST": str(manifest),
+        "CLAUDE_PLUGIN_REPO_1": "https://example/env/mkt.git",
+        "CLAUDE_PLUGIN_NAME_1": "envplug",
+        "CLAUDE_PLUGIN_MARKETPLACE_1": "envmkt",
+        "CLAUDE_PLUGIN_SCOPE_1": "project",
+    }
+
+    result = _run_installer(env)
+    assert result.returncode == 0, result.stderr
+
+    claude_log = _read(tmp_path / "claude.log")
+    assert "plugin uninstall envplug@envmkt --scope project" in claude_log
+    assert "plugin install envplug@envmkt" not in claude_log
+
+
 def test_manifest_removed_uninstall_failure_does_not_block_startup(tmp_path):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()

--- a/tests/test_install_plugins_script.py
+++ b/tests/test_install_plugins_script.py
@@ -189,6 +189,58 @@ def test_collect_entries_parses_legacy_and_indexed(monkeypatch):
     assert entries[2].names == ["mkt"]
 
 
+def test_manifest_private_entry_inherits_git_token(tmp_path, monkeypatch):
+    # A private marketplace added via the admin panel must replay on startup when
+    # the un-indexed CLAUDE_PLUGIN_GIT_TOKEN is provided: the manifest entry has
+    # no token of its own, so it inherits that env credential for the clone.
+    for key in list(os.environ):
+        if key.startswith("CLAUDE_PLUGIN"):
+            monkeypatch.delenv(key, raising=False)
+    manifest = tmp_path / "gateway-plugins.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "added": [
+                    {
+                        "repo": "https://host/acme/private.git",
+                        "name": "octo",
+                        "marketplace": "acme",
+                        "scope": "user",
+                        "branch": "main",
+                    }
+                ],
+                "removed": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CLAUDE_PLUGIN_MANIFEST", str(manifest))
+    monkeypatch.setenv("CLAUDE_PLUGIN_GIT_TOKEN", "secret-token")
+
+    entries = installer.collect_entries()
+
+    assert len(entries) == 1
+    assert entries[0].source_label == "manifest"
+    assert entries[0].repo == "https://host/acme/private.git"
+    assert entries[0].git_token == "secret-token"
+
+
+def test_manifest_entry_no_token_when_env_unset(tmp_path, monkeypatch):
+    for key in list(os.environ):
+        if key.startswith("CLAUDE_PLUGIN"):
+            monkeypatch.delenv(key, raising=False)
+    manifest = tmp_path / "gateway-plugins.json"
+    manifest.write_text(
+        json.dumps(
+            {"added": [{"repo": "https://host/x/pub.git", "name": "p"}], "removed": []}
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CLAUDE_PLUGIN_MANIFEST", str(manifest))
+    entries = installer.collect_entries()
+    assert entries[0].git_token == ""
+
+
 def test_collect_entries_branch_defaults_to_main_and_honors_override(monkeypatch):
     for key in list(os.environ):
         if key.startswith("CLAUDE_PLUGIN"):

--- a/tests/test_install_plugins_script.py
+++ b/tests/test_install_plugins_script.py
@@ -263,6 +263,86 @@ def test_collect_entries_empty_when_unset(monkeypatch):
     assert installer.collect_entries() == []
 
 
+def test_env_journal_path_defaults_beside_manifest(monkeypatch):
+    monkeypatch.delenv("CLAUDE_PLUGIN_ENV_JOURNAL", raising=False)
+    monkeypatch.setenv("CLAUDE_PLUGIN_MANIFEST", "/data/gw.json")
+    assert installer.env_journal_path() == Path("/data/gateway-plugins-env.json")
+
+
+def test_env_journal_path_honors_override(monkeypatch):
+    monkeypatch.setenv("CLAUDE_PLUGIN_ENV_JOURNAL", "/x/custom.json")
+    assert installer.env_journal_path() == Path("/x/custom.json")
+
+
+def test_write_env_journal_records_real_name_scope_branch_repo(tmp_path, monkeypatch):
+    # The journal key is the marketplace.json `name`, NOT the env declaration's
+    # repo basename, so the app can match it against known_marketplaces.json.
+    for key in list(os.environ):
+        if key.startswith("CLAUDE_PLUGIN"):
+            monkeypatch.delenv(key, raising=False)
+    journal = tmp_path / "env.json"
+    monkeypatch.setenv("CLAUDE_PLUGIN_ENV_JOURNAL", str(journal))
+
+    clone = tmp_path / "clone"
+    (clone / ".claude-plugin").mkdir(parents=True)
+    (clone / ".claude-plugin" / "marketplace.json").write_text(
+        json.dumps({"name": "real-mkt-name", "plugins": []})
+    )
+    entry = installer.PluginEntry(
+        repo=str(clone),
+        names=["p"],
+        marketplace="",
+        scope="project",
+        branch="develop",
+        source_label="CLAUDE_PLUGIN_REPO_1",
+    )
+
+    installer.write_env_journal([entry], tmp_path)
+
+    data = json.loads(journal.read_text())
+    assert data["marketplaces"] == {
+        "real-mkt-name": {
+            "scope": "project",
+            "branch": "develop",
+            "repo": str(clone),
+        }
+    }
+
+
+def test_write_env_journal_skips_manifest_entries_and_clears(tmp_path, monkeypatch):
+    journal = tmp_path / "env.json"
+    monkeypatch.setenv("CLAUDE_PLUGIN_ENV_JOURNAL", str(journal))
+    manifest_entry = installer.PluginEntry(
+        repo="https://host/x/y.git", names=["p"], source_label="manifest"
+    )
+    installer.write_env_journal([manifest_entry], tmp_path)
+    assert json.loads(journal.read_text())["marketplaces"] == {}
+
+
+def test_write_env_journal_name_fallback_to_explicit_then_basename(
+    tmp_path, monkeypatch
+):
+    journal = tmp_path / "env.json"
+    monkeypatch.setenv("CLAUDE_PLUGIN_ENV_JOURNAL", str(journal))
+    # No marketplace.json on disk -> explicit marketplace name wins.
+    e1 = installer.PluginEntry(
+        repo=str(tmp_path / "missing1"),
+        names=["p"],
+        marketplace="explicit-mkt",
+        source_label="CLAUDE_PLUGIN_REPO_1",
+    )
+    # No marketplace.json and no explicit name -> repo basename.
+    e2 = installer.PluginEntry(
+        repo="https://host/acme/cool-mkt.git",
+        names=["q"],
+        source_label="CLAUDE_PLUGIN_REPO_2",
+    )
+    installer.write_env_journal([e1, e2], tmp_path)
+    mkts = json.loads(journal.read_text())["marketplaces"]
+    assert "explicit-mkt" in mkts
+    assert "cool-mkt" in mkts
+
+
 def test_collect_entries_drops_entry_with_uninferable_name(monkeypatch):
     for key in list(os.environ):
         if key.startswith("CLAUDE_PLUGIN"):

--- a/tests/test_plugin_admin_service.py
+++ b/tests/test_plugin_admin_service.py
@@ -49,12 +49,25 @@ def fake_manifest(monkeypatch):
             self.mark_removed_calls = []
             self.unmark_removed_calls = []
             self.remove_marketplace_calls = []
+            self.marketplaces = {}
+            self.set_marketplace_calls = []
 
         def spec_for(self, name, marketplace):
             return f"{name}@{marketplace}" if marketplace else name
 
         def list_added(self):
             return self.added_entries
+
+        def set_marketplace(self, name, *, repo, branch, scope):
+            rec = {"repo": repo, "branch": branch, "scope": scope}
+            self.set_marketplace_calls.append({"name": name, **rec})
+            self.marketplaces[name] = rec
+
+        def get_marketplace(self, name):
+            return self.marketplaces.get(name, {})
+
+        def list_marketplace_records(self):
+            return self.marketplaces
 
         def add_plugin(self, *, repo, name, marketplace, scope, branch):
             self.add_plugin_calls.append(
@@ -301,6 +314,37 @@ def test_install_from_catalog_resolves_marketplace_repo(
     ]
 
 
+def test_catalog_install_after_add_marketplace_replays_remote(
+    monkeypatch, fake_claude, recorded_runs, fake_manifest
+):
+    # The REAL admin flow: add a remote marketplace (clone-then-add-local, which
+    # makes claude record source: directory, losing the remote), then install a
+    # plugin from its catalog. The manifest added-entry must carry the ORIGINAL
+    # REMOTE + branch (from the marketplace record), not the local clone path, so
+    # the startup installer can re-clone it after a `docker compose down -v`.
+    monkeypatch.setattr(
+        svc, "prepare_repo", lambda repo, **kw: svc.Path("/clones/octo-mkt-x")
+    )
+    svc.add_marketplace(
+        "https://github.com/acme/octo-mkt", branch="dev", scope="project"
+    )
+    # name falls back to the repo basename (the fake clone has no marketplace.json)
+    assert fake_manifest.marketplaces["octo-mkt"] == {
+        "repo": "https://github.com/acme/octo-mkt",
+        "branch": "dev",
+        "scope": "project",
+    }
+
+    svc.install_plugin("octo", marketplace="octo-mkt", scope="project")
+    assert fake_manifest.add_plugin_calls[-1] == {
+        "repo": "https://github.com/acme/octo-mkt",
+        "name": "octo",
+        "marketplace": "octo-mkt",
+        "scope": "project",
+        "branch": "dev",
+    }
+
+
 def test_resolve_marketplace_repo_prefers_full_url(monkeypatch, tmp_path):
     import json as _json
 
@@ -313,11 +357,13 @@ def test_resolve_marketplace_repo_prefers_full_url(monkeypatch, tmp_path):
         encoding="utf-8",
     )
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("CLAUDE_PLUGIN_MANIFEST", str(tmp_path / "manifest.json"))
     assert svc._resolve_marketplace_repo("m") == "https://git.example/m.git"
 
 
 def test_resolve_marketplace_repo_unknown_returns_empty(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("CLAUDE_PLUGIN_MANIFEST", str(tmp_path / "manifest.json"))
     assert svc._resolve_marketplace_repo("nope") == ""
 
 

--- a/tests/test_plugin_admin_service.py
+++ b/tests/test_plugin_admin_service.py
@@ -367,6 +367,51 @@ def test_resolve_marketplace_repo_unknown_returns_empty(monkeypatch, tmp_path):
     assert svc._resolve_marketplace_repo("nope") == ""
 
 
+def test_resolve_marketplace_repo_falls_back_to_env_journal(monkeypatch, tmp_path):
+    # An env-bootstrapped marketplace (clone-then-add records source: directory)
+    # has no remote in known_marketplaces.json; the startup installer's journal
+    # supplies it so the catalog-install manifest entry stays replayable.
+    from src import plugin_service
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("CLAUDE_PLUGIN_MANIFEST", str(tmp_path / "manifest.json"))
+    monkeypatch.setattr(
+        plugin_service,
+        "env_bootstrap_records",
+        lambda: {"envmkt": {"scope": "project", "branch": "dev", "repo": "o/r.git"}},
+    )
+    assert svc._resolve_marketplace_repo("envmkt") == "o/r.git"
+
+
+def test_catalog_install_from_env_marketplace_replays_branch_and_repo(
+    monkeypatch, fake_claude, recorded_runs, fake_manifest
+):
+    # Catalog install from an env-bootstrapped (non-main) marketplace must record
+    # the journaled branch + remote, not the main/local defaults, so a `down -v`
+    # self-heal clones the same content.
+    from src import plugin_service
+
+    monkeypatch.setattr(
+        plugin_service,
+        "env_bootstrap_records",
+        lambda: {
+            "envmkt": {
+                "scope": "project",
+                "branch": "develop",
+                "repo": "https://host/o/r.git",
+            }
+        },
+    )
+    svc.install_plugin("octo", marketplace="envmkt", scope="project")
+    assert fake_manifest.add_plugin_calls[-1] == {
+        "repo": "https://host/o/r.git",
+        "name": "octo",
+        "marketplace": "envmkt",
+        "scope": "project",
+        "branch": "develop",
+    }
+
+
 def test_install_plugin_cli_failure_raises(monkeypatch, fake_claude, fake_manifest):
     def boom(cmd, *, token=""):
         raise subprocess.CalledProcessError(2, cmd)

--- a/tests/test_plugin_admin_service.py
+++ b/tests/test_plugin_admin_service.py
@@ -367,6 +367,51 @@ def test_resolve_marketplace_repo_unknown_returns_empty(monkeypatch, tmp_path):
     assert svc._resolve_marketplace_repo("nope") == ""
 
 
+def test_strip_url_credentials():
+    f = svc._strip_url_credentials
+    # http(s) userinfo (user:token and token-only) is removed
+    assert f("https://user:tok@host/org/r.git") == "https://host/org/r.git"
+    assert f("https://tok@host/org/r.git") == "https://host/org/r.git"
+    assert f("http://u:p@host:8443/r") == "http://host:8443/r"
+    # clean / non-http(s) values are untouched (ssh user is not a secret)
+    assert f("https://host/org/r.git") == "https://host/org/r.git"
+    assert f("ssh://git@host/org/r.git") == "ssh://git@host/org/r.git"
+    assert f("git@host:org/r.git") == "git@host:org/r.git"
+    assert f("/clones/local-mkt") == "/clones/local-mkt"
+    assert f("") == ""
+
+
+def test_resolve_marketplace_repo_strips_journal_credentials(monkeypatch, tmp_path):
+    from src import plugin_service
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("CLAUDE_PLUGIN_MANIFEST", str(tmp_path / "manifest.json"))
+    monkeypatch.setattr(
+        plugin_service,
+        "env_bootstrap_records",
+        lambda: {"m": {"repo": "https://user:tok@host/o/r.git"}},
+    )
+    assert svc._resolve_marketplace_repo("m") == "https://host/o/r.git"
+
+
+def test_resolve_marketplace_repo_strips_known_marketplaces_credentials(
+    monkeypatch, tmp_path
+):
+    import json as _json
+
+    plugins_dir = tmp_path / ".claude" / "plugins"
+    plugins_dir.mkdir(parents=True)
+    (plugins_dir / "known_marketplaces.json").write_text(
+        _json.dumps(
+            {"m": {"source": {"source": "git", "url": "https://t@git.example/m.git"}}}
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("CLAUDE_PLUGIN_MANIFEST", str(tmp_path / "manifest.json"))
+    assert svc._resolve_marketplace_repo("m") == "https://git.example/m.git"
+
+
 def test_resolve_marketplace_repo_falls_back_to_env_journal(monkeypatch, tmp_path):
     # An env-bootstrapped marketplace (clone-then-add records source: directory)
     # has no remote in known_marketplaces.json; the startup installer's journal

--- a/tests/test_plugin_admin_service.py
+++ b/tests/test_plugin_admin_service.py
@@ -1,0 +1,403 @@
+"""Unit tests for src.plugin_admin_service.
+
+The subprocess (``run``) layer and the manifest module are mocked, so no real
+``git``/``claude`` process is spawned and no manifest file is written. Tests
+assert (a) the exact claude CLI argv per operation, (b) correct manifest
+mutations, and (c) that injection inputs raise PluginAdminError before any
+subprocess runs.
+"""
+
+import subprocess
+
+import pytest
+
+import src.plugin_admin_service as svc
+
+CLAUDE_BIN = "/fake/bin/claude"
+
+
+@pytest.fixture
+def fake_claude(monkeypatch):
+    """Pretend the claude CLI is resolvable and executable."""
+    monkeypatch.setattr(svc, "resolve_claude_bin", lambda: CLAUDE_BIN)
+    monkeypatch.setattr(svc, "_is_executable", lambda p: p == CLAUDE_BIN)
+    return CLAUDE_BIN
+
+
+@pytest.fixture
+def recorded_runs(monkeypatch):
+    """Capture every svc.run() argv; default to a success CompletedProcess."""
+    calls = []
+
+    def fake_run(cmd, *, token=""):
+        calls.append({"cmd": list(cmd), "token": token})
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(svc, "run", fake_run)
+    return calls
+
+
+@pytest.fixture
+def fake_manifest(monkeypatch):
+    """Replace plugin_manifest calls with recorders."""
+
+    class M:
+        def __init__(self):
+            self.added_entries = []
+            self.add_plugin_calls = []
+            self.remove_added_calls = []
+            self.mark_removed_calls = []
+            self.unmark_removed_calls = []
+            self.remove_marketplace_calls = []
+
+        def spec_for(self, name, marketplace):
+            return f"{name}@{marketplace}" if marketplace else name
+
+        def list_added(self):
+            return self.added_entries
+
+        def add_plugin(self, *, repo, name, marketplace, scope, branch):
+            self.add_plugin_calls.append(
+                {
+                    "repo": repo,
+                    "name": name,
+                    "marketplace": marketplace,
+                    "scope": scope,
+                    "branch": branch,
+                }
+            )
+
+        def remove_added(self, spec):
+            self.remove_added_calls.append(spec)
+
+        def mark_removed(self, spec):
+            self.mark_removed_calls.append(spec)
+
+        def unmark_removed(self, spec):
+            self.unmark_removed_calls.append(spec)
+
+        def remove_marketplace_entries(self, marketplace):
+            self.remove_marketplace_calls.append(marketplace)
+
+    m = M()
+    monkeypatch.setattr(svc, "plugin_manifest", m)
+    return m
+
+
+# ---------------------------------------------------------------------------
+# add_marketplace
+# ---------------------------------------------------------------------------
+
+
+def test_add_marketplace_remote_clones_then_adds(
+    monkeypatch, fake_claude, recorded_runs, fake_manifest
+):
+    monkeypatch.setattr(
+        svc, "prepare_repo", lambda repo, **kw: svc.Path("/clones/octo-12345678")
+    )
+    result = svc.add_marketplace(
+        "https://github.com/acme/octo", branch="main", scope="user"
+    )
+
+    assert result["status"] == "added"
+    assert recorded_runs[-1]["cmd"] == [
+        CLAUDE_BIN,
+        "plugin",
+        "marketplace",
+        "add",
+        "/clones/octo-12345678",
+        "--scope",
+        "user",
+    ]
+
+
+def test_add_marketplace_local_path_added_in_place(
+    monkeypatch, tmp_path, fake_claude, recorded_runs, fake_manifest
+):
+    local = tmp_path / "mkt"
+    local.mkdir()
+    result = svc.add_marketplace(str(local), scope="project")
+
+    assert result["status"] == "added"
+    # No git clone for a local path: only the marketplace add ran.
+    assert all(c["cmd"][:1] != ["git"] for c in recorded_runs)
+    assert recorded_runs[-1]["cmd"] == [
+        CLAUDE_BIN,
+        "plugin",
+        "marketplace",
+        "add",
+        str(local),
+        "--scope",
+        "project",
+    ]
+
+
+def test_add_marketplace_cli_failure_raises(
+    monkeypatch, tmp_path, fake_claude, fake_manifest
+):
+    local = tmp_path / "mkt"
+    local.mkdir()
+
+    def boom(cmd, *, token=""):
+        raise subprocess.CalledProcessError(1, cmd)
+
+    monkeypatch.setattr(svc, "run", boom)
+    with pytest.raises(svc.PluginAdminError):
+        svc.add_marketplace(str(local))
+
+
+# ---------------------------------------------------------------------------
+# remove_marketplace
+# ---------------------------------------------------------------------------
+
+
+def test_remove_marketplace_argv_and_manifest(
+    fake_claude, recorded_runs, fake_manifest
+):
+    result = svc.remove_marketplace("nyldn-plugins", scope="user")
+
+    assert result["status"] == "removed"
+    assert recorded_runs[-1]["cmd"] == [
+        CLAUDE_BIN,
+        "plugin",
+        "marketplace",
+        "remove",
+        "nyldn-plugins",
+        "--scope",
+        "user",
+    ]
+    assert fake_manifest.remove_marketplace_calls == ["nyldn-plugins"]
+
+
+# ---------------------------------------------------------------------------
+# install_plugin
+# ---------------------------------------------------------------------------
+
+
+def test_install_plugin_argv_and_manifest(fake_claude, recorded_runs, fake_manifest):
+    result = svc.install_plugin("octo", marketplace="nyldn-plugins", scope="user")
+
+    assert result["status"] == "installed"
+    assert result["spec"] == "octo@nyldn-plugins"
+
+    install_cmds = [c["cmd"] for c in recorded_runs]
+    assert [
+        CLAUDE_BIN,
+        "plugin",
+        "install",
+        "octo@nyldn-plugins",
+        "--scope",
+        "user",
+    ] in install_cmds
+    assert [
+        CLAUDE_BIN,
+        "plugin",
+        "update",
+        "octo@nyldn-plugins",
+        "--scope",
+        "user",
+    ] in install_cmds
+
+    assert fake_manifest.add_plugin_calls == [
+        {
+            "repo": "",
+            "name": "octo",
+            "marketplace": "nyldn-plugins",
+            "scope": "user",
+            "branch": "main",
+        }
+    ]
+
+
+def test_install_plugin_no_marketplace_spec_is_bare_name(
+    fake_claude, recorded_runs, fake_manifest
+):
+    result = svc.install_plugin("octo")
+    assert result["spec"] == "octo"
+    assert [
+        CLAUDE_BIN,
+        "plugin",
+        "install",
+        "octo",
+        "--scope",
+        "user",
+    ] in [c["cmd"] for c in recorded_runs]
+
+
+def test_install_plugin_update_failure_is_nonfatal(
+    monkeypatch, fake_claude, fake_manifest
+):
+    def fake_run(cmd, *, token=""):
+        if "update" in cmd:
+            raise subprocess.CalledProcessError(1, cmd)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(svc, "run", fake_run)
+    result = svc.install_plugin("octo", marketplace="m")
+    assert result["status"] == "installed"
+    assert fake_manifest.add_plugin_calls  # still recorded
+
+
+def test_install_plugin_with_repo_adds_marketplace_first(
+    monkeypatch, fake_claude, recorded_runs, fake_manifest
+):
+    monkeypatch.setattr(
+        svc, "prepare_repo", lambda repo, **kw: svc.Path("/clones/octo-deadbeef")
+    )
+    svc.install_plugin("octo", marketplace="octo", repo="https://github.com/acme/octo")
+    cmds = [c["cmd"] for c in recorded_runs]
+    # marketplace add came before install
+    add_idx = cmds.index(
+        [
+            CLAUDE_BIN,
+            "plugin",
+            "marketplace",
+            "add",
+            "/clones/octo-deadbeef",
+            "--scope",
+            "user",
+        ]
+    )
+    install_idx = cmds.index(
+        [CLAUDE_BIN, "plugin", "install", "octo@octo", "--scope", "user"]
+    )
+    assert add_idx < install_idx
+
+
+def test_install_plugin_cli_failure_raises(monkeypatch, fake_claude, fake_manifest):
+    def boom(cmd, *, token=""):
+        raise subprocess.CalledProcessError(2, cmd)
+
+    monkeypatch.setattr(svc, "run", boom)
+    with pytest.raises(svc.PluginAdminError):
+        svc.install_plugin("octo", marketplace="m")
+    assert fake_manifest.add_plugin_calls == []
+
+
+# ---------------------------------------------------------------------------
+# uninstall_plugin
+# ---------------------------------------------------------------------------
+
+
+def test_uninstall_managed_plugin_removes_added(
+    fake_claude, recorded_runs, fake_manifest
+):
+    fake_manifest.added_entries = [
+        {"name": "octo", "marketplace": "nyldn-plugins", "scope": "user"}
+    ]
+    result = svc.uninstall_plugin("octo@nyldn-plugins", scope="user")
+
+    assert result["status"] == "uninstalled"
+    assert recorded_runs[-1]["cmd"] == [
+        CLAUDE_BIN,
+        "plugin",
+        "uninstall",
+        "octo@nyldn-plugins",
+        "--scope",
+        "user",
+    ]
+    assert fake_manifest.remove_added_calls == ["octo@nyldn-plugins"]
+    assert fake_manifest.mark_removed_calls == []
+
+
+def test_uninstall_env_plugin_marks_removed(fake_claude, recorded_runs, fake_manifest):
+    # Not present in manifest.added -> it came from env bootstrap.
+    fake_manifest.added_entries = []
+    result = svc.uninstall_plugin("telegram@other-mkt")
+
+    assert result["status"] == "uninstalled"
+    assert fake_manifest.mark_removed_calls == ["telegram@other-mkt"]
+    assert fake_manifest.remove_added_calls == []
+
+
+def test_uninstall_cli_failure_raises(monkeypatch, fake_claude, fake_manifest):
+    def boom(cmd, *, token=""):
+        raise subprocess.CalledProcessError(1, cmd)
+
+    monkeypatch.setattr(svc, "run", boom)
+    with pytest.raises(svc.PluginAdminError):
+        svc.uninstall_plugin("octo@m")
+    assert fake_manifest.mark_removed_calls == []
+    assert fake_manifest.remove_added_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Input validation — injection inputs must raise and run NO subprocess
+# ---------------------------------------------------------------------------
+
+
+INJECTION = ["x; rm -rf /", "a b", "$(whoami)", "a|b", "a`b`", "a&&b", "a>b"]
+
+
+@pytest.mark.parametrize("bad", INJECTION)
+def test_install_plugin_rejects_injection_name(
+    monkeypatch, bad, fake_claude, fake_manifest
+):
+    calls = []
+    monkeypatch.setattr(svc, "run", lambda cmd, **kw: calls.append(cmd))
+    with pytest.raises(svc.PluginAdminError):
+        svc.install_plugin(bad, marketplace="m")
+    assert calls == []
+    assert fake_manifest.add_plugin_calls == []
+
+
+@pytest.mark.parametrize("bad", INJECTION)
+def test_install_plugin_rejects_injection_marketplace(
+    monkeypatch, bad, fake_claude, fake_manifest
+):
+    calls = []
+    monkeypatch.setattr(
+        svc, "run", lambda cmd, **kw: calls.append(cmd)
+    )  # pragma: no cover
+    with pytest.raises(svc.PluginAdminError):
+        svc.install_plugin("octo", marketplace=bad)
+    assert calls == []
+
+
+@pytest.mark.parametrize("bad", INJECTION)
+def test_add_marketplace_rejects_injection_repo(
+    monkeypatch, bad, fake_claude, fake_manifest
+):
+    calls = []
+    monkeypatch.setattr(svc, "run", lambda cmd, **kw: calls.append(cmd))
+    with pytest.raises(svc.PluginAdminError):
+        svc.add_marketplace(bad)
+    assert calls == []
+
+
+@pytest.mark.parametrize("bad", INJECTION)
+def test_uninstall_rejects_injection(monkeypatch, bad, fake_claude, fake_manifest):
+    calls = []
+    monkeypatch.setattr(svc, "run", lambda cmd, **kw: calls.append(cmd))
+    with pytest.raises(svc.PluginAdminError):
+        svc.uninstall_plugin(bad)
+    assert calls == []
+    assert fake_manifest.mark_removed_calls == []
+
+
+@pytest.mark.parametrize("bad", INJECTION)
+def test_remove_marketplace_rejects_injection(
+    monkeypatch, bad, fake_claude, fake_manifest
+):
+    calls = []
+    monkeypatch.setattr(svc, "run", lambda cmd, **kw: calls.append(cmd))
+    with pytest.raises(svc.PluginAdminError):
+        svc.remove_marketplace(bad)
+    assert calls == []
+    assert fake_manifest.remove_marketplace_calls == []
+
+
+def test_invalid_scope_rejected(monkeypatch, fake_claude, fake_manifest):
+    calls = []
+    monkeypatch.setattr(svc, "run", lambda cmd, **kw: calls.append(cmd))
+    with pytest.raises(svc.PluginAdminError):
+        svc.install_plugin("octo", scope="root")
+    assert calls == []
+
+
+def test_missing_claude_bin_raises(monkeypatch, recorded_runs, fake_manifest):
+    monkeypatch.setattr(svc, "resolve_claude_bin", lambda: None)
+    with pytest.raises(svc.PluginAdminError):
+        svc.install_plugin("octo", marketplace="m")
+    # validation passed, but bin resolution failed before any subprocess
+    assert recorded_runs == []

--- a/tests/test_plugin_admin_service.py
+++ b/tests/test_plugin_admin_service.py
@@ -80,14 +80,14 @@ def fake_manifest(monkeypatch):
                 }
             )
 
-        def remove_added(self, spec):
-            self.remove_added_calls.append(spec)
+        def remove_added(self, spec, scope):
+            self.remove_added_calls.append((spec, scope))
 
-        def mark_removed(self, spec):
-            self.mark_removed_calls.append(spec)
+        def mark_removed(self, spec, scope):
+            self.mark_removed_calls.append((spec, scope))
 
-        def unmark_removed(self, spec):
-            self.unmark_removed_calls.append(spec)
+        def unmark_removed(self, spec, scope):
+            self.unmark_removed_calls.append((spec, scope))
 
         def remove_marketplace_entries(self, marketplace):
             self.remove_marketplace_calls.append(marketplace)
@@ -399,7 +399,7 @@ def test_uninstall_managed_plugin_removes_added(
         "--scope",
         "user",
     ]
-    assert fake_manifest.remove_added_calls == ["octo@nyldn-plugins"]
+    assert fake_manifest.remove_added_calls == [("octo@nyldn-plugins", "user")]
     assert fake_manifest.mark_removed_calls == []
 
 
@@ -409,8 +409,25 @@ def test_uninstall_env_plugin_marks_removed(fake_claude, recorded_runs, fake_man
     result = svc.uninstall_plugin("telegram@other-mkt")
 
     assert result["status"] == "uninstalled"
-    assert fake_manifest.mark_removed_calls == ["telegram@other-mkt"]
+    assert fake_manifest.mark_removed_calls == [("telegram@other-mkt", "user")]
     assert fake_manifest.remove_added_calls == []
+
+
+def test_uninstall_is_scope_specific(fake_claude, recorded_runs, fake_manifest):
+    # Same plugin managed only at project scope; uninstalling the user-scope
+    # install must NOT drop the project managed entry — it marks (spec, user)
+    # removed instead, and uninstalls at the requested scope.
+    fake_manifest.added_entries = [
+        {"name": "octo", "marketplace": "m", "scope": "project"}
+    ]
+    svc.uninstall_plugin("octo@m", scope="user")
+    assert recorded_runs[-1]["cmd"][-2:] == ["--scope", "user"]
+    assert fake_manifest.remove_added_calls == []
+    assert fake_manifest.mark_removed_calls == [("octo@m", "user")]
+
+    # Uninstalling the managed project install drops exactly that entry.
+    svc.uninstall_plugin("octo@m", scope="project")
+    assert fake_manifest.remove_added_calls == [("octo@m", "project")]
 
 
 def test_uninstall_cli_failure_raises(monkeypatch, fake_claude, fake_manifest):

--- a/tests/test_plugin_admin_service.py
+++ b/tests/test_plugin_admin_service.py
@@ -399,35 +399,37 @@ def test_uninstall_managed_plugin_removes_added(
         "--scope",
         "user",
     ]
+    # uninstall always drops any managed entry AND records the removal, so an
+    # env-bootstrap declaration of the same plugin can't resurrect it on restart.
     assert fake_manifest.remove_added_calls == [("octo@nyldn-plugins", "user")]
-    assert fake_manifest.mark_removed_calls == []
+    assert fake_manifest.mark_removed_calls == [("octo@nyldn-plugins", "user")]
 
 
 def test_uninstall_env_plugin_marks_removed(fake_claude, recorded_runs, fake_manifest):
-    # Not present in manifest.added -> it came from env bootstrap.
+    # Not present in manifest.added -> remove_added is a harmless no-op, but the
+    # removal is still recorded so startup skips/uninstalls it.
     fake_manifest.added_entries = []
     result = svc.uninstall_plugin("telegram@other-mkt")
 
     assert result["status"] == "uninstalled"
     assert fake_manifest.mark_removed_calls == [("telegram@other-mkt", "user")]
-    assert fake_manifest.remove_added_calls == []
+    assert fake_manifest.remove_added_calls == [("telegram@other-mkt", "user")]
 
 
-def test_uninstall_is_scope_specific(fake_claude, recorded_runs, fake_manifest):
-    # Same plugin managed only at project scope; uninstalling the user-scope
-    # install must NOT drop the project managed entry — it marks (spec, user)
-    # removed instead, and uninstalls at the requested scope.
+def test_uninstall_records_at_requested_scope(fake_claude, recorded_runs, fake_manifest):
+    # scope is part of the identity: uninstall targets and records the requested
+    # scope, leaving any other-scope install of the same plugin untouched.
     fake_manifest.added_entries = [
         {"name": "octo", "marketplace": "m", "scope": "project"}
     ]
     svc.uninstall_plugin("octo@m", scope="user")
     assert recorded_runs[-1]["cmd"][-2:] == ["--scope", "user"]
-    assert fake_manifest.remove_added_calls == []
+    assert fake_manifest.remove_added_calls == [("octo@m", "user")]
     assert fake_manifest.mark_removed_calls == [("octo@m", "user")]
 
-    # Uninstalling the managed project install drops exactly that entry.
     svc.uninstall_plugin("octo@m", scope="project")
-    assert fake_manifest.remove_added_calls == [("octo@m", "project")]
+    assert ("octo@m", "project") in fake_manifest.remove_added_calls
+    assert ("octo@m", "project") in fake_manifest.mark_removed_calls
 
 
 def test_uninstall_cli_failure_raises(monkeypatch, fake_claude, fake_manifest):
@@ -483,6 +485,41 @@ def test_add_marketplace_rejects_injection_repo(
     with pytest.raises(svc.PluginAdminError):
         svc.add_marketplace(bad)
     assert calls == []
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "https://user:token@host/o/r.git",
+        "https://ghp_secrettoken@github.com/o/r.git",
+        "http://x:y@host/o/r.git",
+    ],
+)
+def test_add_marketplace_rejects_credential_url(
+    monkeypatch, bad, fake_claude, fake_manifest
+):
+    # Credentials in the URL would leak into the manifest/response/logs; reject
+    # before any subprocess and steer the caller to the git_token field.
+    calls = []
+    monkeypatch.setattr(svc, "run", lambda cmd, **kw: calls.append(cmd))
+    with pytest.raises(svc.PluginAdminError):
+        svc.add_marketplace(bad)
+    assert calls == []
+    assert fake_manifest.set_marketplace_calls == []
+
+
+def test_remove_marketplace_best_effort_scope(monkeypatch, fake_claude, fake_manifest):
+    # An env-added project marketplace has no manifest scope record, so the UI
+    # sends user; removal falls back across scopes and succeeds at project.
+    def fake_run(cmd, *, token=""):
+        if cmd[-2:] == ["--scope", "user"]:
+            raise subprocess.CalledProcessError(1, cmd)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(svc, "run", fake_run)
+    result = svc.remove_marketplace("envmkt", scope="user")
+    assert result["scope"] == "project"
+    assert fake_manifest.remove_marketplace_calls == ["envmkt"]
 
 
 @pytest.mark.parametrize("bad", INJECTION)

--- a/tests/test_plugin_admin_service.py
+++ b/tests/test_plugin_admin_service.py
@@ -264,6 +264,63 @@ def test_install_plugin_with_repo_adds_marketplace_first(
     assert add_idx < install_idx
 
 
+def test_install_from_catalog_resolves_marketplace_repo(
+    monkeypatch, tmp_path, fake_claude, recorded_runs, fake_manifest
+):
+    # A catalog install passes only a marketplace name (repo=""). The service
+    # must resolve the marketplace's repo from known_marketplaces.json so the
+    # manifest entry carries a replayable repo (the startup installer skips
+    # entries with no repo).
+    import json as _json
+
+    plugins_dir = tmp_path / ".claude" / "plugins"
+    plugins_dir.mkdir(parents=True)
+    (plugins_dir / "known_marketplaces.json").write_text(
+        _json.dumps(
+            {
+                "nyldn-plugins": {
+                    "source": {"source": "github", "repo": "acme/nyldn"},
+                    "installLocation": str(plugins_dir / "marketplaces" / "nyldn"),
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    svc.install_plugin("octo", marketplace="nyldn-plugins", scope="user")
+
+    assert fake_manifest.add_plugin_calls == [
+        {
+            "repo": "https://github.com/acme/nyldn.git",
+            "name": "octo",
+            "marketplace": "nyldn-plugins",
+            "scope": "user",
+            "branch": "main",
+        }
+    ]
+
+
+def test_resolve_marketplace_repo_prefers_full_url(monkeypatch, tmp_path):
+    import json as _json
+
+    plugins_dir = tmp_path / ".claude" / "plugins"
+    plugins_dir.mkdir(parents=True)
+    (plugins_dir / "known_marketplaces.json").write_text(
+        _json.dumps(
+            {"m": {"source": {"source": "git", "url": "https://git.example/m.git"}}}
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert svc._resolve_marketplace_repo("m") == "https://git.example/m.git"
+
+
+def test_resolve_marketplace_repo_unknown_returns_empty(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert svc._resolve_marketplace_repo("nope") == ""
+
+
 def test_install_plugin_cli_failure_raises(monkeypatch, fake_claude, fake_manifest):
     def boom(cmd, *, token=""):
         raise subprocess.CalledProcessError(2, cmd)

--- a/tests/test_plugin_manifest.py
+++ b/tests/test_plugin_manifest.py
@@ -1,6 +1,7 @@
 """Tests for the persistent managed plugin manifest."""
 
 import json
+import threading
 
 import pytest
 
@@ -170,6 +171,29 @@ def test_remove_marketplace_entries_drops_record(manifest_file):
     plugin_manifest.remove_marketplace_entries("mkt1")
     assert plugin_manifest.get_marketplace("mkt1") == {}
     assert plugin_manifest.list_added() == []
+
+
+def test_concurrent_add_plugin_no_lost_updates(manifest_file):
+    # Concurrent admin mutations (run_in_threadpool) must not clobber each
+    # other: each add_plugin is a read-modify-write that has to run under the
+    # lock, else two requests read the same manifest and the last save wins.
+    n = 12
+    barrier = threading.Barrier(n)
+
+    def worker(i):
+        barrier.wait()  # force all writers to contend at once
+        plugin_manifest.add_plugin(
+            repo="r", name=f"p{i}", marketplace="m", scope="user", branch="main"
+        )
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    names = sorted(e["name"] for e in plugin_manifest.list_added())
+    assert names == sorted(f"p{i}" for i in range(n))
 
 
 def test_save_creates_parent_dirs(tmp_path, monkeypatch):

--- a/tests/test_plugin_manifest.py
+++ b/tests/test_plugin_manifest.py
@@ -19,7 +19,12 @@ def test_manifest_path_env_override(manifest_file):
 
 
 def test_load_missing_returns_defaults(manifest_file):
-    assert plugin_manifest.load() == {"version": 1, "added": [], "removed": []}
+    assert plugin_manifest.load() == {
+        "version": 1,
+        "added": [],
+        "removed": [],
+        "marketplaces": {},
+    }
 
 
 def test_save_load_roundtrip(manifest_file):
@@ -35,6 +40,7 @@ def test_save_load_roundtrip(manifest_file):
             }
         ],
         "removed": ["foo@bar"],
+        "marketplaces": {},
     }
     plugin_manifest.save(data)
     assert json.loads(manifest_file.read_text(encoding="utf-8")) == data
@@ -43,12 +49,22 @@ def test_save_load_roundtrip(manifest_file):
 
 def test_load_corrupt_file_fallback(manifest_file):
     manifest_file.write_text("{not valid json", encoding="utf-8")
-    assert plugin_manifest.load() == {"version": 1, "added": [], "removed": []}
+    assert plugin_manifest.load() == {
+        "version": 1,
+        "added": [],
+        "removed": [],
+        "marketplaces": {},
+    }
 
 
 def test_load_wrong_types_fallback(manifest_file):
     manifest_file.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
-    assert plugin_manifest.load() == {"version": 1, "added": [], "removed": []}
+    assert plugin_manifest.load() == {
+        "version": 1,
+        "added": [],
+        "removed": [],
+        "marketplaces": {},
+    }
 
 
 def test_load_coerces_bad_member_types(manifest_file):
@@ -131,6 +147,29 @@ def test_remove_marketplace_entries(manifest_file):
     plugin_manifest.remove_marketplace_entries("mkt1")
     names = [e["name"] for e in plugin_manifest.list_added()]
     assert names == ["c"]
+
+
+def test_marketplace_record_set_get_list(manifest_file):
+    plugin_manifest.set_marketplace(
+        "mkt1", repo="https://github.com/acme/mkt1.git", branch="dev", scope="project"
+    )
+    assert plugin_manifest.get_marketplace("mkt1") == {
+        "repo": "https://github.com/acme/mkt1.git",
+        "branch": "dev",
+        "scope": "project",
+    }
+    assert plugin_manifest.get_marketplace("missing") == {}
+    assert "mkt1" in plugin_manifest.list_marketplace_records()
+
+
+def test_remove_marketplace_entries_drops_record(manifest_file):
+    plugin_manifest.set_marketplace("mkt1", repo="r", branch="main", scope="user")
+    plugin_manifest.add_plugin(
+        repo="r", name="a", marketplace="mkt1", scope="user", branch="main"
+    )
+    plugin_manifest.remove_marketplace_entries("mkt1")
+    assert plugin_manifest.get_marketplace("mkt1") == {}
+    assert plugin_manifest.list_added() == []
 
 
 def test_save_creates_parent_dirs(tmp_path, monkeypatch):

--- a/tests/test_plugin_manifest.py
+++ b/tests/test_plugin_manifest.py
@@ -1,0 +1,140 @@
+"""Tests for the persistent managed plugin manifest."""
+
+import json
+
+import pytest
+
+from src import plugin_manifest
+
+
+@pytest.fixture
+def manifest_file(tmp_path, monkeypatch):
+    path = tmp_path / "gateway-plugins.json"
+    monkeypatch.setenv("CLAUDE_PLUGIN_MANIFEST", str(path))
+    return path
+
+
+def test_manifest_path_env_override(manifest_file):
+    assert plugin_manifest.manifest_path() == manifest_file
+
+
+def test_load_missing_returns_defaults(manifest_file):
+    assert plugin_manifest.load() == {"version": 1, "added": [], "removed": []}
+
+
+def test_save_load_roundtrip(manifest_file):
+    data = {
+        "version": 1,
+        "added": [
+            {
+                "repo": "https://example.com/x.git",
+                "name": "octo",
+                "marketplace": "nyldn-plugins",
+                "scope": "user",
+                "branch": "main",
+            }
+        ],
+        "removed": ["foo@bar"],
+    }
+    plugin_manifest.save(data)
+    assert json.loads(manifest_file.read_text(encoding="utf-8")) == data
+    assert plugin_manifest.load() == data
+
+
+def test_load_corrupt_file_fallback(manifest_file):
+    manifest_file.write_text("{not valid json", encoding="utf-8")
+    assert plugin_manifest.load() == {"version": 1, "added": [], "removed": []}
+
+
+def test_load_wrong_types_fallback(manifest_file):
+    manifest_file.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+    assert plugin_manifest.load() == {"version": 1, "added": [], "removed": []}
+
+
+def test_load_coerces_bad_member_types(manifest_file):
+    manifest_file.write_text(
+        json.dumps(
+            {
+                "version": "x",
+                "added": [{"name": "a", "marketplace": "m"}, "junk"],
+                "removed": ["ok", 5],
+            }
+        ),
+        encoding="utf-8",
+    )
+    data = plugin_manifest.load()
+    assert data["version"] == 1
+    assert data["added"] == [{"name": "a", "marketplace": "m"}]
+    assert data["removed"] == ["ok"]
+
+
+def test_spec_for():
+    assert plugin_manifest.spec_for("octo", "nyldn-plugins") == "octo@nyldn-plugins"
+    assert plugin_manifest.spec_for("octo", "") == "octo"
+
+
+def test_add_plugin_upsert_and_unmark_removed(manifest_file):
+    spec = "octo@nyldn-plugins"
+    plugin_manifest.mark_removed(spec)
+    plugin_manifest.add_plugin(
+        repo="https://example.com/x.git",
+        name="octo",
+        marketplace="nyldn-plugins",
+        scope="user",
+        branch="main",
+    )
+    # add a second time with a different branch -> upsert (no duplicate)
+    plugin_manifest.add_plugin(
+        repo="https://example.com/x.git",
+        name="octo",
+        marketplace="nyldn-plugins",
+        scope="project",
+        branch="dev",
+    )
+    added = plugin_manifest.list_added()
+    assert len(added) == 1
+    assert added[0]["scope"] == "project"
+    assert added[0]["branch"] == "dev"
+    # add_plugin cleared the removed mark
+    assert spec not in plugin_manifest.list_removed()
+
+
+def test_remove_added(manifest_file):
+    plugin_manifest.add_plugin(
+        repo="r", name="octo", marketplace="nyldn-plugins", scope="user", branch="main"
+    )
+    plugin_manifest.remove_added("octo@nyldn-plugins")
+    assert plugin_manifest.list_added() == []
+    # no-op when absent
+    plugin_manifest.remove_added("missing@x")
+
+
+def test_mark_unmark_removed_idempotent(manifest_file):
+    plugin_manifest.mark_removed("foo@bar")
+    plugin_manifest.mark_removed("foo@bar")
+    assert plugin_manifest.list_removed() == ["foo@bar"]
+    plugin_manifest.unmark_removed("foo@bar")
+    plugin_manifest.unmark_removed("foo@bar")
+    assert plugin_manifest.list_removed() == []
+
+
+def test_remove_marketplace_entries(manifest_file):
+    plugin_manifest.add_plugin(
+        repo="r", name="a", marketplace="mkt1", scope="user", branch="main"
+    )
+    plugin_manifest.add_plugin(
+        repo="r", name="b", marketplace="mkt1", scope="user", branch="main"
+    )
+    plugin_manifest.add_plugin(
+        repo="r", name="c", marketplace="mkt2", scope="user", branch="main"
+    )
+    plugin_manifest.remove_marketplace_entries("mkt1")
+    names = [e["name"] for e in plugin_manifest.list_added()]
+    assert names == ["c"]
+
+
+def test_save_creates_parent_dirs(tmp_path, monkeypatch):
+    nested = tmp_path / "deep" / "nested" / "gateway-plugins.json"
+    monkeypatch.setenv("CLAUDE_PLUGIN_MANIFEST", str(nested))
+    plugin_manifest.save(plugin_manifest.load())
+    assert nested.is_file()

--- a/tests/test_plugin_manifest.py
+++ b/tests/test_plugin_manifest.py
@@ -40,7 +40,7 @@ def test_save_load_roundtrip(manifest_file):
                 "branch": "main",
             }
         ],
-        "removed": ["foo@bar"],
+        "removed": [{"spec": "foo@bar", "scope": "user"}],
         "marketplaces": {},
     }
     plugin_manifest.save(data)
@@ -74,7 +74,7 @@ def test_load_coerces_bad_member_types(manifest_file):
             {
                 "version": "x",
                 "added": [{"name": "a", "marketplace": "m"}, "junk"],
-                "removed": ["ok", 5],
+                "removed": ["ok", 5, {"spec": "p@m", "scope": "project"}],
             }
         ),
         encoding="utf-8",
@@ -82,7 +82,11 @@ def test_load_coerces_bad_member_types(manifest_file):
     data = plugin_manifest.load()
     assert data["version"] == 1
     assert data["added"] == [{"name": "a", "marketplace": "m"}]
-    assert data["removed"] == ["ok"]
+    # legacy string -> user scope; bad member dropped; dict form preserved
+    assert data["removed"] == [
+        {"spec": "ok", "scope": "user"},
+        {"spec": "p@m", "scope": "project"},
+    ]
 
 
 def test_spec_for():
@@ -90,9 +94,9 @@ def test_spec_for():
     assert plugin_manifest.spec_for("octo", "") == "octo"
 
 
-def test_add_plugin_upsert_and_unmark_removed(manifest_file):
+def test_add_plugin_upsert_same_scope_and_unmark_removed(manifest_file):
     spec = "octo@nyldn-plugins"
-    plugin_manifest.mark_removed(spec)
+    plugin_manifest.mark_removed(spec, "user")
     plugin_manifest.add_plugin(
         repo="https://example.com/x.git",
         name="octo",
@@ -100,39 +104,54 @@ def test_add_plugin_upsert_and_unmark_removed(manifest_file):
         scope="user",
         branch="main",
     )
-    # add a second time with a different branch -> upsert (no duplicate)
+    # re-add at the SAME scope with a different branch -> upsert (no duplicate)
     plugin_manifest.add_plugin(
         repo="https://example.com/x.git",
         name="octo",
         marketplace="nyldn-plugins",
-        scope="project",
+        scope="user",
         branch="dev",
     )
     added = plugin_manifest.list_added()
     assert len(added) == 1
-    assert added[0]["scope"] == "project"
     assert added[0]["branch"] == "dev"
-    # add_plugin cleared the removed mark
-    assert spec not in plugin_manifest.list_removed()
+    # add_plugin cleared the (spec, user) removed mark
+    assert plugin_manifest.list_removed() == []
 
 
-def test_remove_added(manifest_file):
-    plugin_manifest.add_plugin(
-        repo="r", name="octo", marketplace="nyldn-plugins", scope="user", branch="main"
-    )
-    plugin_manifest.remove_added("octo@nyldn-plugins")
-    assert plugin_manifest.list_added() == []
+def test_add_plugin_distinct_scopes_coexist(manifest_file):
+    # The same plugin installed at two scopes is two managed entries (scope is
+    # part of the identity), so both replay on startup.
+    for sc in ("user", "project"):
+        plugin_manifest.add_plugin(
+            repo="r", name="octo", marketplace="m", scope=sc, branch="main"
+        )
+    scopes = sorted(e["scope"] for e in plugin_manifest.list_added())
+    assert scopes == ["project", "user"]
+
+
+def test_remove_added_is_scope_specific(manifest_file):
+    for sc in ("user", "project"):
+        plugin_manifest.add_plugin(
+            repo="r", name="octo", marketplace="m", scope=sc, branch="main"
+        )
+    plugin_manifest.remove_added("octo@m", "user")
+    remaining = plugin_manifest.list_added()
+    assert [e["scope"] for e in remaining] == ["project"]
     # no-op when absent
-    plugin_manifest.remove_added("missing@x")
+    plugin_manifest.remove_added("missing@x", "user")
 
 
 def test_mark_unmark_removed_idempotent(manifest_file):
-    plugin_manifest.mark_removed("foo@bar")
-    plugin_manifest.mark_removed("foo@bar")
-    assert plugin_manifest.list_removed() == ["foo@bar"]
-    plugin_manifest.unmark_removed("foo@bar")
-    plugin_manifest.unmark_removed("foo@bar")
-    assert plugin_manifest.list_removed() == []
+    plugin_manifest.mark_removed("foo@bar", "project")
+    plugin_manifest.mark_removed("foo@bar", "project")
+    assert plugin_manifest.list_removed() == [{"spec": "foo@bar", "scope": "project"}]
+    # a different scope is a distinct removal
+    plugin_manifest.mark_removed("foo@bar", "user")
+    assert len(plugin_manifest.list_removed()) == 2
+    plugin_manifest.unmark_removed("foo@bar", "project")
+    plugin_manifest.unmark_removed("foo@bar", "project")
+    assert plugin_manifest.list_removed() == [{"spec": "foo@bar", "scope": "user"}]
 
 
 def test_remove_marketplace_entries(manifest_file):

--- a/tests/test_plugin_service.py
+++ b/tests/test_plugin_service.py
@@ -13,9 +13,12 @@ from src.plugin_service import (
     _parse_plugin_id,
     _read_json,
     _validate_install_path,
+    _validate_marketplace_path,
+    get_marketplaces_with_plugins,
     get_plugin_blocklist,
     get_plugin_detail,
     get_plugin_skill_content,
+    list_marketplace_plugins,
     list_marketplaces,
     list_plugins,
 )
@@ -92,6 +95,35 @@ def _make_plugin_tree(plugins_root: Path) -> Path:
                     "installLocation": str(plugins_root / "marketplaces" / "test-mkt"),
                     "lastUpdated": "2026-03-01T00:00:00Z",
                 }
+            }
+        )
+    )
+
+    # marketplace catalog (.claude-plugin/marketplace.json)
+    mkt_meta = plugins_root / "marketplaces" / "test-mkt" / ".claude-plugin"
+    mkt_meta.mkdir(parents=True)
+    (mkt_meta / "marketplace.json").write_text(
+        json.dumps(
+            {
+                "name": "test-mkt",
+                "owner": {"name": "tester"},
+                "metadata": {},
+                "plugins": [
+                    {
+                        "name": "demo-plugin",
+                        "description": "A demo plugin for testing",
+                        "source": "./demo-plugin",
+                        "strict": True,
+                        "version": "1.0.0",
+                        "skills": ["greet", "farewell"],
+                    },
+                    {
+                        "name": "other-plugin",
+                        "description": "Not installed",
+                        "source": "./other-plugin",
+                        "strict": False,
+                    },
+                ],
             }
         )
     )
@@ -519,3 +551,162 @@ class TestPluginRoutes:
         resp = client.get("/admin/api/plugins/blocklist")
         assert resp.status_code == 200
         assert len(resp.json()["blocklist"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# _validate_marketplace_path
+# ---------------------------------------------------------------------------
+
+
+class TestValidateMarketplacePath:
+    def test_valid_path(self, plugins_dir):
+        loc = plugins_dir / "marketplaces" / "test-mkt"
+        result = _validate_marketplace_path(loc)
+        assert result is not None
+        assert result.is_dir()
+
+    def test_outside_marketplaces_rejected(self, plugins_dir):
+        assert _validate_marketplace_path(Path("/tmp")) is None
+
+    def test_no_plugins_root(self, no_plugins_dir):
+        assert _validate_marketplace_path(Path("/anything")) is None
+
+    def test_nonexistent_rejected(self, plugins_dir):
+        assert (
+            _validate_marketplace_path(plugins_dir / "marketplaces" / "nope")
+            is None
+        )
+
+    def test_symlink_rejected(self, plugins_dir):
+        real = plugins_dir / "marketplaces" / "test-mkt"
+        link = plugins_dir / "marketplaces" / "evil-link"
+        link.symlink_to(real)
+        assert _validate_marketplace_path(link) is None
+
+
+# ---------------------------------------------------------------------------
+# list_marketplace_plugins
+# ---------------------------------------------------------------------------
+
+
+class TestListMarketplacePlugins:
+    def test_installed_flag(self, plugins_dir):
+        plugins = list_marketplace_plugins("test-mkt")
+        by_name = {p["name"]: p for p in plugins}
+        assert by_name["demo-plugin"]["installed"] is True
+        assert by_name["demo-plugin"]["id"] == "demo-plugin@test-mkt"
+        assert by_name["demo-plugin"]["version"] == "1.0.0"
+        assert by_name["demo-plugin"]["skill_count"] == 2
+        assert by_name["other-plugin"]["installed"] is False
+        assert by_name["other-plugin"]["version"] == ""
+        assert by_name["other-plugin"]["skill_count"] == 0
+
+    def test_unknown_marketplace(self, plugins_dir):
+        assert list_marketplace_plugins("does-not-exist") == []
+
+    def test_missing_catalog(self, plugins_dir):
+        # installLocation present + valid but no marketplace.json inside.
+        empty_loc = plugins_dir / "marketplaces" / "empty-mkt"
+        empty_loc.mkdir(parents=True)
+        known = plugins_dir / "known_marketplaces.json"
+        known.write_text(
+            json.dumps(
+                {
+                    "empty-mkt": {
+                        "source": {"source": "github", "repo": "x/y"},
+                        "installLocation": str(empty_loc),
+                        "lastUpdated": "2026-03-01T00:00:00Z",
+                    }
+                }
+            )
+        )
+        assert list_marketplace_plugins("empty-mkt") == []
+
+    def test_corrupt_catalog(self, plugins_dir):
+        catalog = (
+            plugins_dir
+            / "marketplaces"
+            / "test-mkt"
+            / ".claude-plugin"
+            / "marketplace.json"
+        )
+        catalog.write_text("not json {{{")
+        assert list_marketplace_plugins("test-mkt") == []
+
+    def test_symlinked_install_location_rejected(self, plugins_dir):
+        real = plugins_dir / "marketplaces" / "test-mkt"
+        link = plugins_dir / "marketplaces" / "linked-mkt"
+        link.symlink_to(real)
+        known = plugins_dir / "known_marketplaces.json"
+        known.write_text(
+            json.dumps(
+                {
+                    "linked-mkt": {
+                        "source": {"source": "github", "repo": "x/y"},
+                        "installLocation": str(link),
+                        "lastUpdated": "2026-03-01T00:00:00Z",
+                    }
+                }
+            )
+        )
+        assert list_marketplace_plugins("linked-mkt") == []
+
+    def test_no_plugins_dir(self, no_plugins_dir):
+        assert list_marketplace_plugins("test-mkt") == []
+
+
+# ---------------------------------------------------------------------------
+# get_marketplaces_with_plugins
+# ---------------------------------------------------------------------------
+
+
+class TestGetMarketplacesWithPlugins:
+    def test_aggregation(self, plugins_dir):
+        result = get_marketplaces_with_plugins()
+        assert len(result) == 1
+        mkt = result[0]
+        assert mkt["name"] == "test-mkt"
+        assert mkt["plugin_count"] == 2
+        assert len(mkt["plugins"]) == 2
+        names = {p["name"] for p in mkt["plugins"]}
+        assert names == {"demo-plugin", "other-plugin"}
+
+    def test_no_plugins_dir(self, no_plugins_dir):
+        assert get_marketplaces_with_plugins() == []
+
+
+# ---------------------------------------------------------------------------
+# origin field (managed vs env)
+# ---------------------------------------------------------------------------
+
+
+class TestPluginOrigin:
+    def test_env_origin_when_not_managed(self, plugins_dir):
+        with patch("src.plugin_manifest.list_added", return_value=[]):
+            plugins = list_plugins()
+            assert plugins[0]["origin"] == "env"
+            detail = get_plugin_detail("demo-plugin@test-mkt")
+            assert detail["origin"] == "env"
+
+    def test_managed_origin(self, plugins_dir):
+        fake = [
+            {
+                "repo": "test/marketplace",
+                "name": "demo-plugin",
+                "marketplace": "test-mkt",
+                "scope": "user",
+                "branch": "main",
+            }
+        ]
+        with patch("src.plugin_manifest.list_added", return_value=fake):
+            plugins = list_plugins()
+            assert plugins[0]["origin"] == "managed"
+            detail = get_plugin_detail("demo-plugin@test-mkt")
+            assert detail["origin"] == "managed"
+
+    def test_origin_defaults_env_on_manifest_failure(self, plugins_dir):
+        with patch(
+            "src.plugin_manifest.list_added", side_effect=RuntimeError("boom")
+        ):
+            plugins = list_plugins()
+            assert plugins[0]["origin"] == "env"

--- a/tests/test_plugin_service.py
+++ b/tests/test_plugin_service.py
@@ -601,6 +601,27 @@ class TestListMarketplacePlugins:
         assert by_name["other-plugin"]["version"] == ""
         assert by_name["other-plugin"]["skill_count"] == 0
 
+    def test_installed_scope_reflects_registry(self, plugins_dir):
+        # An installed catalog entry exposes its real registry scope (so the UI
+        # can uninstall with the correct scope); not-installed entries default
+        # to "user".
+        known = plugins_dir / "installed_plugins.json"
+        known.write_text(
+            json.dumps(
+                {
+                    "version": 2,
+                    "plugins": {
+                        "demo-plugin@test-mkt": [
+                            {"scope": "local", "installPath": "/x", "version": "1.0.0"}
+                        ]
+                    },
+                }
+            )
+        )
+        by_name = {p["name"]: p for p in list_marketplace_plugins("test-mkt")}
+        assert by_name["demo-plugin"]["scope"] == "local"
+        assert by_name["other-plugin"]["scope"] == "user"
+
     def test_unknown_marketplace(self, plugins_dir):
         assert list_marketplace_plugins("does-not-exist") == []
 

--- a/tests/test_plugin_service.py
+++ b/tests/test_plugin_service.py
@@ -349,6 +349,36 @@ class TestListPlugins:
         assert p["skill_count"] == 2
         assert p["command_count"] == 1
 
+    def test_multi_scope_emits_one_row_per_scope(self, plugins_dir):
+        # claude stores one entry per scope under a plugin id; each must surface
+        # as its own row so it is visible and removable at its real scope.
+        cache = plugins_dir / "cache" / "test-mkt" / "demo-plugin" / "1.0.0"
+        reg = plugins_dir / "installed_plugins.json"
+        reg.write_text(
+            json.dumps(
+                {
+                    "version": 2,
+                    "plugins": {
+                        "demo-plugin@test-mkt": [
+                            {
+                                "scope": "user",
+                                "installPath": str(cache),
+                                "version": "1.0.0",
+                            },
+                            {
+                                "scope": "project",
+                                "installPath": str(cache),
+                                "version": "1.0.0",
+                            },
+                        ]
+                    },
+                }
+            )
+        )
+        rows = list_plugins()
+        assert sorted(p["scope"] for p in rows) == ["project", "user"]
+        assert all(p["id"] == "demo-plugin@test-mkt" for p in rows)
+
     def test_no_plugins_dir(self, no_plugins_dir):
         assert list_plugins() == []
 
@@ -393,6 +423,38 @@ class TestListPlugins:
 
 
 class TestGetPluginDetail:
+    def test_selects_entry_by_scope(self, plugins_dir):
+        # With per-scope entries, the scope arg picks the right one (default first).
+        cache = plugins_dir / "cache" / "test-mkt" / "demo-plugin" / "1.0.0"
+        reg = plugins_dir / "installed_plugins.json"
+        reg.write_text(
+            json.dumps(
+                {
+                    "version": 2,
+                    "plugins": {
+                        "demo-plugin@test-mkt": [
+                            {
+                                "scope": "user",
+                                "installPath": str(cache),
+                                "version": "1.0.0",
+                            },
+                            {
+                                "scope": "project",
+                                "installPath": str(cache),
+                                "version": "9.9.9",
+                            },
+                        ]
+                    },
+                }
+            )
+        )
+        proj = get_plugin_detail("demo-plugin@test-mkt", "project")
+        user = get_plugin_detail("demo-plugin@test-mkt", "user")
+        assert proj["version"] == "9.9.9"
+        assert user["version"] == "1.0.0"
+        # default (no scope) -> first entry
+        assert get_plugin_detail("demo-plugin@test-mkt")["version"] == "1.0.0"
+
     def test_existing_plugin(self, plugins_dir):
         detail = get_plugin_detail("demo-plugin@test-mkt")
         assert detail is not None
@@ -668,26 +730,33 @@ class TestListMarketplacePlugins:
         assert plugins[0]["version"] == "2.0.0"
         assert plugins[0]["installed"] is False
 
-    def test_installed_scope_reflects_registry(self, plugins_dir):
-        # An installed catalog entry exposes its real registry scope (so the UI
-        # can uninstall with the correct scope); not-installed entries default
-        # to "user".
-        known = plugins_dir / "installed_plugins.json"
-        known.write_text(
-            json.dumps(
-                {
-                    "version": 2,
-                    "plugins": {
-                        "demo-plugin@test-mkt": [
-                            {"scope": "local", "installPath": "/x", "version": "1.0.0"}
-                        ]
-                    },
-                }
-            )
+    def test_catalog_scope_is_marketplace_scope(self, plugins_dir, monkeypatch):
+        # The catalog reports the marketplace's own scope (the scope a one-click
+        # install would target), and availability is judged at THAT scope.
+        from src import plugin_manifest
+
+        monkeypatch.setattr(
+            plugin_manifest,
+            "list_marketplace_records",
+            lambda: {"test-mkt": {"repo": "r", "branch": "main", "scope": "project"}},
         )
         by_name = {p["name"]: p for p in list_marketplace_plugins("test-mkt")}
-        assert by_name["demo-plugin"]["scope"] == "local"
-        assert by_name["other-plugin"]["scope"] == "user"
+        # marketplace is project-scope; demo-plugin is installed only at user
+        # scope (fixture), so at the marketplace's project scope it is NOT yet
+        # installed -> still available, and the row scope is the marketplace's.
+        assert by_name["demo-plugin"]["scope"] == "project"
+        assert by_name["demo-plugin"]["installed"] is False
+        assert by_name["other-plugin"]["scope"] == "project"
+
+    def test_catalog_installed_when_scope_matches(self, plugins_dir, monkeypatch):
+        # demo-plugin is installed at user scope in the fixture; a user-scope
+        # marketplace (default, no record) therefore shows it as installed.
+        from src import plugin_manifest
+
+        monkeypatch.setattr(plugin_manifest, "list_marketplace_records", lambda: {})
+        by_name = {p["name"]: p for p in list_marketplace_plugins("test-mkt")}
+        assert by_name["demo-plugin"]["scope"] == "user"
+        assert by_name["demo-plugin"]["installed"] is True
 
     def test_unknown_marketplace(self, plugins_dir):
         assert list_marketplace_plugins("does-not-exist") == []

--- a/tests/test_plugin_service.py
+++ b/tests/test_plugin_service.py
@@ -617,8 +617,48 @@ class TestListMarketplaces:
         monkeypatch.setenv("CLAUDE_PLUGIN_ENV_JOURNAL", str(journal))
         assert list_marketplaces()[0]["scope"] == "local"
 
+    def test_credential_url_is_stripped_from_repo_field(self, plugins_dir):
+        # A known_marketplaces.json source.url with embedded credentials must not
+        # be surfaced verbatim by the listing/catalog API.
+        (plugins_dir / "known_marketplaces.json").write_text(
+            json.dumps(
+                {
+                    "priv-mkt": {
+                        "source": {
+                            "source": "git",
+                            "url": "https://user:secret-token@host/org/priv.git",
+                        },
+                        "installLocation": str(
+                            plugins_dir / "marketplaces" / "priv-mkt"
+                        ),
+                    }
+                }
+            )
+        )
+        mkts = list_marketplaces()
+        assert mkts[0]["repo"] == "https://host/org/priv.git"
+        assert "secret-token" not in json.dumps(mkts)
+
     def test_no_plugins_dir(self, no_plugins_dir):
         assert list_marketplaces() == []
+
+
+class TestStripUrlCredentials:
+    def test_strips_http_userinfo(self):
+        from src.plugin_service import _strip_url_credentials as f
+
+        assert f("https://user:tok@host/o/r.git") == "https://host/o/r.git"
+        assert f("https://tok@host/o/r.git") == "https://host/o/r.git"
+        assert f("http://u:p@host:8443/r") == "http://host:8443/r"
+
+    def test_leaves_clean_and_non_http_untouched(self):
+        from src.plugin_service import _strip_url_credentials as f
+
+        assert f("https://host/o/r.git") == "https://host/o/r.git"
+        assert f("ssh://git@host/o/r.git") == "ssh://git@host/o/r.git"
+        assert f("git@host:o/r.git") == "git@host:o/r.git"
+        assert f("/clones/local") == "/clones/local"
+        assert f("") == ""
 
 
 class TestEnvBootstrapRecords:

--- a/tests/test_plugin_service.py
+++ b/tests/test_plugin_service.py
@@ -455,6 +455,31 @@ class TestGetPluginDetail:
         # default (no scope) -> first entry
         assert get_plugin_detail("demo-plugin@test-mkt")["version"] == "1.0.0"
 
+    def test_explicit_scope_with_no_matching_entry_is_none(self, plugins_dir):
+        # A scope-specific request must 404 (None) rather than silently fall
+        # back to another scope's install path/content.
+        cache = plugins_dir / "cache" / "test-mkt" / "demo-plugin" / "1.0.0"
+        reg = plugins_dir / "installed_plugins.json"
+        reg.write_text(
+            json.dumps(
+                {
+                    "version": 2,
+                    "plugins": {
+                        "demo-plugin@test-mkt": [
+                            {
+                                "scope": "user",
+                                "installPath": str(cache),
+                                "version": "1.0.0",
+                            }
+                        ]
+                    },
+                }
+            )
+        )
+        assert get_plugin_detail("demo-plugin@test-mkt", "project") is None
+        # omitted scope still resolves to the first entry
+        assert get_plugin_detail("demo-plugin@test-mkt") is not None
+
     def test_existing_plugin(self, plugins_dir):
         detail = get_plugin_detail("demo-plugin@test-mkt")
         assert detail is not None
@@ -547,8 +572,92 @@ class TestListMarketplaces:
         )
         assert list_marketplaces()[0]["scope"] == "project"
 
+    def test_scope_from_env_journal_without_manifest_record(
+        self, plugins_dir, monkeypatch, tmp_path
+    ):
+        # No manifest record -> fall back to the startup installer's env journal
+        # so an env-bootstrapped marketplace keeps its declared (non-user) scope.
+        from src import plugin_manifest
+
+        monkeypatch.setattr(plugin_manifest, "list_marketplace_records", lambda: {})
+        journal = tmp_path / "gateway-plugins-env.json"
+        journal.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "marketplaces": {
+                        "test-mkt": {
+                            "scope": "project",
+                            "branch": "main",
+                            "repo": "test/marketplace",
+                        }
+                    },
+                }
+            )
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ENV_JOURNAL", str(journal))
+        assert list_marketplaces()[0]["scope"] == "project"
+
+    def test_manifest_record_wins_over_env_journal(
+        self, plugins_dir, monkeypatch, tmp_path
+    ):
+        from src import plugin_manifest
+
+        monkeypatch.setattr(
+            plugin_manifest,
+            "list_marketplace_records",
+            lambda: {"test-mkt": {"repo": "r", "branch": "main", "scope": "local"}},
+        )
+        journal = tmp_path / "gateway-plugins-env.json"
+        journal.write_text(
+            json.dumps(
+                {"version": 1, "marketplaces": {"test-mkt": {"scope": "project"}}}
+            )
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ENV_JOURNAL", str(journal))
+        assert list_marketplaces()[0]["scope"] == "local"
+
     def test_no_plugins_dir(self, no_plugins_dir):
         assert list_marketplaces() == []
+
+
+class TestEnvBootstrapRecords:
+    def test_missing_journal_returns_empty(self, monkeypatch, tmp_path):
+        from src.plugin_service import env_bootstrap_records
+
+        monkeypatch.setenv(
+            "CLAUDE_PLUGIN_ENV_JOURNAL", str(tmp_path / "nope.json")
+        )
+        assert env_bootstrap_records() == {}
+
+    def test_reads_and_normalizes(self, monkeypatch, tmp_path):
+        from src.plugin_service import env_bootstrap_records
+
+        journal = tmp_path / "env.json"
+        journal.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "marketplaces": {
+                        "mkt": {"scope": "project", "branch": "dev", "repo": "o/r"},
+                        "bare": {},
+                    },
+                }
+            )
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_ENV_JOURNAL", str(journal))
+        recs = env_bootstrap_records()
+        assert recs["mkt"] == {"scope": "project", "branch": "dev", "repo": "o/r"}
+        # missing fields default to user/main/empty
+        assert recs["bare"] == {"scope": "user", "branch": "main", "repo": ""}
+
+    def test_corrupt_journal_returns_empty(self, monkeypatch, tmp_path):
+        from src.plugin_service import env_bootstrap_records
+
+        journal = tmp_path / "env.json"
+        journal.write_text("not json{")
+        monkeypatch.setenv("CLAUDE_PLUGIN_ENV_JOURNAL", str(journal))
+        assert env_bootstrap_records() == {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_plugin_service.py
+++ b/tests/test_plugin_service.py
@@ -469,6 +469,22 @@ class TestListMarketplaces:
         assert mkts[0]["source_type"] == "github"
         assert mkts[0]["repo"] == "test/marketplace"
 
+    def test_scope_defaults_user_without_manifest_record(self, plugins_dir, monkeypatch):
+        from src import plugin_manifest
+
+        monkeypatch.setattr(plugin_manifest, "list_marketplace_records", lambda: {})
+        assert list_marketplaces()[0]["scope"] == "user"
+
+    def test_scope_from_manifest_record(self, plugins_dir, monkeypatch):
+        from src import plugin_manifest
+
+        monkeypatch.setattr(
+            plugin_manifest,
+            "list_marketplace_records",
+            lambda: {"test-mkt": {"repo": "r", "branch": "main", "scope": "project"}},
+        )
+        assert list_marketplaces()[0]["scope"] == "project"
+
     def test_no_plugins_dir(self, no_plugins_dir):
         assert list_marketplaces() == []
 

--- a/tests/test_plugin_service.py
+++ b/tests/test_plugin_service.py
@@ -599,6 +599,21 @@ class TestValidateMarketplacePath:
         link.symlink_to(real)
         assert _validate_marketplace_path(link) is None
 
+    def test_clone_root_location_accepted(self, plugins_dir, monkeypatch):
+        # claude stores installLocation as the clone-root path when a marketplace
+        # is added from a local clone (the admin/env flow), so that root is valid.
+        clone_root = plugins_dir.parent / "clones"
+        loc = clone_root / "m-123"
+        loc.mkdir(parents=True)
+        monkeypatch.setenv("CLAUDE_PLUGIN_CLONE_ROOT", str(clone_root))
+        assert _validate_marketplace_path(loc) == loc.resolve()
+
+    def test_outside_all_roots_rejected(self, plugins_dir, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PLUGIN_CLONE_ROOT", str(plugins_dir / "clones"))
+        outside = plugins_dir.parent / "elsewhere"
+        outside.mkdir()
+        assert _validate_marketplace_path(outside) is None
+
 
 # ---------------------------------------------------------------------------
 # list_marketplace_plugins
@@ -616,6 +631,42 @@ class TestListMarketplacePlugins:
         assert by_name["other-plugin"]["installed"] is False
         assert by_name["other-plugin"]["version"] == ""
         assert by_name["other-plugin"]["skill_count"] == 0
+
+    def test_catalog_from_clone_root_install_location(self, plugins_dir, monkeypatch):
+        # The real admin/env flow: claude records installLocation as the
+        # clone-root clone path (NOT under plugins/marketplaces). The catalog
+        # reader must still read it, else "add marketplace -> Browse" is empty.
+        clone_root = plugins_dir.parent / "clones"
+        mkt_loc = clone_root / "acme-mkt-deadbeef"
+        meta = mkt_loc / ".claude-plugin"
+        meta.mkdir(parents=True)
+        (meta / "marketplace.json").write_text(
+            json.dumps(
+                {
+                    "name": "acme-mkt",
+                    "plugins": [
+                        {"name": "octo", "description": "d", "version": "2.0.0"}
+                    ],
+                }
+            )
+        )
+        (plugins_dir / "known_marketplaces.json").write_text(
+            json.dumps(
+                {
+                    "acme-mkt": {
+                        "source": {"source": "directory", "path": str(mkt_loc)},
+                        "installLocation": str(mkt_loc),
+                        "lastUpdated": "2026-03-01T00:00:00Z",
+                    }
+                }
+            )
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_CLONE_ROOT", str(clone_root))
+
+        plugins = list_marketplace_plugins("acme-mkt")
+        assert [p["name"] for p in plugins] == ["octo"]
+        assert plugins[0]["version"] == "2.0.0"
+        assert plugins[0]["installed"] is False
 
     def test_installed_scope_reflects_registry(self, plugins_dir):
         # An installed catalog entry exposes its real registry scope (so the UI


### PR DESCRIPTION
## Summary

Adds runtime **plugin & marketplace management** to the admin panel, layered on top of the existing `CLAUDE_PLUGIN_*` env-var bootstrap. **Pure env-var deployments are unaffected** — the manifest is purely additive.

### Why
Until now plugins could only be added via environment variables, applied at container startup by `docker/install_plugins.py` (install-only, no removal). There was no way to add/remove plugins at runtime or to discover what a marketplace offers.

## What's included

### Persistence — managed manifest
- New `src/plugin_manifest.py` → persistent JSON at `/app/data/gateway-plugins.json` (the `./data` host bind mount, so it survives image redeploy **and** `docker compose down -v`).
- `docker/install_plugins.py` reconciles on startup: **(env entries ∪ `manifest.added`) − `manifest.removed`**, with `removed` specs uninstalled. Admin intent wins over env on conflict.
- All three compose files pin `CLAUDE_PLUGIN_MANIFEST` so the startup script and the app agree on the path. **Self-healing**: after a plugin-cache volume wipe, the manifest reinstalls admin-added plugins and re-applies removals.

### Runtime mutations
- `src/plugin_admin_service.py` — add/remove marketplace, install/uninstall plugin via the `claude` CLI. Strict input validation (arg lists only, no `shell=True`), `GIT_ASKPASS` token handling (never logged), clone root shared with the startup installer.
- `src/plugin_service.py` stays **strictly read-only** (discovery only).
- Endpoints: `POST`/`DELETE /api/marketplaces`, `POST`/`DELETE /api/plugins`, `GET /api/plugins/manifest`, plus catalog browsing `GET /api/marketplaces/catalog` and `GET /api/marketplaces/{name}/plugins`. Literal routes stay ahead of the `{plugin_id:path}` catch-all.

### Admin UI (PLUGINS tab)
- Browse each marketplace's catalog and **install/uninstall with one click** — `INSTALLED` badges, per-action busy state, client-side search filter.
- Installed list shows **ENV vs MANAGED** origin badges.
- Manual install-by-name kept under an "advanced" section.

> Changes take effect for **new sessions without a gateway restart** (`CLAUDE_SETTING_SOURCES=user`).

## Testing
- Full suite: **2469 passed, 3 skipped, 2 xfailed (pre-existing), 0 new failures**.
- New tests: `test_plugin_manifest.py`, `test_plugin_admin_service.py`, `test_admin_plugins.py`, `test_plugin_service.py` (catalog/origin), and reconcile cases in `test_install_plugins_script.py`.
- Verified: route ordering (no shadowing), manifest path agreement, shell-injection safety, symlink-safe catalog reads, `plugin_service.py` read-only.

## Notes / not yet done
- Not manually exercised against a live Docker stack — recommend a smoke test of the PLUGINS tab before merge.
- codex-only / opencode-only deployments don't mount `claude_home`; the manifest is a harmless no-op there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)