### PR TITLE
feat(ui): modern console redesign + light/dark/system theming

### DIFF
--- a/src/admin_html_config.py
+++ b/src/admin_html_config.py
@@ -76,7 +76,7 @@ def get_config_html() -> str:
         <div class="prompt-status-bar">
           <div class="prompt-status-main">
             <span class="text-xs text-muted prompt-status-label">Active prompt</span>
-            <span x-show="systemPrompt.active_name" style="color:var(--green); font-weight:600; font-size:var(--fs-sm); text-shadow: 0 0 6px var(--green-muted)" x-text="systemPrompt.active_name"></span>
+            <span x-show="systemPrompt.active_name" style="color:var(--green); font-weight:600; font-size:var(--fs-sm)" x-text="systemPrompt.active_name"></span>
             <span x-show="!systemPrompt.active_name && systemPrompt.mode === 'preset'" style="color:var(--text-dim); font-size:var(--fs-sm)">claude_code (preset)</span>
             <span x-show="!systemPrompt.active_name && systemPrompt.mode === 'file'" style="color:var(--cyan); font-size:var(--fs-sm)">file default (SYSTEM_PROMPT_FILE)</span>
             <span x-show="!systemPrompt.active_name && systemPrompt.mode === 'custom'" style="color:var(--amber); font-size:var(--fs-sm)">custom (unnamed)</span>

--- a/src/admin_html_dashboard.py
+++ b/src/admin_html_dashboard.py
@@ -21,16 +21,16 @@ def get_dashboard_html() -> str:
               <div class="label">ACTIVE SESSIONS</div>
             </div>
             <div class="card stat">
-              <div class="value" style="color:var(--cyan); text-shadow: 0 0 10px var(--cyan-subtle)" x-text="summary.models?.length ?? '-'"></div>
+              <div class="value" style="color:var(--cyan)" x-text="summary.models?.length ?? '-'"></div>
               <div class="label">MODELS LOADED</div>
             </div>
             <div class="card stat">
-              <div class="value" style="color:var(--amber); text-shadow: 0 0 10px var(--amber-subtle)"
+              <div class="value" style="color:var(--amber)"
                 x-text="loading.backends ? '...' : (backendsDetail.length || '-')"></div>
               <div class="label">BACKENDS</div>
             </div>
             <div class="card stat">
-              <div class="value" :style="(metrics.stats?.error_rate ?? 0) > 0.05 ? 'color:var(--red); text-shadow: 0 0 10px var(--red-subtle)' : ''"
+              <div class="value" :style="(metrics.stats?.error_rate ?? 0) > 0.05 ? 'color:var(--red)' : ''"
                 x-text="((metrics.stats?.error_rate ?? 0) * 100).toFixed(1) + '%'"></div>
               <div class="label">ERROR RATE</div>
             </div>

--- a/src/admin_html_logs.py
+++ b/src/admin_html_logs.py
@@ -11,7 +11,7 @@ def get_logs_html() -> str:
             <div class="label">TOTAL REQUESTS</div>
           </div>
           <div class="card stat">
-            <div class="value" :style="(logs.stats?.error_count ?? 0) > 0 ? 'color:var(--red); text-shadow: 0 0 10px var(--red-subtle)' : ''" x-text="logs.stats?.error_count ?? '-'"></div>
+            <div class="value" :style="(logs.stats?.error_count ?? 0) > 0 ? 'color:var(--red)' : ''" x-text="logs.stats?.error_count ?? '-'"></div>
             <div class="label">ERRORS</div>
           </div>
           <div class="card stat">

--- a/src/admin_html_ratelimits.py
+++ b/src/admin_html_ratelimits.py
@@ -33,7 +33,7 @@ def get_ratelimits_html() -> str:
               <div style="background:var(--bg-surface); height:4px; overflow:hidden; margin-bottom:0.75rem">
                 <div class="rate-bar-fill" :style="'width:' + Math.min(100, data.total_usage / data.limit * 100) + '%; height:100%; background:' +
                   ((data.total_usage / data.limit * 100) > 90 ? 'var(--red)' : (data.total_usage / data.limit * 100) > 70 ? 'var(--amber)' : 'var(--green)') +
-                  '; box-shadow: 0 0 6px currentColor'"></div>
+                  ''"></div>
               </div>
               <template x-if="data.clients && data.clients.length > 0">
                 <div class="table-wrapper">

--- a/src/admin_page.py
+++ b/src/admin_page.py
@@ -18,6 +18,13 @@ from src.admin_html_skills import get_skills_html
 from src.admin_html_usage import get_usage_html
 from src.admin_js import get_admin_js
 from src.admin_styles import get_admin_css
+from src.theme import (
+    base_css,
+    theme_head_init,
+    theme_tokens_css,
+    theme_toggle_html,
+    theme_toggle_js,
+)
 
 
 @lru_cache(maxsize=1)
@@ -34,11 +41,14 @@ def build_admin_page() -> str:
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Oh My Gateway Admin</title>
+"""
+        + theme_head_init()
+        + """
 <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.8/dist/cdn.min.js" integrity="sha384-X9kJyAubVxnP0hcA+AMMs21U445qsnqhnUF8EBlEpP3a42Kh/JwWjlv2ZcvGfphb" crossorigin="anonymous"></script>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 <style>
 """
+        + theme_tokens_css()
+        + base_css()
         + get_admin_css()
         + """
 </style>
@@ -87,6 +97,9 @@ def build_admin_page() -> str:
           <span class="status-line">
             <span class="online"></span> Connected
           </span>
+          """
+        + theme_toggle_html()
+        + """
           <button class="btn btn-sm btn-ghost" @click="refreshAll()" aria-label="Refresh all data">Refresh</button>
           <button class="btn btn-sm btn-ghost" @click="doLogout()" aria-label="Log out">Log out</button>
         </div>
@@ -132,6 +145,9 @@ def build_admin_page() -> str:
         + get_admin_js()
         + """
 </script>
+"""
+        + theme_toggle_js()
+        + """
 </body>
 </html>"""
     )

