### PR TITLE
fix(admin/plugins): enable Install button + accurate catalog skill count

### DIFF
--- a/src/admin_html_plugins.py
+++ b/src/admin_html_plugins.py
@@ -64,12 +64,12 @@ def get_plugins_html() -> str:
                               style="white-space:nowrap; overflow:hidden; text-overflow:ellipsis" x-text="plug.description"></div>
                           </div>
                           <button x-show="!plug.installed" class="btn btn-sm btn-primary"
-                            @click="installFromCatalog(m, plug)" :disabled="catalogBusy[plug.id]"
+                            @click="installFromCatalog(m, plug)" :disabled="!!catalogBusy[plug.id]"
                             aria-label="Install plugin">
                             <span x-text="catalogBusy[plug.id] ? 'Working...' : 'Install'"></span>
                           </button>
                           <button x-show="plug.installed" class="btn btn-sm btn-ghost" style="color:var(--red)"
-                            @click="uninstallFromCatalog(plug)" :disabled="catalogBusy[plug.id]"
+                            @click="uninstallFromCatalog(plug)" :disabled="!!catalogBusy[plug.id]"
                             aria-label="Uninstall plugin">
                             <span x-text="catalogBusy[plug.id] ? 'Working...' : 'Uninstall'"></span>
                           </button>

--- a/src/plugin_service.py
+++ b/src/plugin_service.py
@@ -676,6 +676,29 @@ def list_marketplaces() -> List[Dict[str, Any]]:
     return results
 
 
+def _count_catalog_skills(location: Path, source: Any) -> int:
+    """Best-effort skill count for a not-yet-installed catalog plugin.
+
+    ``marketplace.json`` entries rarely declare ``skills`` explicitly, so when a
+    plugin lives in a local directory under the marketplace checkout, resolve its
+    ``source`` path and scan it the same way installed plugins are scanned (see
+    :func:`_discover_skills`). Returns 0 for remote/object sources or any path
+    that escapes the marketplace directory.
+    """
+    if not isinstance(source, str) or not source or "://" in source:
+        return 0
+    try:
+        base = location.resolve()
+        plugin_dir = (location / source).resolve()
+        if plugin_dir != base and base not in plugin_dir.parents:
+            return 0
+        if not plugin_dir.is_dir():
+            return 0
+        return len(_discover_skills(plugin_dir))
+    except Exception:
+        return 0
+
+
 def list_marketplace_plugins(marketplace_name: str) -> List[Dict[str, Any]]:
     """Return the plugins a marketplace offers in its catalog.
 
@@ -732,13 +755,19 @@ def list_marketplace_plugins(marketplace_name: str) -> List[Dict[str, Any]]:
             continue
         version = entry.get("version")
         skills = entry.get("skills")
+        if isinstance(skills, list):
+            skill_count = len(skills)
+        else:
+            # marketplace.json omitted an explicit skills list — scan the
+            # plugin's local source dir so the catalog matches the installed view.
+            skill_count = _count_catalog_skills(location, entry.get("source"))
         plugin_id = f"{name}@{marketplace_name}"
         results.append(
             {
                 "name": name,
                 "description": entry.get("description", ""),
                 "version": version if isinstance(version, str) else "",
-                "skill_count": len(skills) if isinstance(skills, list) else 0,
+                "skill_count": skill_count,
                 "id": plugin_id,
                 "installed": (plugin_id, mkt_scope) in installed_scoped,
                 "scope": mkt_scope,

--- a/tests/test_plugin_service.py
+++ b/tests/test_plugin_service.py
@@ -879,6 +879,45 @@ class TestListMarketplacePlugins:
         assert plugins[0]["version"] == "2.0.0"
         assert plugins[0]["installed"] is False
 
+    def test_catalog_skill_count_scans_local_source(self, plugins_dir, monkeypatch):
+        # marketplace.json entries usually omit an explicit "skills" list; the
+        # catalog must scan the plugin's local source dir so it doesn't show
+        # "0 skills" for a plugin that actually ships skills/*/SKILL.md.
+        clone_root = plugins_dir.parent / "clones"
+        mkt_loc = clone_root / "brainy-mkt-cafe"
+        meta = mkt_loc / ".claude-plugin"
+        meta.mkdir(parents=True)
+        (meta / "marketplace.json").write_text(
+            json.dumps(
+                {
+                    "name": "brainy-mkt",
+                    "plugins": [
+                        # No "skills" field -> must be discovered from source dir.
+                        {"name": "brain", "source": "./plugins/brain"},
+                    ],
+                }
+            )
+        )
+        for skill in ("brain-search", "brain-ingest", "brain-reflect"):
+            sdir = mkt_loc / "plugins" / "brain" / "skills" / skill
+            sdir.mkdir(parents=True)
+            (sdir / "SKILL.md").write_text(f"# {skill}")
+        (plugins_dir / "known_marketplaces.json").write_text(
+            json.dumps(
+                {
+                    "brainy-mkt": {
+                        "source": {"source": "directory", "path": str(mkt_loc)},
+                        "installLocation": str(mkt_loc),
+                        "lastUpdated": "2026-03-01T00:00:00Z",
+                    }
+                }
+            )
+        )
+        monkeypatch.setenv("CLAUDE_PLUGIN_CLONE_ROOT", str(clone_root))
+
+        plugins = list_marketplace_plugins("brainy-mkt")
+        assert plugins[0]["skill_count"] == 3
+
     def test_catalog_scope_is_marketplace_scope(self, plugins_dir, monkeypatch):
         # The catalog reports the marketplace's own scope (the scope a one-click
         # install would target), and availability is judged at THAT scope.


### PR DESCRIPTION
## Bugs fixed

Two admin **Plugins** tab bugs surfaced while adding a marketplace and trying to install a plugin.

### 1. Catalog Install/Uninstall buttons permanently disabled
`:disabled="catalogBusy[plug.id]"` evaluates to `undefined` whenever the key is absent — i.e. the normal idle state, since `catalogBusy` starts as `{}`. Alpine 3 does **not** strip a boolean attribute for `undefined` the way it does for `false`, so it rendered `disabled="disabled"` and the Install button was never clickable. (The sibling `x-text` ternary handled `undefined` fine, so the button still *read* "Install" — which masked the bug.)

**Fix:** coerce to an explicit boolean — `:disabled="!!catalogBusy[plug.id]"`.

### 2. Catalog showed "0 skills"
The catalog only read an explicit `skills` array from `marketplace.json`, which most marketplaces omit. Now it scans the plugin's local `source` directory with the same `_discover_skills()` used by the installed view, so the catalog count matches reality. Guarded against path escape and remote/object sources.

## Verification
- Driven end-to-end in a real headless browser (Playwright): Install button is enabled, clicking it installs, and the **Installed Plugins** pane updates immediately (no reload).
- `pytest tests/test_plugin_service.py tests/test_admin_plugins.py` — all green; added `test_catalog_skill_count_scans_local_source`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)