--- a/src/admin_styles.py
+++ b/src/admin_styles.py
@@ -1,84 +1,23 @@
-"""Admin dashboard CSS styles."""
+"""Admin dashboard CSS styles.
+
+Layers admin-specific components on top of the shared design system
+(`src.theme.theme_tokens_css()` + `base_css()`), which are emitted before
+this block in `admin_page.py`. The shared layer provides the design tokens,
+reset, base elements, and shared components (`.card`, `.btn`, `.badge`,
+inputs, tables, `.toast`, the theme toggle, scrollbars, focus ring). This
+module only adds/overrides what is specific to the admin SPA.
+
+UI text inherits `var(--font)` (sans) from the shared base; code, endpoint
+paths, and tabular/identifier data use `var(--font-mono)`.
+"""
 
 
 def get_admin_css() -> str:
     """Return the admin dashboard css styles."""
     return """/* ================================================================
-   Oh My Gateway Admin
+   Oh My Gateway Admin — surface-specific components
+   (design tokens + base + shared components come from src/theme.py)
    ================================================================ */
-
-:root {
-  --green: #15803d;
-  --green-dim: #166534;
-  --green-muted: #bbf7d0;
-  --green-subtle: #ecfdf3;
-  --green-glow: none;
-  --amber: #b45309;
-  --amber-dim: #92400e;
-  --amber-subtle: #fffbeb;
-  --cyan: #2563eb;
-  --cyan-dim: #1d4ed8;
-  --cyan-subtle: #eff6ff;
-  --red: #b91c1c;
-  --red-dim: #991b1b;
-  --red-subtle: #fef2f2;
-  --magenta: #7c3aed;
-
-  --bg-deep: #f4f6f8;
-  --bg: #ffffff;
-  --bg-raised: #ffffff;
-  --bg-surface: #f8fafc;
-  --bg-hover: #f1f5f9;
-  --border: #e2e8f0;
-  --border-dim: #edf2f7;
-  --border-bright: #cbd5e1;
-
-  --text: #243244;
-  --text-bright: #0f172a;
-  --text-dim: #64748b;
-  --text-muted: #94a3b8;
-
-  --accent: var(--cyan);
-  --accent-hover: var(--cyan-dim);
-  --color-success: var(--green);
-  --color-success-subtle: var(--green-subtle);
-  --color-warning: var(--amber);
-  --color-warning-subtle: var(--amber-subtle);
-  --color-danger: var(--red);
-  --color-danger-subtle: var(--red-subtle);
-  --color-info: var(--cyan);
-  --color-info-subtle: var(--cyan-subtle);
-
-  --gap-xs: 0.25rem;
-  --gap-sm: 0.5rem;
-  --gap-md: 0.75rem;
-  --gap-lg: 1rem;
-  --gap-xl: 1.5rem;
-
-  --font: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', 'SF Mono', monospace;
-  --fs-xs: 0.72rem;
-  --fs-sm: 0.8rem;
-  --fs-base: 0.9rem;
-  --fs-lg: 1rem;
-  --fs-xl: 1.25rem;
-  --fs-2xl: 1.6rem;
-  --fs-display: 2rem;
-}
-
-*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-
-html { color-scheme: light; }
-
-body {
-  min-height: 100vh;
-  background: var(--bg-deep);
-  color: var(--text);
-  font-family: var(--font);
-  font-size: var(--fs-base);
-  line-height: 1.55;
-  -webkit-font-smoothing: antialiased;
-  overflow-x: hidden;
-}
 
 .container {
   width: min(1440px, 100%);
@@ -95,7 +34,7 @@ body {
 }
 .flex-gap-sm { display: flex; gap: var(--gap-sm); align-items: center; }
 .flex-wrap-gap { display: flex; flex-wrap: wrap; gap: var(--gap-sm); }
-.text-mono { font-family: var(--font); font-size: var(--fs-xs); }
+.text-mono { font-family: var(--font-mono); font-size: var(--fs-xs); }
 .text-xs { font-size: var(--fs-xs); }
 .text-sm { font-size: var(--fs-sm); }
 .text-muted { color: var(--text-muted); }
@@ -114,7 +53,7 @@ body {
   font-weight: 700;
   line-height: 1.2;
   text-transform: uppercase;
-  letter-spacing: 0;
+  letter-spacing: 0.06em;
 }
 
 .header-bar {
@@ -133,7 +72,6 @@ body {
   font-size: var(--fs-2xl);
   font-weight: 700;
   line-height: 1.15;
-  letter-spacing: 0;
 }
 
 .header-bar .status-line {
@@ -143,7 +81,7 @@ body {
   min-height: 32px;
   padding: 0 0.65rem;
   border: 1px solid var(--border);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--bg);
   color: var(--text-dim);
   font-size: var(--fs-xs);
@@ -153,18 +91,12 @@ body {
 .header-bar .status-line .online {
   width: 8px;
   height: 8px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--green);
 }
 
-.card {
-  background: var(--bg-raised);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: var(--gap-lg);
-  margin-bottom: var(--gap-lg);
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
-}
+/* Admin cards add a bottom margin on top of the shared .card base. */
+.card { margin-bottom: var(--gap-lg); }
 
 .card h3 {
   margin-top: 0;
@@ -172,8 +104,6 @@ body {
   font-size: var(--fs-sm);
   font-weight: 700;
   line-height: 1.35;
-  text-transform: none;
-  letter-spacing: 0;
 }
 
 .grid-2 {
@@ -216,6 +146,7 @@ body {
 }
 .stat .value {
   color: var(--text-bright);
+  font-family: var(--font-mono);
   font-size: var(--fs-display);
   font-weight: 700;
   font-variant-numeric: tabular-nums;
@@ -228,28 +159,8 @@ body {
   font-size: var(--fs-xs);
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0;
+  letter-spacing: 0.04em;
 }
-
-.badge {
-  display: inline-flex;
-  align-items: center;
-  min-height: 22px;
-  padding: 1px 8px;
-  border: 1px solid var(--border-bright);
-  border-radius: 999px;
-  background: var(--bg-surface);
-  color: var(--text);
-  font-family: var(--font);
-  font-size: var(--fs-xs);
-  font-weight: 600;
-  letter-spacing: 0;
-  white-space: nowrap;
-}
-.badge-ok { background: var(--green-subtle); color: var(--green-dim); border-color: var(--green-muted); }
-.badge-warn { background: var(--amber-subtle); color: var(--amber-dim); border-color: #fde68a; }
-.badge-err { background: var(--red-subtle); color: var(--red-dim); border-color: #fecaca; }
-.badge-info { background: var(--cyan-subtle); color: var(--cyan-dim); border-color: #bfdbfe; }
 
 nav.tabs {
   position: sticky;
@@ -260,7 +171,7 @@ nav.tabs {
   margin: 0 calc(var(--gap-xl) * -1) var(--gap-lg);
   padding: 0 var(--gap-xl);
   border-bottom: 1px solid var(--border);
-  background: rgba(244, 246, 248, 0.95);
+  background: var(--bg-deep);
   overflow-x: auto;
   scrollbar-width: thin;
 }
@@ -280,18 +191,17 @@ nav.tabs button,
   font-weight: 600;
   text-decoration: none;
   white-space: nowrap;
-  letter-spacing: 0;
 }
 nav.tabs button[aria-selected="true"] {
-  color: var(--cyan-dim);
-  border-bottom-color: var(--cyan);
+  color: var(--accent);
+  border-bottom-color: var(--accent);
 }
 nav.tabs button:hover,
 .tab-link:hover {
   color: var(--text-bright);
-  background: rgba(255, 255, 255, 0.65);
+  background: var(--bg-hover);
 }
-.tab-link { color: var(--cyan-dim); }
+.tab-link { color: var(--accent); }
 
 .sidebar { display: flex; gap: var(--gap-lg); }
 .sidebar .file-tree { width: clamp(300px, 26vw, 360px); flex-shrink: 0; }
@@ -303,7 +213,7 @@ nav.tabs button:hover,
   min-height: 32px;
   padding: 5px 10px;
   border-left: 3px solid transparent;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   color: var(--text);
   cursor: pointer;
   font-size: var(--fs-sm);
@@ -313,9 +223,9 @@ nav.tabs button:hover,
 }
 .file-item:hover { background: var(--bg-hover); }
 .file-item.active {
-  background: var(--cyan-subtle);
-  border-left-color: var(--cyan);
-  color: var(--cyan-dim);
+  background: var(--accent-subtle);
+  border-left-color: var(--accent);
+  color: var(--accent);
 }
 .file-item .icon { font-size: var(--fs-sm); }
 .marketplace-row {
@@ -340,7 +250,7 @@ nav.tabs button:hover,
 }
 .editor-toolbar .path {
   color: var(--text-dim);
-  font-family: var(--font);
+  font-family: var(--font-mono);
   font-size: var(--fs-sm);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -355,7 +265,7 @@ nav.tabs button:hover,
   margin-bottom: var(--gap-sm);
   padding: 8px 16px;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius);
   background: var(--bg-raised);
 }
 .prompt-status-main,
@@ -370,58 +280,28 @@ nav.tabs button:hover,
   white-space: nowrap;
 }
 
-.btn {
+/* Admin-only button variant; base .btn/.btn-primary/.btn-ghost/.btn-sm
+   come from the shared component layer. */
+.btn-danger-ghost {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: var(--gap-xs);
   min-height: 34px;
   padding: 6px 13px;
-  border: 1px solid var(--border-bright);
-  border-radius: 6px;
-  background: var(--bg);
-  color: var(--text-bright);
+  border: 1px solid var(--red-muted);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--red-dim);
   cursor: pointer;
   font-family: var(--font);
   font-size: var(--fs-sm);
   font-weight: 600;
-  letter-spacing: 0;
-  text-transform: none;
-  transition: background-color 0.15s, border-color 0.15s, color 0.15s;
   white-space: nowrap;
-}
-.btn:hover { background: var(--bg-hover); border-color: var(--text-dim); }
-.btn-primary {
-  background: var(--cyan);
-  color: #ffffff;
-  border-color: var(--cyan);
-}
-.btn-primary:hover {
-  background: var(--cyan-dim);
-  color: #ffffff;
-  border-color: var(--cyan-dim);
-}
-.btn-sm { min-height: 30px; padding: 4px 10px; font-size: var(--fs-xs); }
-.btn-ghost {
-  background: transparent;
-  border-color: var(--border);
-  color: var(--text);
-}
-.btn-ghost:hover {
-  background: var(--bg-hover);
-  border-color: var(--border-bright);
-  color: var(--text-bright);
-}
-.btn-danger-ghost {
-  background: transparent;
-  border-color: #fecaca;
-  color: var(--red-dim);
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 .btn-danger-ghost:hover { background: var(--red-subtle); }
-.btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
+.btn-danger-ghost:disabled { opacity: 0.5; cursor: not-allowed; }
 
 .login-wrap {
   min-height: calc(100vh - 3rem);
@@ -437,80 +317,12 @@ nav.tabs button:hover,
   color: var(--text-bright);
   font-size: var(--fs-2xl);
   line-height: 1.2;
-  letter-spacing: 0;
 }
 .login-box .prompt-prefix {
   margin-bottom: var(--gap-lg);
   color: var(--text-dim);
   font-size: var(--fs-sm);
 }
-
-input[type="text"],
-input[type="number"],
-input[type="password"],
-input[type="date"],
-select,
-textarea {
-  min-height: 34px;
-  background: var(--bg);
-  border: 1px solid var(--border-bright);
-  border-radius: 6px;
-  color: var(--text-bright);
-  font-family: var(--font);
-  font-size: var(--fs-sm);
-  padding: 6px 10px;
-  outline: none;
-  caret-color: var(--cyan);
-}
-input[type="text"]:focus,
-input[type="number"]:focus,
-input[type="password"]:focus,
-input[type="date"]:focus,
-select:focus,
-textarea:focus {
-  border-color: var(--cyan);
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.14);
-}
-input::placeholder,
-textarea::placeholder { color: var(--text-muted); }
-select {
-  cursor: pointer;
-  -webkit-appearance: none;
-  appearance: none;
-  padding-right: 28px;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%2364748b'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: right 10px center;
-}
-input[type="checkbox"] { accent-color: var(--cyan); }
-
-.table-wrapper {
-  width: 100%;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-}
-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: var(--fs-sm);
-}
-table th {
-  padding: 8px 12px;
-  border-bottom: 1px solid var(--border-bright);
-  color: var(--text-dim);
-  font-size: var(--fs-xs);
-  font-weight: 700;
-  text-align: left;
-  text-transform: uppercase;
-  letter-spacing: 0;
-  white-space: nowrap;
-}
-table td {
-  padding: 9px 12px;
-  border-bottom: 1px solid var(--border);
-  vertical-align: middle;
-}
-table tr:hover td { background: var(--bg-hover); }
 
 .toast-container {
   position: fixed;
@@ -521,29 +333,10 @@ table tr:hover td { background: var(--bg-hover); }
   gap: var(--gap-sm);
   z-index: 10000;
 }
-.toast {
-  max-width: min(420px, calc(100vw - 2rem));
-  padding: 10px 14px;
-  border: 1px solid var(--border);
-  border-left-width: 4px;
-  border-radius: 8px;
-  background: var(--bg);
-  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
-  color: var(--text);
-  font-family: var(--font);
-  font-size: var(--fs-sm);
-  animation: toast-in 0.2s ease;
-}
-.toast-ok { border-left-color: var(--green); }
-.toast-err { border-left-color: var(--red); }
-@keyframes toast-in {
-  from { opacity: 0; transform: translateY(8px); }
-  to { opacity: 1; transform: translateY(0); }
-}
 
 .skeleton {
-  border-radius: 6px;
-  background: linear-gradient(90deg, var(--bg-surface) 25%, #e8eef6 50%, var(--bg-surface) 75%);
+  border-radius: var(--radius-sm);
+  background: linear-gradient(90deg, var(--bg-surface) 25%, var(--bg-hover) 50%, var(--bg-surface) 75%);
   background-size: 200% 100%;
   animation: shimmer 1.4s infinite;
 }
@@ -557,21 +350,20 @@ table tr:hover td { background: var(--bg-hover); }
   display: inline-block;
   width: 8px;
   height: 8px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--amber);
 }
 
 .config-key {
-  color: var(--cyan-dim);
-  font-family: var(--font);
+  color: var(--accent);
+  font-family: var(--font-mono);
   font-size: var(--fs-sm);
 }
 .redacted { color: var(--text-muted); font-style: normal; }
-:focus-visible { outline: 2px solid var(--cyan); outline-offset: 2px; }
 
 details.config-section {
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius);
   background: var(--bg-raised);
   margin-bottom: var(--gap-lg);
   overflow: hidden;
@@ -587,7 +379,6 @@ details.config-section > summary {
   cursor: pointer;
   font-size: var(--fs-sm);
   font-weight: 700;
-  letter-spacing: 0;
   list-style: none;
 }
 details.config-section > summary::-webkit-details-marker { display: none; }
@@ -598,9 +389,10 @@ details.config-section > summary::before {
   justify-content: center;
   width: 20px;
   height: 20px;
-  border-radius: 999px;
-  background: var(--cyan-subtle);
-  color: var(--cyan-dim);
+  border-radius: var(--radius-pill);
+  background: var(--accent-subtle);
+  color: var(--accent);
+  font-family: var(--font-mono);
   font-weight: 700;
 }
 details.config-section[open] > summary {
@@ -614,13 +406,13 @@ details.config-section .config-body { padding: var(--gap-lg); }
   flex: 1;
   height: 6px;
   background: var(--bg-surface);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   margin: 0 var(--gap-sm);
   overflow: hidden;
 }
 .latency-fill {
   height: 100%;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   transition: width 0.25s ease;
 }
 
@@ -629,7 +421,7 @@ details.config-section .config-body { padding: var(--gap-lg); }
   padding: 9px 12px;
   border: 1px solid var(--border);
   border-left-width: 4px;
-  border-radius: 8px;
+  border-radius: var(--radius);
   font-size: var(--fs-sm);
   overflow-wrap: anywhere;
   white-space: pre-wrap;
@@ -656,14 +448,14 @@ details.config-section .config-body { padding: var(--gap-lg); }
   margin-bottom: 4px;
   font-size: var(--fs-xs);
   font-weight: 700;
-  letter-spacing: 0;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
 }
 .msg-thinking {
   margin: 4px 0 8px;
   padding: 6px 8px;
   border-left: 3px solid var(--amber);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   background: var(--amber-subtle);
 }
 .msg-thinking-label {
@@ -680,23 +472,16 @@ details.config-section .config-body { padding: var(--gap-lg); }
   max-height: 60vh;
   padding: 10px;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius);
   background: var(--bg-surface);
   color: var(--text);
   cursor: default;
-  font-family: var(--font);
+  font-family: var(--font-mono);
   font-size: 0.78rem;
   resize: vertical;
 }
 
 .rate-bar-fill { transition: width 0.25s ease, background-color 0.25s ease; }
-.cursor-blink::after { content: ''; }
-.boot-line { opacity: 1; }
-.prompt::before { content: ''; }
-::-webkit-scrollbar { width: 8px; height: 8px; }
-::-webkit-scrollbar-track { background: var(--bg-surface); }
-::-webkit-scrollbar-thumb { background: var(--border-bright); border-radius: 999px; }
-::-webkit-scrollbar-thumb:hover { background: var(--text-muted); }
 
 @media (max-width: 1080px) {
   .grid-4 { grid-template-columns: repeat(2, minmax(0, 1fr)); }

--- a/src/chat_page.py
+++ b/src/chat_page.py
@@ -7,76 +7,41 @@ and AskUserQuestion (function_call / function_call_output) flow.
 
 from functools import lru_cache
 
+from src.theme import (
+    theme_head_init,
+    theme_tokens_css,
+    base_css,
+    theme_toggle_html,
+    theme_toggle_js,
+)
+
 
 @lru_cache(maxsize=1)
 def build_chat_page() -> str:
     """Build the chat UI HTML."""
-    return r"""<!DOCTYPE html>
+    return (
+        _CHAT_PAGE_TEMPLATE.replace("__OMG_THEME_HEAD_INIT__", theme_head_init())
+        .replace("__OMG_THEME_TOKENS_CSS__", theme_tokens_css())
+        .replace("__OMG_BASE_CSS__", base_css())
+        .replace("__OMG_THEME_TOGGLE_HTML__", theme_toggle_html())
+        .replace("__OMG_THEME_TOGGLE_JS__", theme_toggle_js())
+    )
+
+
+_CHAT_PAGE_TEMPLATE = r"""<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Oh My Gateway Chat</title>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+__OMG_THEME_HEAD_INIT__
 <style>
+__OMG_THEME_TOKENS_CSS____OMG_BASE_CSS__
 /* ================================================================
-   Oh My Gateway Chat
+   Oh My Gateway Chat — page-specific styles
    ================================================================ */
 
-:root {
-  --green: #15803d;
-  --green-dim: #166534;
-  --green-muted: #bbf7d0;
-  --green-subtle: #ecfdf3;
-  --green-glow: none;
-  --amber: #b45309;
-  --amber-dim: #92400e;
-  --amber-subtle: #fffbeb;
-  --cyan: #2563eb;
-  --cyan-dim: #1d4ed8;
-  --cyan-subtle: #eff6ff;
-  --red: #b91c1c;
-  --red-dim: #991b1b;
-  --red-subtle: #fef2f2;
-  --magenta: #7c3aed;
-
-  --bg-deep: #f4f6f8;
-  --bg: #ffffff;
-  --bg-raised: #ffffff;
-  --bg-surface: #f8fafc;
-  --bg-hover: #f1f5f9;
-  --border: #e2e8f0;
-  --border-bright: #cbd5e1;
-
-  --text: #243244;
-  --text-bright: #0f172a;
-  --text-dim: #64748b;
-  --text-muted: #94a3b8;
-
-  --font: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', 'SF Mono', monospace;
-  --fs-xs: 0.7rem;
-  --fs-sm: 0.78rem;
-  --fs-base: 0.85rem;
-  --fs-lg: 1rem;
-
-  --gap-xs: 0.25rem;
-  --gap-sm: 0.5rem;
-  --gap-md: 0.75rem;
-  --gap-lg: 1rem;
-}
-
-*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-
-html { color-scheme: light; }
-
 body {
-  background: var(--bg-deep);
-  color: var(--text);
-  font-family: var(--font);
-  font-size: var(--fs-base);
-  line-height: 1.6;
-  -webkit-font-smoothing: antialiased;
   height: 100vh;
   display: flex;
   flex-direction: column;
@@ -103,12 +68,14 @@ body {
   color: var(--text-bright);
   font-size: var(--fs-lg);
   font-weight: 700;
+  letter-spacing: -0.01em;
 }
 .header .session-tag {
+  font-family: var(--font-mono);
   font-size: var(--fs-xs);
   color: var(--text-dim);
   border: 1px solid var(--border);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   padding: 3px 9px;
   background: var(--bg-surface);
 }
@@ -118,66 +85,31 @@ body {
   gap: 0.5rem;
 }
 
-/* Buttons */
-.btn {
-  font-family: var(--font);
-  font-size: var(--fs-xs);
+/* Header buttons: compact variant of the shared .btn */
+.header .btn {
   min-height: 30px;
-  padding: 4px 10px;
-  background: var(--bg-raised);
-  border: 1px solid var(--border-bright);
-  border-radius: 6px;
-  color: var(--text-bright);
-  cursor: pointer;
-  text-transform: none;
-  letter-spacing: 0;
-  transition: background-color 0.15s, border-color 0.15s, color 0.15s;
-  text-decoration: none;
-}
-.btn:hover {
-  background: var(--bg-hover);
-  color: var(--text-bright);
-  border-color: var(--text-dim);
+  padding: 4px 11px;
+  font-size: var(--fs-xs);
 }
 .btn-danger:hover {
   color: var(--red);
-  border-color: var(--red-dim);
+  border-color: var(--red);
 }
 
-/* API key input */
+/* API key input (mono — it holds a credential token) */
 .api-key-input {
-  font-family: var(--font);
+  font-family: var(--font-mono);
   font-size: var(--fs-xs);
-  background: var(--bg-raised);
-  color: var(--text-bright);
-  border: 1px solid var(--border-bright);
-  border-radius: 6px;
-  padding: 3px 6px;
+  min-height: 30px;
   width: 140px;
-  outline: none;
-}
-.api-key-input:focus {
-  border-color: var(--cyan);
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.14);
-}
-.api-key-input::placeholder {
-  color: var(--text-muted);
+  padding: 4px 8px;
 }
 
 /* Model select */
 .model-select {
-  font-family: var(--font);
+  min-height: 30px;
   font-size: var(--fs-xs);
-  background: var(--bg-raised);
-  color: var(--text-bright);
-  border: 1px solid var(--border-bright);
-  border-radius: 6px;
-  padding: 3px 6px;
-  outline: none;
-  cursor: pointer;
-}
-.model-select:focus {
-  border-color: var(--cyan);
+  padding: 4px 26px 4px 8px;
 }
 .model-select option {
   background: var(--bg);
@@ -191,10 +123,6 @@ body {
   padding: 1rem;
   scroll-behavior: smooth;
 }
-
-.chat-container::-webkit-scrollbar { width: 6px; }
-.chat-container::-webkit-scrollbar-track { background: var(--bg-deep); }
-.chat-container::-webkit-scrollbar-thumb { background: var(--border-bright); border-radius: 3px; }
 
 /* Messages */
 .message {
@@ -215,13 +143,14 @@ body {
 
 .message .role {
   font-size: var(--fs-xs);
+  font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0;
-  margin-bottom: 2px;
+  letter-spacing: 0.04em;
+  margin-bottom: 3px;
 }
-.message.user .role { color: var(--cyan); }
-.message.assistant .role { color: var(--green-dim); }
-.message.system .role { color: var(--amber); }
+.message.user .role { color: var(--cyan-dim); }
+.message.assistant .role { color: var(--accent); }
+.message.system .role { color: var(--amber-dim); }
 
 .message .bubble {
   display: inline-block;
@@ -237,22 +166,22 @@ body {
   max-width: 100%;
 }
 .message.user .bubble {
-  border-color: var(--cyan-dim);
+  border-color: var(--cyan-muted);
   background: var(--cyan-subtle);
 }
 .message.assistant .bubble {
-  border-color: var(--border-bright);
+  border-color: var(--border);
 }
 .message.system .bubble {
-  border-color: var(--amber-dim);
+  border-color: var(--amber-muted);
   background: var(--amber-subtle);
-  color: var(--amber);
+  color: var(--amber-dim);
   font-size: var(--fs-xs);
 }
 .thinking-panel {
   margin-bottom: 0.4rem;
-  border: 1px solid var(--amber-dim);
-  border-radius: 8px;
+  border: 1px solid var(--amber-muted);
+  border-radius: var(--radius);
   background: var(--amber-subtle);
   overflow: hidden;
 }
@@ -271,13 +200,13 @@ body {
 }
 .thinking-panel summary::-webkit-details-marker { display: none; }
 .thinking-panel summary::after {
-  content: '>';
+  content: '›';
   margin-left: auto;
   color: var(--amber-dim);
   transition: transform 0.15s;
 }
 .thinking-panel[open] summary::after { transform: rotate(90deg); }
-.thinking-panel[open] summary { border-bottom: 1px solid var(--amber-dim); }
+.thinking-panel[open] summary { border-bottom: 1px solid var(--amber-muted); }
 .thinking-meta {
   color: var(--text-dim);
   font-size: var(--fs-xs);
@@ -297,46 +226,51 @@ body {
   display: inline-block;
   width: 7px;
   height: 14px;
-  background: var(--green);
+  background: var(--accent);
   animation: blink 0.8s step-end infinite;
   vertical-align: text-bottom;
   margin-left: 2px;
+  border-radius: 1px;
 }
 @keyframes blink {
   50% { opacity: 0; }
 }
 
-/* Markdown in assistant */
+/* Markdown in assistant (code = mono, body text = sans) */
 .bubble code {
+  font-family: var(--font-mono);
   background: var(--bg-surface);
-  padding: 1px 4px;
-  border-radius: 4px;
-  font-size: 0.9em;
+  border: 1px solid var(--border-dim);
+  padding: 1px 5px;
+  border-radius: var(--radius-sm);
+  font-size: 0.88em;
 }
 .bubble pre {
+  font-family: var(--font-mono);
   background: var(--bg-surface);
   border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 0.5rem;
-  margin: 0.4rem 0;
+  border-radius: var(--radius-sm);
+  padding: 0.6rem 0.7rem;
+  margin: 0.45rem 0;
   overflow-x: auto;
   font-size: var(--fs-xs);
 }
 .bubble pre code {
   background: none;
+  border: 0;
   padding: 0;
 }
 .bubble ul, .bubble ol { margin: 0.3rem 0 0.3rem 1.25rem; padding: 0; }
 .bubble li { margin: 0.12rem 0; }
-.bubble a { color: var(--cyan); text-decoration: underline; word-break: break-all; }
-.bubble a:hover { text-shadow: 0 0 6px var(--cyan-dim); }
+.bubble a { color: var(--accent); text-decoration: underline; word-break: break-all; }
+.bubble a:hover { color: var(--accent-hover); }
 .bubble em { color: var(--text-bright); font-style: italic; }
 
 /* Error bubble — visually distinct from normal assistant output */
 .message.assistant .bubble.bubble-error {
-  border-color: var(--red-dim);
+  border-color: var(--red-muted);
   background: var(--red-subtle);
-  color: var(--red);
+  color: var(--red-dim);
 }
 
 /* AskUserQuestion prompt */
@@ -355,8 +289,8 @@ body {
 .ask-prompt .ask-bubble {
   padding: 0.5rem 0.75rem;
   border: 1px solid var(--magenta);
-  border-radius: 8px;
-  background: #f5f3ff;
+  border-radius: var(--radius);
+  background: var(--magenta-subtle);
   font-size: var(--fs-sm);
   white-space: pre-wrap;
   word-break: break-word;
@@ -385,10 +319,10 @@ body {
   padding: 8px 12px;
   background: var(--bg-surface);
   border: 1px solid var(--border-bright);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   color: var(--text);
   cursor: pointer;
-  transition: all 0.15s;
+  transition: background-color 0.15s, border-color 0.15s, color 0.15s;
 }
 .ask-prompt .ask-option-btn.multi {
   display: flex;
@@ -397,11 +331,11 @@ body {
 }
 .ask-prompt .ask-option-btn:hover {
   border-color: var(--magenta);
-  background: #ede9fe;
+  background: var(--magenta-subtle);
 }
 .ask-prompt .ask-option-btn.selected {
   border-color: var(--magenta);
-  background: #ede9fe;
+  background: var(--magenta-subtle);
   color: var(--magenta);
 }
 .ask-prompt .ask-option-marker {
@@ -427,30 +361,30 @@ body {
   font-family: var(--font);
   font-size: var(--fs-sm);
   background: var(--bg);
-  color: var(--text);
+  color: var(--text-bright);
   border: 1px solid var(--magenta);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   padding: 6px 10px;
   outline: none;
 }
 .ask-prompt .ask-input:focus {
-  box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.14);
+  box-shadow: 0 0 0 3px var(--magenta-subtle);
 }
 .ask-prompt .ask-submit {
   font-family: var(--font);
   font-size: var(--fs-xs);
+  font-weight: 600;
   padding: 6px 14px;
-  background: rgba(255, 0, 255, 0.1);
+  background: var(--magenta-subtle);
   border: 1px solid var(--magenta);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   color: var(--magenta);
   cursor: pointer;
-  text-transform: none;
-  letter-spacing: 0;
-  transition: all 0.15s;
+  transition: background-color 0.15s, color 0.15s;
 }
 .ask-prompt .ask-submit:hover {
-  background: #ede9fe;
+  background: var(--magenta);
+  color: var(--bg);
 }
 
 /* === Tool events ===
@@ -474,11 +408,11 @@ body {
 .tool-event details {
   border: 1px solid var(--border);
   border-left: none;
-  border-radius: 0 8px 8px 0;
+  border-radius: 0 var(--radius) var(--radius) 0;
   background: var(--bg-surface);
   overflow: hidden;
 }
-.tool-event.tool-agent > details { background: #f5f3ff; }
+.tool-event.tool-agent > details { background: var(--magenta-subtle); }
 .tool-event summary {
   display: flex;
   align-items: center;
@@ -491,20 +425,21 @@ body {
 }
 .tool-event summary::-webkit-details-marker { display: none; }
 .tool-event summary::after {
-  content: '>';
+  content: '›';
   margin-left: 0.25rem;
   color: var(--text-muted);
-  font-size: var(--fs-xs);
+  font-size: var(--fs-base);
   transition: transform 0.15s;
 }
-.tool-event details[open] summary::after { transform: rotate(90deg); color: var(--green-dim); }
+.tool-event details[open] summary::after { transform: rotate(90deg); color: var(--text-dim); }
 .tool-event details[open] summary { border-bottom: 1px solid var(--border); }
 .tool-event .tool-badge {
   flex: 0 0 auto;
+  font-family: var(--font-mono);
   font-size: var(--fs-xs);
-  padding: 1px 6px;
+  padding: 1px 7px;
   border: 1px solid;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   font-weight: 600;
   letter-spacing: 0;
   white-space: nowrap;
@@ -560,10 +495,14 @@ body {
 .tool-event .tool-section-result .tool-section-label { color: var(--cyan-dim); }
 .tool-event .tool-section-error .tool-section-label { color: var(--red); }
 .tool-event .tool-body pre {
+  font-family: var(--font-mono);
   margin: 0;
   white-space: pre-wrap;
   word-break: break-word;
   color: var(--text-dim);
+  background: none;
+  border: 0;
+  padding: 0;
 }
 .tool-event .tool-children { padding-left: 0.85rem; }
 .tool-event .tool-children:empty { display: none; }
@@ -613,10 +552,10 @@ body {
   flex: 1;
   font-family: var(--font);
   font-size: var(--fs-sm);
-  background: var(--bg-deep);
+  background: var(--bg-surface);
   color: var(--text-bright);
   border: 1px solid var(--border-bright);
-  border-radius: 8px;
+  border-radius: var(--radius);
   padding: 8px 12px;
   resize: none;
   outline: none;
@@ -626,34 +565,30 @@ body {
   overflow-y: auto;
 }
 .input-row textarea:focus {
-  border-color: var(--cyan);
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.14);
-}
-.input-row textarea::placeholder {
-  color: var(--text-muted);
+  border-color: var(--accent);
+  box-shadow: var(--ring);
 }
 
 .send-btn {
   font-family: var(--font);
   font-size: var(--fs-sm);
+  font-weight: 600;
   padding: 8px 18px;
-  background: var(--cyan);
-  color: #ffffff;
-  border: 1px solid var(--cyan);
-  border-radius: 8px;
+  background: var(--accent);
+  color: var(--accent-fg);
+  border: 1px solid var(--accent);
+  border-radius: var(--radius);
   cursor: pointer;
-  text-transform: none;
-  letter-spacing: 0;
   transition: background-color 0.15s, border-color 0.15s;
   white-space: nowrap;
   height: 38px;
 }
 .send-btn:hover:not(:disabled) {
-  background: var(--cyan-dim);
-  border-color: var(--cyan-dim);
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
 }
 .send-btn:disabled {
-  opacity: 0.3;
+  opacity: 0.4;
   cursor: not-allowed;
 }
 
@@ -682,6 +617,10 @@ body {
 .status-dot.streaming { background: var(--amber); animation: pulse 1s ease-in-out infinite; }
 .status-dot.error { background: var(--red); }
 @keyframes pulse { 50% { opacity: 0.4; } }
+.status-bar #token-info {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
 
 /* Welcome */
 .welcome {
@@ -697,9 +636,9 @@ body {
   min-height: 42px;
   margin-bottom: 1rem;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius);
   background: var(--bg);
-  color: var(--cyan-dim);
+  color: var(--accent);
   font-weight: 700;
 }
 .welcome p {
@@ -711,14 +650,11 @@ body {
   font-size: var(--fs-xs);
 }
 
-/* Focus visible */
-:focus-visible { outline: 2px solid var(--cyan); outline-offset: 2px; }
-
 /* === Auth Overlay === */
 .auth-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(15, 23, 42, 0.35);
+  background: rgba(10, 10, 11, 0.5);
   backdrop-filter: blur(4px);
   display: flex;
   align-items: center;
@@ -731,15 +667,14 @@ body {
   width: min(420px, 100%);
   background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: 1.5rem;
-  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.22);
+  box-shadow: var(--shadow-lg);
 }
 .auth-box h2 {
   color: var(--text-bright);
   font-size: var(--fs-lg);
   margin-bottom: 0.5rem;
-  letter-spacing: 0;
 }
 .auth-box .auth-prompt {
   color: var(--text-dim);
@@ -754,36 +689,25 @@ body {
 }
 .auth-box .auth-input {
   width: 100%;
-  font-family: var(--font);
+  font-family: var(--font-mono);
   font-size: var(--fs-sm);
-  background: var(--bg-deep);
-  color: var(--text-bright);
-  border: 1px solid var(--border-bright);
-  border-radius: 6px;
-  padding: 8px 10px;
-  outline: none;
   margin-bottom: 0.75rem;
-}
-.auth-box .auth-input:focus {
-  border-color: var(--cyan);
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.14);
 }
 .auth-box .auth-submit {
   width: 100%;
   font-family: var(--font);
   font-size: var(--fs-sm);
+  font-weight: 600;
   padding: 8px 14px;
-  background: var(--cyan);
-  color: #ffffff;
-  border: 1px solid var(--cyan);
-  border-radius: 6px;
+  background: var(--accent);
+  color: var(--accent-fg);
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  text-transform: none;
-  letter-spacing: 0;
 }
 .auth-box .auth-submit:hover {
-  background: var(--cyan-dim);
-  border-color: var(--cyan-dim);
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
 }
 .auth-box .auth-error {
   color: var(--red);
@@ -793,10 +717,7 @@ body {
 }
 
 /* Send button active */
-.send-btn:active:not(:disabled) { transform: scale(0.98); background: var(--cyan-dim); }
-
-.tool-event .tool-body::-webkit-scrollbar { width: 4px; }
-.tool-event .tool-body::-webkit-scrollbar-thumb { background: var(--border-bright); border-radius: 2px; }
+.send-btn:active:not(:disabled) { transform: scale(0.98); background: var(--accent-hover); }
 
 /* Responsive */
 @media (max-width: 640px) {
@@ -846,6 +767,7 @@ body {
     <button class="btn" onclick="newSession()" title="New session">New</button>
     <a class="btn" href="/admin">Admin</a>
     <a class="btn" href="/">Home</a>
+    __OMG_THEME_TOGGLE_HTML__
   </div>
 </div>
 
@@ -1819,5 +1741,6 @@ checkAdminAuth();
 loadModels();
 inputEl.focus();
 </script>
+__OMG_THEME_TOGGLE_JS__
 </body>
 </html>"""

--- a/src/landing_page.py
+++ b/src/landing_page.py
@@ -1,334 +1,248 @@
 import html
 from typing import Any, Dict
 
+from src.theme import (
+    theme_head_init,
+    theme_tokens_css,
+    base_css,
+    theme_toggle_html,
+    theme_toggle_js,
+)
+
 
 def build_root_page(version: str, auth_info: Dict[str, Any], default_port: int) -> str:
     """Build the landing page HTML."""
     auth_method = html.escape(str(auth_info.get("method", "unknown")))
     auth_valid = auth_info.get("status", {}).get("valid", False)
-    status_text = html.escape("ONLINE" if auth_valid else "OFFLINE")
+    status_text = html.escape("Online" if auth_valid else "Offline")
     status_class = "online" if auth_valid else "offline"
     version = html.escape(str(version))
 
+    # Theme module returns single-brace CSS/JS/HTML. Because the page body below
+    # is an f-string (where only `{name}` interpolates and `{{`/`}}` are literal
+    # braces), interpolated values are inserted verbatim — their `{`/`}` are NOT
+    # re-processed. So these can be embedded directly with no brace escaping.
+    head_init = theme_head_init()
+    tokens_css = theme_tokens_css()
+    shared_css = base_css()
+    toggle_html = theme_toggle_html()
+    toggle_js = theme_toggle_js()
+
     return f"""<!DOCTYPE html>
-<html lang="ko">
+<html lang="en" data-theme="system">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Oh My Gateway</title>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+{head_init}
 <style>
+{tokens_css}
+{shared_css}
+
 /* ================================================================
-   TERMINAL DESIGN SYSTEM — Landing Page
-   Mirrors the admin panel phosphor/CRT aesthetic
+   Landing page — modern developer console (page-specific styles)
    ================================================================ */
 
-:root {{
-  --green: #00ff41;
-  --green-dim: #00cc33;
-  --green-muted: #00802080;
-  --green-subtle: #00ff4112;
-  --green-glow: 0 0 10px #00ff4140, 0 0 40px #00ff4110;
-  --amber: #ffb000;
-  --amber-dim: #cc8800;
-  --amber-subtle: #ffb00015;
-  --cyan: #00e5ff;
-  --cyan-dim: #00b8cc;
-  --cyan-subtle: #00e5ff12;
-  --red: #ff0033;
-  --red-dim: #cc0029;
-  --red-subtle: #ff003315;
+.container {{ max-width: 960px; margin: 0 auto; padding: 2rem 1.5rem 3rem; }}
 
-  --bg-deep: #050505;
-  --bg: #0a0a0a;
-  --bg-raised: #111111;
-  --bg-surface: #161616;
-  --bg-hover: #1a1a1a;
-  --border: #1e1e1e;
-  --border-bright: #2a2a2a;
-
-  --text: #b0ffb0;
-  --text-bright: #00ff41;
-  --text-dim: #4a7a4a;
-  --text-muted: #3a5a3a;
-
-  --font: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', 'SF Mono', monospace;
-  --fs-xs: 0.7rem;
-  --fs-sm: 0.78rem;
-  --fs-base: 0.85rem;
-  --fs-lg: 1rem;
-  --fs-xl: 1.2rem;
-}}
-
-*, *::before, *::after {{ box-sizing: border-box; margin: 0; padding: 0; }}
-
-body {{
-  background: var(--bg-deep);
-  color: var(--text);
+/* === Wordmark / header === */
+.wordmark {{
   font-family: var(--font);
-  font-size: var(--fs-base);
-  line-height: 1.6;
-  -webkit-font-smoothing: antialiased;
-  overflow-x: hidden;
+  font-weight: 700;
+  font-size: var(--fs-2xl);
+  letter-spacing: -0.02em;
+  color: var(--text-bright);
+  margin: 0;
+  line-height: 1.1;
 }}
-
-/* CRT Scanline Overlay */
-body::before {{
-  content: '';
-  position: fixed;
-  inset: 0;
-  background: repeating-linear-gradient(
-    0deg,
-    transparent,
-    transparent 2px,
-    rgba(0, 0, 0, 0.08) 2px,
-    rgba(0, 0, 0, 0.08) 4px
-  );
-  pointer-events: none;
-  z-index: 9999;
-}}
-
-/* Grid Background */
-body::after {{
-  content: '';
-  position: fixed;
-  inset: 0;
-  background-image:
-    linear-gradient(var(--green-muted) 1px, transparent 1px),
-    linear-gradient(90deg, var(--green-muted) 1px, transparent 1px);
-  background-size: 60px 60px;
-  opacity: 0.04;
-  pointer-events: none;
-  z-index: -1;
-}}
-
-.container {{ max-width: 960px; margin: 0 auto; padding: 1.5rem; }}
-
-a {{ color: var(--green-dim); text-decoration: none; transition: color 0.15s, text-shadow 0.15s; }}
-a:hover {{ color: var(--green); text-shadow: 0 0 6px var(--green-muted); }}
-
-/* === ASCII Header === */
-.ascii-header {{
-  font-size: var(--fs-xs);
-  color: var(--green-dim);
-  text-align: center;
-  line-height: 1.15;
-  letter-spacing: 0.05em;
-  margin-bottom: var(--fs-sm);
-  text-shadow: 0 0 8px var(--green-muted);
-  white-space: pre;
-  overflow: hidden;
+.wordmark .accent {{ color: var(--accent); }}
+.tagline {{
+  color: var(--text-dim);
+  font-size: var(--fs-sm);
+  margin-top: 0.35rem;
 }}
 
 .header-bar {{
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  padding: 0.5rem 0;
-  border-bottom: 1px solid var(--border-bright);
-  margin-bottom: 1.5rem;
+  padding-bottom: 1.25rem;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 1.75rem;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 1rem;
 }}
 .header-bar .left {{
   display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}}
+.header-bar .meta {{
+  display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.6rem;
+  flex-wrap: wrap;
 }}
 .header-bar .right {{
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.6rem;
 }}
+
 .version-tag {{
-  font-size: var(--fs-xs);
-  color: var(--text-dim);
-  border: 1px solid var(--border-bright);
-  padding: 2px 8px;
-}}
-.github-link {{
+  font-family: var(--font-mono);
   font-size: var(--fs-xs);
   color: var(--text-dim);
   border: 1px solid var(--border);
-  padding: 2px 8px;
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  transition: all 0.15s;
+  border-radius: var(--radius-pill);
+  padding: 2px 10px;
+  background: var(--bg-surface);
 }}
-.github-link:hover {{
-  color: var(--green);
-  border-color: var(--green-dim);
-}}
-.github-link svg {{ width: 14px; height: 14px; }}
-
-/* Status */
-.status-indicator {{
+.github-link {{
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 5px 10px;
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  transition: color 0.15s ease, border-color 0.15s ease, background-color 0.15s ease;
+}}
+.github-link:hover {{
+  color: var(--text-bright);
+  border-color: var(--border-bright);
+  background: var(--bg-hover);
+}}
+.github-link svg {{ width: 15px; height: 15px; }}
+
+/* === Status === */
+.status-indicator {{
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
   font-size: var(--fs-sm);
+  font-weight: 500;
 }}
 .status-dot {{
   width: 8px;
   height: 8px;
   border-radius: 50%;
   display: inline-block;
+  flex-shrink: 0;
 }}
 .status-dot.online {{
   background: var(--green);
-  box-shadow: 0 0 8px var(--green-muted);
-  animation: pulse-glow 2s ease-in-out infinite;
+  box-shadow: 0 0 0 3px var(--green-subtle);
 }}
 .status-dot.offline {{
   background: var(--red);
-  box-shadow: 0 0 8px var(--red-subtle);
-  animation: pulse-glow 2s ease-in-out infinite;
+  box-shadow: 0 0 0 3px var(--red-subtle);
 }}
-.status-label.online {{ color: var(--green); text-shadow: 0 0 6px var(--green-muted); }}
-.status-label.offline {{ color: var(--red); }}
+.status-label.online {{ color: var(--green-dim); }}
+.status-label.offline {{ color: var(--red-dim); }}
 
-@keyframes pulse-glow {{
-  0%, 100% {{ opacity: 1; }}
-  50% {{ opacity: 0.5; }}
-}}
-
-/* Auth badge */
+/* === Auth badge === */
 .auth-badge {{
+  font-family: var(--font-mono);
   font-size: var(--fs-xs);
-  color: var(--cyan);
-  border: 1px solid var(--cyan-dim);
-  padding: 1px 8px;
-  background: var(--cyan-subtle);
+  color: var(--accent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  padding: 2px 10px;
+  background: var(--accent-subtle);
 }}
 
 /* === Cards === */
-.card {{
-  background: var(--bg-raised);
-  border: 1px solid var(--border);
-  padding: 1rem 1.25rem;
-  margin-bottom: 1rem;
-  position: relative;
-}}
-.card::before {{
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, var(--green-dim), transparent);
-  opacity: 0.4;
-}}
+.card {{ margin-bottom: 1.25rem; }}
 .card-title {{
-  font-size: var(--fs-sm);
+  font-size: var(--fs-xs);
   color: var(--text-dim);
   text-transform: uppercase;
-  letter-spacing: 0.12em;
-  font-weight: 500;
-  margin-bottom: 0.75rem;
-}}
-.card-title::before {{
-  content: '// ';
-  color: var(--text-muted);
+  letter-spacing: 0.08em;
+  font-weight: 700;
+  margin-bottom: 1rem;
 }}
 
 /* === Quick Start === */
 .quickstart-wrapper {{
   position: relative;
-  background: var(--bg);
+  background: var(--bg-surface);
   border: 1px solid var(--border);
-  padding: 1rem;
+  border-radius: var(--radius);
+  padding: 1rem 1.1rem;
   overflow-x: auto;
 }}
 .quickstart-wrapper pre {{
   margin: 0;
+  padding: 0;
+  border: 0;
+  background: none;
   color: var(--text);
-  font-family: var(--font);
+  font-family: var(--font-mono);
   font-size: var(--fs-sm);
+  line-height: 1.6;
   white-space: pre-wrap;
-  word-break: break-all;
+  word-break: break-word;
 }}
 .copy-btn {{
   position: absolute;
-  top: 0.5rem;
-  right: 0.5rem;
-  padding: 4px 10px;
-  background: var(--bg-raised);
+  top: 0.6rem;
+  right: 0.6rem;
+  padding: 4px 11px;
+  background: var(--bg);
   border: 1px solid var(--border-bright);
+  border-radius: var(--radius-sm);
   color: var(--text-dim);
   cursor: pointer;
   font-family: var(--font);
   font-size: var(--fs-xs);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  transition: all 0.15s;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  transition: color 0.15s ease, border-color 0.15s ease, background-color 0.15s ease;
 }}
 .copy-btn:hover {{
-  color: var(--green);
-  border-color: var(--green-dim);
-  text-shadow: 0 0 4px var(--green-muted);
+  color: var(--text-bright);
+  border-color: var(--text-dim);
+  background: var(--bg-hover);
 }}
 .copy-btn.copied {{
-  color: var(--green);
-  border-color: var(--green-dim);
+  color: var(--green-dim);
+  border-color: var(--green-muted);
+  background: var(--green-subtle);
 }}
 
 /* === Endpoint List === */
 .endpoint-group-label {{
   font-size: var(--fs-xs);
-  font-weight: 500;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.08em;
   color: var(--text-muted);
-  padding: 0.75rem 0 0.35rem;
+  padding: 1rem 0 0.4rem;
 }}
 .endpoint-group-label:first-child {{ padding-top: 0; }}
 
 .endpoint-row {{
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.4rem 0;
-  border-bottom: 1px solid var(--border);
+  gap: 0.85rem;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--border-dim);
   font-size: var(--fs-sm);
 }}
 .endpoint-row:last-child {{ border-bottom: none; }}
 
-.badge {{
-  display: inline-block;
-  padding: 1px 8px;
-  font-size: var(--fs-xs);
-  font-weight: 500;
-  font-family: var(--font);
-  letter-spacing: 0.05em;
-  border: 1px solid;
-  flex-shrink: 0;
-  min-width: 44px;
-  text-align: center;
-}}
-.badge-post {{
-  background: var(--green-subtle);
-  color: var(--green);
-  border-color: var(--green-dim);
-  text-shadow: 0 0 4px var(--green-muted);
-}}
-.badge-get {{
-  background: var(--cyan-subtle);
-  color: var(--cyan);
-  border-color: var(--cyan-dim);
-}}
-.badge-del {{
-  background: var(--red-subtle);
-  color: var(--red);
-  border-color: var(--red-dim);
-}}
+.badge {{ min-width: 50px; }}
 
 .endpoint-path {{
   color: var(--text);
-  font-family: var(--font);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
   flex: 1;
+  min-width: 0;
+  overflow-wrap: anywhere;
 }}
 .endpoint-desc {{
   color: var(--text-dim);
@@ -338,117 +252,118 @@ a:hover {{ color: var(--green); text-shadow: 0 0 6px var(--green-muted); }}
 
 /* === Expandable Details === */
 details {{
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-dim);
+  border-radius: var(--radius-sm);
   background: var(--bg-surface);
-  margin-bottom: 2px;
+  margin-bottom: 4px;
 }}
 details summary {{
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.4rem 0.75rem;
+  gap: 0.85rem;
+  padding: 0.5rem 0.85rem;
   cursor: pointer;
   list-style: none;
   font-size: var(--fs-sm);
-  transition: background 0.1s;
+  border-radius: var(--radius-sm);
+  transition: background-color 0.12s ease;
 }}
 details summary::-webkit-details-marker {{ display: none; }}
 details summary::after {{
-  content: '>';
+  content: '';
+  width: 7px;
+  height: 7px;
   margin-left: auto;
-  color: var(--text-muted);
-  font-size: var(--fs-xs);
-  transition: transform 0.15s;
+  border-right: 1.5px solid var(--text-muted);
+  border-bottom: 1.5px solid var(--text-muted);
+  transform: rotate(-45deg);
+  transition: transform 0.15s ease, border-color 0.15s ease;
+  flex-shrink: 0;
 }}
 details[open] summary::after {{
-  transform: rotate(90deg);
-  color: var(--green-dim);
+  transform: rotate(45deg);
+  border-color: var(--accent);
 }}
 details[open] summary {{
   border-bottom: 1px solid var(--border);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }}
 details summary:hover {{
   background: var(--bg-hover);
 }}
 details .detail-body {{
-  padding: 0.75rem;
+  padding: 0.85rem;
   font-size: var(--fs-sm);
 }}
 details .detail-body pre {{
   margin: 0;
   overflow-x: auto;
+  font-family: var(--font-mono);
 }}
 
 /* === Config Grid === */
 .config-grid {{
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   gap: 0.75rem;
 }}
 .config-item {{
-  padding: 0.75rem;
+  padding: 0.85rem;
   background: var(--bg-surface);
   border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
 }}
 .config-item .val {{
-  color: var(--green);
+  color: var(--text-bright);
+  font-family: var(--font-mono);
   font-weight: 600;
   font-size: var(--fs-sm);
-  text-shadow: 0 0 4px var(--green-muted);
 }}
 .config-item .label {{
   font-size: var(--fs-xs);
   color: var(--text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  margin-top: 2px;
+  margin-top: 4px;
+}}
+.config-key {{
+  font-family: var(--font-mono);
+  color: var(--accent);
+  font-weight: 600;
 }}
 
 /* === Footer === */
 footer {{
   border-top: 1px solid var(--border);
-  padding-top: 1rem;
-  margin-top: 1rem;
+  padding-top: 1.25rem;
+  margin-top: 1.5rem;
 }}
 footer nav {{
   display: flex;
   justify-content: center;
-  gap: 2rem;
+  gap: 1.75rem;
   flex-wrap: wrap;
 }}
 footer a {{
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
   font-size: var(--fs-sm);
+  font-weight: 500;
   color: var(--text-dim);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
   padding: 4px 0;
   border-bottom: 1px solid transparent;
-  transition: all 0.15s;
+  transition: color 0.15s ease, border-color 0.15s ease;
 }}
 footer a:hover {{
-  color: var(--green);
-  border-bottom-color: var(--green-dim);
-  text-shadow: 0 0 4px var(--green-muted);
-}}
-footer a::before {{
-  content: '>';
-  color: var(--text-muted);
-  transition: color 0.15s;
-}}
-footer a:hover::before {{
-  color: var(--green-dim);
+  color: var(--text-bright);
+  border-bottom-color: var(--accent);
 }}
 footer .copyright {{
   text-align: center;
+  font-family: var(--font-mono);
   font-size: var(--fs-xs);
   color: var(--text-muted);
-  margin-top: 0.75rem;
+  margin-top: 1rem;
 }}
 
-/* === Loading spinner === */
+/* === Loading indicator === */
 .loader {{
   color: var(--text-dim);
   font-size: var(--fs-xs);
@@ -466,7 +381,7 @@ footer .copyright {{
 
 .hidden {{ display: none !important; }}
 
-/* Shiki overrides */
+/* === Shiki overrides === */
 .shiki {{
   padding: 0 !important;
   margin: 0 !important;
@@ -476,14 +391,14 @@ footer .copyright {{
 .shiki code {{
   white-space: pre-wrap;
   word-break: break-word;
-  font-family: var(--font);
+  font-family: var(--font-mono);
   font-size: var(--fs-sm);
 }}
 
-/* Responsive */
+/* === Responsive === */
 @media (max-width: 640px) {{
-  .container {{ padding: 1rem; }}
-  .ascii-header {{ font-size: 0.45rem; }}
+  .container {{ padding: 1.25rem 1rem 2rem; }}
+  .wordmark {{ font-size: var(--fs-xl); }}
   .endpoint-desc {{ display: none; }}
   .config-grid {{ grid-template-columns: 1fr 1fr; }}
 }}
@@ -491,12 +406,17 @@ footer .copyright {{
 <script type="module">
     import {{ codeToHtml }} from 'https://esm.sh/shiki@3.0.0';
 
-    const theme = 'vitesse-dark';
+    function shikiTheme() {{
+        var t = document.documentElement.getAttribute('data-theme');
+        if (t === 'dark') return 'github-dark';
+        if (t === 'light') return 'github-light';
+        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'github-dark' : 'github-light';
+    }}
 
     async function highlightJson(json, targetId) {{
         const code = typeof json === 'string' ? json : JSON.stringify(json, null, 2);
         try {{
-            const html = await codeToHtml(code, {{ lang: 'json', theme }});
+            const html = await codeToHtml(code, {{ lang: 'json', theme: shikiTheme() }});
             document.getElementById(targetId).innerHTML = html;
         }} catch (e) {{
             document.getElementById(targetId).innerHTML = '<pre style="color:var(--red);">ERR: ' + e.message + '</pre>';
@@ -531,7 +451,7 @@ footer .copyright {{
 
     async function highlightQuickstart() {{
         try {{
-            const html = await codeToHtml(quickstartCode, {{ lang: 'bash', theme }});
+            const html = await codeToHtml(quickstartCode, {{ lang: 'bash', theme: shikiTheme() }});
             document.getElementById('quickstart-code').innerHTML = html;
         }} catch (e) {{
             document.getElementById('quickstart-code').textContent = quickstartCode;
@@ -558,13 +478,14 @@ footer .copyright {{
         ta.style.cssText = 'position:fixed;opacity:0';
         document.body.appendChild(ta);
         ta.select();
-        try {{ document.execCommand('copy'); showCopied(btn); }} catch (e) {{}}
+        try {{ document.execCommand('copy'); showCopied(btn); }}
+        catch (e) {{ if (window.console && console.debug) console.debug('copy failed', e); }}
         document.body.removeChild(ta);
     }}
 
     function showCopied(btn) {{
         const orig = btn.textContent;
-        btn.textContent = 'COPIED';
+        btn.textContent = 'Copied';
         btn.classList.add('copied');
         setTimeout(() => {{ btn.textContent = orig; btn.classList.remove('copied'); }}, 2000);
     }}
@@ -573,30 +494,25 @@ footer .copyright {{
 <body>
 <main class="container">
 
-    <!-- ASCII Art Header -->
-    <div class="ascii-header" aria-hidden="true">
- ██████╗ ██╗  ██╗    ███╗   ███╗██╗   ██╗     ██████╗  █████╗ ████████╗███████╗██╗    ██╗ █████╗ ██╗   ██╗
-██╔═══██╗██║  ██║    ████╗ ████║╚██╗ ██╔╝    ██╔════╝ ██╔══██╗╚══██╔══╝██╔════╝██║    ██║██╔══██╗╚██╗ ██╔╝
-██║   ██║███████║    ██╔████╔██║ ╚████╔╝     ██║  ███╗███████║   ██║   █████╗  ██║ █╗ ██║███████║ ╚████╔╝
-██║   ██║██╔══██║    ██║╚██╔╝██║  ╚██╔╝      ██║   ██║██╔══██║   ██║   ██╔══╝  ██║███╗██║██╔══██║  ╚██╔╝
-╚██████╔╝██║  ██║    ██║ ╚═╝ ██║   ██║       ╚██████╔╝██║  ██║   ██║   ███████╗╚███╔███╔╝██║  ██║   ██║
- ╚═════╝ ╚═╝  ╚═╝    ╚═╝     ╚═╝   ╚═╝        ╚═════╝ ╚═╝  ╚═╝   ╚═╝   ╚══════╝ ╚══╝╚══╝ ╚═╝  ╚═╝   ╚═╝
-    </div>
-
     <!-- Header Bar -->
     <div class="header-bar">
         <div class="left">
-            <span class="status-indicator">
-                <span class="status-dot {status_class}"></span>
-                <span class="status-label {status_class}">{status_text}</span>
-            </span>
-            <span class="auth-badge">AUTH: {auth_method}</span>
+            <h1 class="wordmark">Oh My <span class="accent">Gateway</span></h1>
+            <p class="tagline">OpenAI-compatible gateway for Claude, OpenCode &amp; Codex backends.</p>
+            <div class="meta">
+                <span class="status-indicator">
+                    <span class="status-dot {status_class}"></span>
+                    <span class="status-label {status_class}">{status_text}</span>
+                </span>
+                <span class="auth-badge">auth: {auth_method}</span>
+            </div>
         </div>
         <div class="right">
+            {toggle_html}
             <span class="version-tag">v{version}</span>
             <a href="https://github.com/JinY0ung-Shin/oh-my-gateway" target="_blank" rel="noopener noreferrer" class="github-link" title="GitHub">
                 <svg fill="currentColor" viewBox="0 0 24 24"><path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/></svg>
-                GITHUB
+                GitHub
             </a>
         </div>
     </div>
@@ -605,7 +521,7 @@ footer .copyright {{
     <div class="card">
         <div class="card-title">Quick Start</div>
         <div class="quickstart-wrapper">
-            <button id="copy-btn" onclick="copyQuickstart()" class="copy-btn" title="Copy">COPY</button>
+            <button id="copy-btn" onclick="copyQuickstart()" class="copy-btn" title="Copy">Copy</button>
             <div id="quickstart-code">
                 <pre>curl -X POST http://localhost:{default_port}/v1/responses \\
   -H "Content-Type: application/json" \\
@@ -730,7 +646,7 @@ footer .copyright {{
     <div class="card">
         <div class="card-title">Configuration</div>
         <p style="color:var(--text-dim);font-size:var(--fs-sm);margin-bottom:0.75rem;">
-            Set <span style="color:var(--amber);">CLAUDE_AUTH_METHOD</span> to choose authentication:
+            Set <span class="config-key">CLAUDE_AUTH_METHOD</span> to choose authentication:
         </p>
         <div class="config-grid" style="margin-bottom:1rem;">
             <div class="config-item">
@@ -756,12 +672,13 @@ footer .copyright {{
         <nav>
             <a href="/docs">API Docs</a>
             <a href="/redoc">ReDoc</a>
-            <a href="/admin">Admin Terminal</a>
+            <a href="/admin">Admin</a>
             <a href="/admin/chat">Chat</a>
         </nav>
-        <div class="copyright">OH MY GATEWAY // v{version}</div>
+        <div class="copyright">Oh My Gateway // v{version}</div>
     </footer>
 
 </main>
+{toggle_js}
 </body>
 </html>"""

--- a/src/theme.py
+++ b/src/theme.py
@@ -1,0 +1,696 @@
+"""Shared design system for all server-rendered surfaces.
+
+One source of truth for the "modern developer console" look (Linear/Vercel
+flavored): neutral zinc/slate surfaces, a single restrained indigo accent, and
+the HTTP-method colors (GET/POST/PUT/DELETE) as the structural color system.
+
+Three surfaces consume this module: the API-reference landing page (`/`), the
+chat UI, and the admin SPA. Every function below is pure and returns a plain
+string (single-brace CSS / HTML / JS) with no side effects, so callers can
+embed the output however they template.
+
+Theming model
+-------------
+- `data-theme` lives on <html> with values "light" | "dark" | "system".
+- Light tokens are defined on `:root`; dark tokens override under
+  `html[data-theme="dark"]`. "system" follows `prefers-color-scheme` only when
+  the user has not explicitly chosen light/dark.
+- `theme_head_init()` applies the saved choice before first paint (no FOUC).
+- The toggle is VANILLA JS (works on plain pages AND alongside Alpine).
+
+IMPORTANT for the landing page: `src/landing_page.py` builds its HTML with
+`str.format()`, so any CSS/JS injected there must have its braces doubled
+(`{` -> `{{`, `}` -> `}}`). The strings returned here are canonical
+SINGLE-brace; the landing integrator is responsible for escaping them.
+"""
+
+__all__ = [
+    "theme_head_init",
+    "theme_tokens_css",
+    "base_css",
+    "theme_toggle_html",
+    "theme_toggle_js",
+]
+
+# localStorage key shared by the head init script and the toggle controller.
+_STORAGE_KEY = "omg-theme"
+
+
+def theme_head_init() -> str:
+    """Return a tiny synchronous <script> for <head> that prevents FOUC.
+
+    Reads localStorage["omg-theme"] (light|dark|system, default "system") and
+    sets <html data-theme="..."> before first paint. For "system" it sets
+    data-theme="system" and lets the media query in the token CSS resolve it.
+    Wrapped in try/catch so a blocked localStorage never breaks rendering.
+    """
+    return (
+        "<script>(function(){try{"
+        "var t=localStorage.getItem('" + _STORAGE_KEY + "');"
+        "if(t!=='light'&&t!=='dark'&&t!=='system'){t='system';}"
+        "document.documentElement.setAttribute('data-theme',t);"
+        "}catch(e){document.documentElement.setAttribute('data-theme','system');}"
+        "})();</script>"
+    )
+
+
+def theme_tokens_css() -> str:
+    """Return the CSS custom-property token set (light + dark + system).
+
+    The variable set is a SUPERSET of every var referenced across the landing,
+    chat, and admin surfaces today, so all existing component rules keep
+    resolving. Both light and dark values are provided for every token.
+
+    Method/status mapping (the signature color system):
+      --cyan  = GET    (blue)
+      --green = POST   (emerald/green)
+      --amber = PUT/PATCH (amber)
+      --red   = DELETE (red)
+      --accent = indigo (the single restrained UI accent)
+    """
+    return """/* ================================================================
+   Oh My Gateway — design tokens (light + dark + system)
+   data-theme on <html>: "light" | "dark" | "system"
+   ================================================================ */
+
+:root {
+  color-scheme: light;
+
+  /* --- Method / status: GET=blue, POST=green, PUT/PATCH=amber, DELETE=red --- */
+  --green: #047857;          /* POST */
+  --green-dim: #065f46;
+  --green-muted: #6ee7b7;
+  --green-subtle: #ecfdf5;
+  --green-glow: none;
+  --green-fg: #ffffff;
+
+  --cyan: #2563eb;           /* GET */
+  --cyan-dim: #1d4ed8;
+  --cyan-muted: #93c5fd;
+  --cyan-subtle: #eff6ff;
+  --cyan-fg: #ffffff;
+
+  --amber: #b45309;          /* PUT / PATCH */
+  --amber-dim: #92400e;
+  --amber-muted: #fcd34d;
+  --amber-subtle: #fffbeb;
+  --amber-fg: #ffffff;
+
+  --red: #dc2626;            /* DELETE */
+  --red-dim: #b91c1c;
+  --red-muted: #fca5a5;
+  --red-subtle: #fef2f2;
+  --red-fg: #ffffff;
+
+  --magenta: #7c3aed;        /* AskUserQuestion / agent accents */
+  --magenta-subtle: #f5f3ff;
+
+  /* --- Accent: indigo/violet (the one restrained UI accent) --- */
+  --accent: #4f46e5;
+  --accent-hover: #4338ca;
+  --accent-subtle: #eef2ff;
+  --accent-fg: #ffffff;
+
+  /* --- Surfaces --- */
+  --bg-deep: #f7f7f8;        /* page */
+  --bg: #ffffff;             /* card / control */
+  --bg-raised: #ffffff;
+  --bg-surface: #f1f5f9;     /* raised / subtle */
+  --bg-hover: #eef2f6;
+  --border: #e4e4e7;
+  --border-dim: #efeff1;
+  --border-bright: #d4d4d8;
+
+  /* --- Text --- */
+  --text: #27272a;
+  --text-bright: #18181b;
+  --text-dim: #52525b;
+  --text-muted: #a1a1aa;
+
+  /* --- Semantic aliases --- */
+  --color-success: var(--green);
+  --color-success-subtle: var(--green-subtle);
+  --color-warning: var(--amber);
+  --color-warning-subtle: var(--amber-subtle);
+  --color-danger: var(--red);
+  --color-danger-subtle: var(--red-subtle);
+  --color-info: var(--cyan);
+  --color-info-subtle: var(--cyan-subtle);
+
+  /* --- Spacing --- */
+  --gap-xs: 0.25rem;
+  --gap-sm: 0.5rem;
+  --gap-md: 0.75rem;
+  --gap-lg: 1rem;
+  --gap-xl: 1.5rem;
+
+  /* --- Radius --- */
+  --radius-sm: 6px;
+  --radius: 8px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
+  --radius-pill: 999px;
+
+  /* --- Elevation (prefer borders over heavy shadows) --- */
+  --shadow-sm: 0 1px 2px rgba(24, 24, 27, 0.05);
+  --shadow-md: 0 4px 12px rgba(24, 24, 27, 0.08);
+  --shadow-lg: 0 12px 30px rgba(24, 24, 27, 0.12);
+  --ring: 0 0 0 3px rgba(79, 70, 229, 0.28);
+
+  /* --- Typography --- */
+  --font: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Apple Color Emoji", sans-serif;
+  --font-mono: ui-monospace, "JetBrains Mono", "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  --fs-xs: 0.75rem;
+  --fs-sm: 0.8125rem;
+  --fs-base: 0.9rem;
+  --fs-lg: 1rem;
+  --fs-xl: 1.25rem;
+  --fs-2xl: 1.6rem;
+  --fs-display: 2rem;
+}
+
+/* ---------------- Dark: explicit override ---------------- */
+html[data-theme="dark"] {
+  color-scheme: dark;
+
+  --green: #34d399;
+  --green-dim: #6ee7b7;
+  --green-muted: #065f46;
+  --green-subtle: rgba(16, 185, 129, 0.14);
+  --green-glow: none;
+  --green-fg: #052e1b;
+
+  --cyan: #60a5fa;
+  --cyan-dim: #93c5fd;
+  --cyan-muted: #1e3a8a;
+  --cyan-subtle: rgba(59, 130, 246, 0.16);
+  --cyan-fg: #06183a;
+
+  --amber: #fbbf24;
+  --amber-dim: #fcd34d;
+  --amber-muted: #78350f;
+  --amber-subtle: rgba(245, 158, 11, 0.15);
+  --amber-fg: #1c1206;
+
+  --red: #f87171;
+  --red-dim: #fca5a5;
+  --red-muted: #7f1d1d;
+  --red-subtle: rgba(239, 68, 68, 0.16);
+  --red-fg: #2a0808;
+
+  --magenta: #a78bfa;
+  --magenta-subtle: rgba(124, 58, 237, 0.18);
+
+  --accent: #818cf8;
+  --accent-hover: #a5b4fc;
+  --accent-subtle: rgba(99, 102, 241, 0.18);
+  --accent-fg: #0a0a0b;
+
+  --bg-deep: #0a0a0b;
+  --bg: #161618;
+  --bg-raised: #161618;
+  --bg-surface: #1f1f23;
+  --bg-hover: #25252a;
+  --border: #2a2a2e;
+  --border-dim: #1f1f23;
+  --border-bright: #3a3a40;
+
+  --text: #ededf0;
+  --text-bright: #fafafa;
+  --text-dim: #a1a1aa;
+  --text-muted: #71717a;
+
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.45);
+  --shadow-lg: 0 12px 30px rgba(0, 0, 0, 0.55);
+  --ring: 0 0 0 3px rgba(129, 140, 248, 0.4);
+}
+
+/* ---------------- System: follow OS only when not explicit ---------------- */
+@media (prefers-color-scheme: dark) {
+  html[data-theme="system"],
+  :root:not([data-theme]) {
+    color-scheme: dark;
+
+    --green: #34d399;
+    --green-dim: #6ee7b7;
+    --green-muted: #065f46;
+    --green-subtle: rgba(16, 185, 129, 0.14);
+    --green-glow: none;
+    --green-fg: #052e1b;
+
+    --cyan: #60a5fa;
+    --cyan-dim: #93c5fd;
+    --cyan-muted: #1e3a8a;
+    --cyan-subtle: rgba(59, 130, 246, 0.16);
+    --cyan-fg: #06183a;
+
+    --amber: #fbbf24;
+    --amber-dim: #fcd34d;
+    --amber-muted: #78350f;
+    --amber-subtle: rgba(245, 158, 11, 0.15);
+    --amber-fg: #1c1206;
+
+    --red: #f87171;
+    --red-dim: #fca5a5;
+    --red-muted: #7f1d1d;
+    --red-subtle: rgba(239, 68, 68, 0.16);
+    --red-fg: #2a0808;
+
+    --magenta: #a78bfa;
+    --magenta-subtle: rgba(124, 58, 237, 0.18);
+
+    --accent: #818cf8;
+    --accent-hover: #a5b4fc;
+    --accent-subtle: rgba(99, 102, 241, 0.18);
+    --accent-fg: #0a0a0b;
+
+    --bg-deep: #0a0a0b;
+    --bg: #161618;
+    --bg-raised: #161618;
+    --bg-surface: #1f1f23;
+    --bg-hover: #25252a;
+    --border: #2a2a2e;
+    --border-dim: #1f1f23;
+    --border-bright: #3a3a40;
+
+    --text: #ededf0;
+    --text-bright: #fafafa;
+    --text-dim: #a1a1aa;
+    --text-muted: #71717a;
+
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.45);
+    --shadow-lg: 0 12px 30px rgba(0, 0, 0, 0.55);
+    --ring: 0 0 0 3px rgba(129, 140, 248, 0.4);
+  }
+}
+"""
+
+
+def base_css() -> str:
+    """Return the reset, base element styles, and shared component classes.
+
+    Built entirely on the tokens from `theme_tokens_css()`. UI text uses
+    var(--font) (sans); only code/endpoint/data uses var(--font-mono). Selector
+    specificity is kept low (single class / element selectors) so per-page
+    component CSS can still override without `!important`.
+    """
+    return """/* ================================================================
+   Oh My Gateway — base + shared components
+   Built on the design tokens. UI text = var(--font) [sans];
+   code / endpoints / data = var(--font-mono).
+   ================================================================ */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html {
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+
+body {
+  min-height: 100vh;
+  background: var(--bg-deep);
+  color: var(--text);
+  font-family: var(--font);
+  font-size: var(--fs-base);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  overflow-x: hidden;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+a:hover { color: var(--accent-hover); }
+
+h1, h2, h3, h4 {
+  color: var(--text-bright);
+  line-height: 1.25;
+  font-weight: 650;
+}
+
+hr { border: 0; border-top: 1px solid var(--border); margin: var(--gap-lg) 0; }
+
+/* --- Focus ring (visible, accent) --- */
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+/* --- Code / mono surfaces --- */
+code, kbd, samp, pre {
+  font-family: var(--font-mono);
+  font-size: 0.92em;
+}
+:not(pre) > code {
+  padding: 1px 5px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-dim);
+  color: var(--text-bright);
+}
+pre {
+  padding: var(--gap-md);
+  border-radius: var(--radius);
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  overflow-x: auto;
+  font-size: var(--fs-sm);
+  line-height: 1.55;
+}
+pre code { padding: 0; background: none; border: 0; }
+
+/* --- Card --- */
+.card {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--gap-lg);
+  box-shadow: var(--shadow-sm);
+}
+
+/* --- Buttons --- */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--gap-xs);
+  min-height: 34px;
+  padding: 6px 13px;
+  border: 1px solid var(--border-bright);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  color: var(--text-bright);
+  cursor: pointer;
+  font-family: var(--font);
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  line-height: 1.2;
+  white-space: nowrap;
+  text-decoration: none;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+.btn:hover { background: var(--bg-hover); border-color: var(--text-dim); }
+.btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.btn-primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-fg);
+}
+.btn-primary:hover {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+  color: var(--accent-fg);
+}
+
+.btn-ghost {
+  background: transparent;
+  border-color: var(--border);
+  color: var(--text);
+}
+.btn-ghost:hover {
+  background: var(--bg-hover);
+  border-color: var(--border-bright);
+  color: var(--text-bright);
+}
+
+.btn-sm { min-height: 30px; padding: 4px 10px; font-size: var(--fs-xs); }
+
+/* --- Badges (generic + HTTP method variants) --- */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 22px;
+  padding: 1px 8px;
+  border: 1px solid var(--border-bright);
+  border-radius: var(--radius-pill);
+  background: var(--bg-surface);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+.badge-get    { background: var(--cyan-subtle);  color: var(--cyan-dim);  border-color: var(--cyan-muted); }
+.badge-post   { background: var(--green-subtle); color: var(--green-dim); border-color: var(--green-muted); }
+.badge-put,
+.badge-patch  { background: var(--amber-subtle); color: var(--amber-dim); border-color: var(--amber-muted); }
+.badge-delete,
+.badge-del    { background: var(--red-subtle);   color: var(--red-dim);   border-color: var(--red-muted); }
+/* status flavors */
+.badge-ok   { background: var(--green-subtle); color: var(--green-dim); border-color: var(--green-muted); }
+.badge-warn { background: var(--amber-subtle); color: var(--amber-dim); border-color: var(--amber-muted); }
+.badge-err  { background: var(--red-subtle);   color: var(--red-dim);   border-color: var(--red-muted); }
+.badge-info { background: var(--cyan-subtle);  color: var(--cyan-dim);  border-color: var(--cyan-muted); }
+
+/* --- Tags / chips --- */
+.tag, .chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--gap-xs);
+  padding: 2px 9px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  background: var(--bg-surface);
+  color: var(--text-dim);
+  font-size: var(--fs-xs);
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+/* --- Inputs --- */
+input[type="text"],
+input[type="number"],
+input[type="password"],
+input[type="email"],
+input[type="search"],
+input[type="date"],
+select,
+textarea {
+  min-height: 34px;
+  width: auto;
+  background: var(--bg);
+  border: 1px solid var(--border-bright);
+  border-radius: var(--radius-sm);
+  color: var(--text-bright);
+  font-family: var(--font);
+  font-size: var(--fs-sm);
+  padding: 6px 10px;
+  outline: none;
+  caret-color: var(--accent);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+input[type="text"]:focus,
+input[type="number"]:focus,
+input[type="password"]:focus,
+input[type="email"]:focus,
+input[type="search"]:focus,
+input[type="date"]:focus,
+select:focus,
+textarea:focus {
+  border-color: var(--accent);
+  box-shadow: var(--ring);
+}
+input::placeholder, textarea::placeholder { color: var(--text-muted); }
+textarea { line-height: 1.5; resize: vertical; }
+select {
+  cursor: pointer;
+  -webkit-appearance: none;
+  appearance: none;
+  padding-right: 28px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%2371717a'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+}
+input[type="checkbox"], input[type="radio"] { accent-color: var(--accent); }
+
+/* --- Tables (tabular data = mono numerals) --- */
+.table-wrapper {
+  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--fs-sm);
+}
+table th {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-bright);
+  color: var(--text-dim);
+  font-size: var(--fs-xs);
+  font-weight: 700;
+  text-align: left;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+table td {
+  padding: 9px 12px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: middle;
+  font-variant-numeric: tabular-nums;
+}
+table tr:hover td { background: var(--bg-hover); }
+
+/* --- Toast --- */
+.toast {
+  max-width: min(420px, calc(100vw - 2rem));
+  padding: 10px 14px;
+  border: 1px solid var(--border);
+  border-left-width: 4px;
+  border-radius: var(--radius);
+  background: var(--bg);
+  box-shadow: var(--shadow-lg);
+  color: var(--text);
+  font-family: var(--font);
+  font-size: var(--fs-sm);
+  animation: omg-toast-in 0.2s ease;
+}
+.toast-ok  { border-left-color: var(--green); }
+.toast-err { border-left-color: var(--red); }
+@keyframes omg-toast-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* --- Theme toggle (3-way segmented control) --- */
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  background: var(--bg-surface);
+}
+.theme-toggle button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 24px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+.theme-toggle button:hover { color: var(--text); }
+.theme-toggle button svg { width: 15px; height: 15px; display: block; }
+.theme-toggle button[aria-pressed="true"] {
+  background: var(--bg);
+  color: var(--accent);
+  box-shadow: var(--shadow-sm);
+}
+.theme-toggle button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+/* --- Scrollbars (theme-aware) --- */
+* { scrollbar-width: thin; scrollbar-color: var(--border-bright) transparent; }
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--border-bright); border-radius: var(--radius-pill); }
+::-webkit-scrollbar-thumb:hover { background: var(--text-muted); }
+
+/* --- Reduced motion --- */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+"""
+
+
+def theme_toggle_html() -> str:
+    """Return markup for a compact 3-way segmented theme control.
+
+    Three buttons (Light / System / Dark) with inline sun/monitor/moon SVGs and
+    data-theme-set attributes. NO Alpine directives — works on any page. The
+    wrapping element carries a stable class (.theme-toggle) and id
+    (#omg-theme-toggle) the controller hooks onto. Include once per page.
+    """
+    sun = (
+        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" '
+        'stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'
+        '<circle cx="12" cy="12" r="4"/>'
+        '<path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41'
+        'M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>'
+    )
+    monitor = (
+        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" '
+        'stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'
+        '<rect x="2" y="3" width="20" height="14" rx="2"/>'
+        '<path d="M8 21h8M12 17v4"/></svg>'
+    )
+    moon = (
+        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" '
+        'stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'
+        '<path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>'
+    )
+    return (
+        '<div class="theme-toggle" id="omg-theme-toggle" role="group" aria-label="Color theme">'
+        '<button type="button" data-theme-set="light" aria-pressed="false" '
+        'aria-label="Light theme" title="Light">' + sun + "</button>"
+        '<button type="button" data-theme-set="system" aria-pressed="false" '
+        'aria-label="System theme" title="System">' + monitor + "</button>"
+        '<button type="button" data-theme-set="dark" aria-pressed="false" '
+        'aria-label="Dark theme" title="Dark">' + moon + "</button>"
+        "</div>"
+    )
+
+
+def theme_toggle_js() -> str:
+    """Return the vanilla-JS <script> controller for the theme toggle.
+
+    IIFE, idempotent (guarded so re-inclusion is a no-op). Reads/writes
+    localStorage["omg-theme"], sets <html data-theme>, marks the active segment
+    (aria-pressed + .is-active), and live-reflects OS changes via matchMedia
+    while in "system" mode. Runs on DOMContentLoaded and immediately if the DOM
+    is already parsed. Safe to include once per page on plain pages and admin.
+    """
+    return (
+        "<script>(function(){"
+        "if(window.__omgTheme)return;window.__omgTheme=true;"
+        "var KEY='" + _STORAGE_KEY + "';"
+        "var VALID={light:1,dark:1,system:1};"
+        "function read(){try{var v=localStorage.getItem(KEY);"
+        "return VALID[v]?v:'system';}catch(e){return 'system';}}"
+        "function apply(v){document.documentElement.setAttribute('data-theme',v);}"
+        "function mark(v){"
+        "var els=document.querySelectorAll('[data-theme-set]');"
+        "for(var i=0;i<els.length;i++){var on=els[i].getAttribute('data-theme-set')===v;"
+        "els[i].setAttribute('aria-pressed',on?'true':'false');"
+        "els[i].classList.toggle('is-active',on);}}"
+        "function set(v){if(!VALID[v])v='system';"
+        "try{localStorage.setItem(KEY,v);}"
+        "catch(e){if(window.console&&console.debug)console.debug('omg-theme: persist failed',e);}"
+        "apply(v);mark(v);}"
+        "function init(){var cur=read();apply(cur);mark(cur);"
+        "document.addEventListener('click',function(e){"
+        "var t=e.target.closest&&e.target.closest('[data-theme-set]');"
+        "if(t){set(t.getAttribute('data-theme-set'));}});"
+        "try{var mq=window.matchMedia('(prefers-color-scheme: dark)');"
+        "var onChange=function(){if(read()==='system')mark('system');};"
+        "if(mq.addEventListener)mq.addEventListener('change',onChange);"
+        "else if(mq.addListener)mq.addListener(onChange);}"
+        "catch(e){if(window.console&&console.debug)console.debug('omg-theme: matchMedia unavailable',e);}}"
+        "if(document.readyState==='loading'){"
+        "document.addEventListener('DOMContentLoaded',init);}else{init();}"
+        "})();</script>"
+    )


### PR DESCRIPTION
## What

Full visual overhaul of every server-rendered surface (landing `/`, chat, admin), replacing the terminal/phosphor aesthetic (green-on-black, all-monospace, CRT scanlines) with a readable **"modern developer console"** design, plus a **light / dark / system** theme switcher.

## How

- **New shared design system** — `src/theme.py` exports one token set + base components + a no-FOUC `<head>` init + a vanilla-JS 3-way theme toggle (Light / System / Dark), persisted to `localStorage` (`omg-theme`). The token set is a strict **superset** of every CSS variable the three surfaces referenced, so existing component CSS keeps resolving.
- **Theming** — `data-theme` on `<html>`; light on `:root`, dark under `html[data-theme="dark"]`, system via `prefers-color-scheme`. The toggle is vanilla JS so it works on the plain-HTML pages *and* alongside Alpine on admin.
- **Look** — neutral zinc/slate surfaces, restrained **indigo** accent, sans UI text with **mono reserved for code / endpoints / data**. HTTP method colors (GET/POST/PUT/DELETE) are the structural accent. Removed leftover phosphor glows from admin stat cards.
- **A11y** — visible `:focus-visible` rings, AA contrast in both themes, `prefers-reduced-motion` respected, no empty `catch` blocks.

## Integrity

All element IDs, Alpine bindings, event handlers, and form field names preserved.

## Verification

Driven in a headless browser: landing / admin / chat all render correctly in **light and dark**; the 3-way toggle is present and persists on every surface. `pytest` green for the affected suites (admin routes, chat, plugin service).

## Notes

Independent of #120 (compose `extra_hosts`) and #121 (plugin Install-button fix) — different files; all three merge cleanly to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)