### PR TITLE
feat(admin): runtime MCP server management (CRUD + hot-reload + diagnostics)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -385,6 +385,13 @@ DEFAULT_MODEL=sonnet
 # Format: {"mcpServers": {"name": {"type": "stdio|sse|http|streamable-http", ...}}}
 # MCP_CONFIG={"mcpServers": {"filesystem": {"type": "stdio", "command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "/workspace"]}}}
 # MCP_CONFIG=/path/to/mcp-config.json
+#
+# Admin-managed MCP server manifest (data/gateway-mcp.json on the ./data bind
+# mount). MCP_CONFIG stays the base/default; this manifest layers on top
+# (manifest wins on name collision). Admin panel CRUD writes here and changes
+# HOT-RELOAD into NEW sessions (Claude/Codex). OpenCode reads MCP only at
+# managed-server startup behind OPENCODE_USE_WRAPPER_MCP_CONFIG — restart needed.
+# GATEWAY_MCP_MANIFEST=/app/data/gateway-mcp.json
 
 # Metadata env var passthrough (comma-separated allowlist)
 # Only metadata keys listed here are forwarded as env vars to the Claude subprocess.

--- a/src/admin_html_dashboard.py
+++ b/src/admin_html_dashboard.py
@@ -121,10 +121,15 @@ def get_dashboard_html() -> str:
           <div class="card">
             <div class="flex-between mb-md">
               <h3 style="margin:0">MCP Servers</h3>
-              <button class="btn btn-sm btn-ghost" @click="loadMcpServers()" aria-label="Refresh MCP servers">Reload</button>
+              <button class="btn btn-sm btn-ghost" @click="loadMcpDetail()" aria-label="Refresh MCP servers">Reload</button>
             </div>
             <div x-show="loading.mcp" class="text-muted" style="text-align:center; padding:0.5rem">
               Loading MCP servers...
+            </div>
+            <div x-show="mcpDetail.dropped?.length" class="text-xs text-warning" style="margin-bottom:0.5rem">
+              <template x-for="d in (mcpDetail.dropped ?? [])" :key="d.name">
+                <div x-text="'! ' + d.name + ': ' + d.reason"></div>
+              </template>
             </div>
             <template x-for="s in mcpServers" :key="s.name">
               <div style="border:1px solid var(--border); padding:0.75rem; margin-bottom:0.5rem">

--- a/src/admin_html_mcp.py
+++ b/src/admin_html_mcp.py
@@ -1,0 +1,134 @@
+"""Admin MCP tab HTML (manage MCP servers at runtime; env base + manifest overlay)."""
+
+
+def get_mcp_html() -> str:
+    """Return the admin MCP servers management tab html."""
+    return """      <!-- MCP Tab -->
+      <div x-show="tab==='mcp'" role="tabpanel">
+        <div class="flex-between mb-sm">
+          <h3 style="margin:0">MCP Servers <span class="text-xs" style="color:var(--green)">HOT-RELOAD</span></h3>
+          <button class="btn btn-sm btn-ghost" @click="refreshMcp()" :disabled="loading.mcp" aria-label="Reload MCP servers">
+            <span x-text="loading.mcp ? 'Loading...' : 'Reload'"></span>
+          </button>
+        </div>
+        <p class="text-xs text-muted mb-md">
+          Overlay on top of the MCP_CONFIG environment base (manifest wins). Applies to new sessions.
+          Existing sessions keep the MCP set pinned at creation. OpenCode requires a restart.
+        </p>
+
+        <!-- Dropped servers banner (diagnostic 2) -->
+        <div x-show="mcpDetail.dropped.length" class="card mb-md" style="border-color:var(--amber)">
+          <div class="flex-gap-sm mb-sm">
+            <span class="badge badge-warn text-xs">DROPPED</span>
+            <span class="text-xs text-muted">Servers present in config but not loaded.</span>
+          </div>
+          <template x-for="d in mcpDetail.dropped" :key="d.name">
+            <div class="flex-gap-sm mb-sm" style="align-items:baseline">
+              <span class="badge badge-warn text-xs" x-text="d.name"></span>
+              <span class="text-xs text-muted" x-text="d.source"></span>
+              <span class="text-xs text-warning" x-text="d.reason"></span>
+            </div>
+          </template>
+        </div>
+
+        <!-- Servers table -->
+        <div class="card mb-lg">
+          <div class="table-wrapper">
+            <table>
+              <thead><tr><th>NAME</th><th>TYPE</th><th>SOURCE</th><th>TOOLS</th><th>REACH</th><th></th></tr></thead>
+              <tbody>
+                <template x-for="s in mcpDetail.servers" :key="s.name">
+                  <tr>
+                    <td style="color:var(--cyan); font-weight:600" x-text="s.name"></td>
+                    <td>
+                      <span class="badge text-xs" x-text="s.type"></span>
+                    </td>
+                    <td>
+                      <span class="badge text-xs" x-show="s.source === 'manifest'"
+                        style="border-color:var(--green); color:var(--green)">MANIFEST</span>
+                      <span class="badge text-xs" x-show="s.source !== 'manifest'"
+                        style="border-color:var(--cyan); color:var(--cyan); opacity:0.7">ENV</span>
+                      <div class="text-xs text-muted" x-text="s.editable ? 'editable' : 'read-only'"></div>
+                    </td>
+                    <td>
+                      <div class="flex-wrap-gap" style="gap:0.25rem">
+                        <template x-for="t in (s.tools ?? [])" :key="t">
+                          <span class="text-xs text-mono" style="padding:1px 6px; border:1px solid var(--border-bright); background:var(--bg-surface); color:var(--text-dim)" x-text="t"></span>
+                        </template>
+                        <span x-show="!(s.tools?.length)" class="text-xs text-muted">-</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="flex-wrap-gap" style="gap:0.25rem">
+                        <template x-for="r in (s.reach ?? [])" :key="r.backend">
+                          <span class="badge text-xs" :title="r.condition"
+                            :style="r.reaches ? 'border-color:var(--green); color:var(--green)' : 'border-color:var(--border-bright); color:var(--text-dim); opacity:0.5'"
+                            x-text="r.backend"></span>
+                        </template>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="flex-gap-sm">
+                        <button class="btn btn-sm btn-ghost" @click="testMcpServer(s.name)" :disabled="!!mcpTestBusy[s.name]"
+                          aria-label="Test MCP server">
+                          <span x-text="mcpTestBusy[s.name] ? 'Testing...' : 'Test'"></span>
+                        </button>
+                        <button x-show="s.editable" class="btn btn-sm btn-ghost" @click="editMcpServer(s)"
+                          aria-label="Edit MCP server">Edit</button>
+                        <button x-show="s.editable" class="btn btn-sm btn-ghost" style="color:var(--red)"
+                          @click="deleteMcpServer(s.name)" aria-label="Delete MCP server">Delete</button>
+                      </div>
+                      <div x-show="mcpTestResult[s.name]" class="text-xs" style="margin-top:4px"
+                        :style="mcpTestResult[s.name]?.ok ? 'color:var(--green)' : 'color:var(--red)'"
+                        x-text="mcpTestResult[s.name] ? ((mcpTestResult[s.name].ok ? '✓ ' : '✗ ') + mcpTestResult[s.name].message) : ''"></div>
+                    </td>
+                  </tr>
+                </template>
+                <tr x-show="mcpDetail.servers.length === 0">
+                  <td colspan="6" class="text-sm text-muted">No MCP servers</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <!-- Add / Edit form -->
+        <div class="card">
+          <div class="flex-between mb-md">
+            <h3 style="margin:0" x-text="mcpEditName ? ('Edit ' + mcpEditName) : 'Add MCP Server'"></h3>
+            <span x-show="mcpEditName" class="badge badge-ok text-xs">EDITING</span>
+          </div>
+          <div class="flex-gap-sm mb-sm">
+            <input type="text" x-model="mcpForm.name" @input="validateMcpJson()"
+              placeholder="server-name" aria-label="MCP server name"
+              :disabled="!!mcpEditName" style="flex:1">
+            <select x-model="mcpForm.type" @input="validateMcpJson()" aria-label="MCP server type" style="flex:1">
+              <option value="stdio">stdio</option>
+              <option value="sse">sse</option>
+              <option value="http">http</option>
+              <option value="streamable-http">streamable-http</option>
+            </select>
+          </div>
+          <label class="text-xs text-muted">CONFIG (JSON):</label>
+          <textarea x-model="mcpForm.jsonConfig" @input="validateMcpJson()"
+            style="width:100%; min-height:180px; max-height:50vh; font-family:var(--font-mono); font-size:0.78rem;
+              background:var(--bg-surface); color:var(--text-bright); border:1px solid var(--border-bright);
+              padding:8px; resize:vertical; border-radius:0; margin-top:4px"
+            placeholder='{"command": "npx", "args": ["-y", "server"], "env": {}}'></textarea>
+          <p x-show="mcpJsonError" class="text-sm text-danger" style="margin:0.5rem 0 0 0" x-text="'! ' + mcpJsonError"></p>
+          <p x-show="mcpJsonWarning && !mcpJsonError" class="text-sm" style="margin:0.5rem 0 0 0; color:var(--amber)" x-text="'? ' + mcpJsonWarning"></p>
+          <div x-show="mcpPatternPreview.length" class="flex-wrap-gap" style="gap:0.25rem; margin-top:0.5rem">
+            <span class="text-xs text-muted">tool patterns:</span>
+            <template x-for="p in mcpPatternPreview" :key="p">
+              <span class="text-xs text-mono" style="padding:1px 6px; border:1px solid var(--border-bright); background:var(--bg-surface); color:var(--text-dim)" x-text="p"></span>
+            </template>
+          </div>
+          <div class="flex-gap-sm" style="margin-top:0.75rem">
+            <button class="btn btn-sm btn-primary" @click="mcpEditName ? saveMcpServer() : createMcpServer()"
+              :disabled="!mcpForm.name.trim() || !!mcpJsonError || mcpBusy">
+              <span x-text="mcpBusy ? 'Working...' : (mcpEditName ? 'Save' : 'Add server')"></span>
+            </button>
+            <button x-show="mcpEditName" class="btn btn-sm btn-ghost" @click="cancelMcpEdit()">Cancel</button>
+          </div>
+        </div>
+      </div>"""

--- a/src/admin_js.py
+++ b/src/admin_js.py
@@ -784,14 +784,14 @@ def get_admin_js() -> str:
     validateMcpJson() {
       this.mcpJsonError = ''; this.mcpJsonWarning = ''; this.mcpPatternPreview = [];
       const nm = this.mcpForm.name.trim();
-      if (nm && !/^[A-Za-z0-9._@/-]+$/.test(nm)) this.mcpJsonError = 'invalid name: letters, digits, ._@/- only';
+      if (nm && !/^[A-Za-z0-9._@-]+$/.test(nm)) this.mcpJsonError = 'invalid name: letters, digits, ._@- only';
       const raw = this.mcpForm.jsonConfig.trim();
       if (raw) {
         let cfg;
         try { cfg = JSON.parse(raw); }
         catch(e) { this.mcpJsonError = 'invalid JSON: ' + e.message; return; }
         if (typeof cfg !== 'object' || Array.isArray(cfg)) { this.mcpJsonError = 'config must be a JSON object'; return; }
-        const t = cfg.type || 'stdio';
+        const t = cfg.type || this.mcpForm.type || 'stdio';
         if (t === 'stdio' && !cfg.command) this.mcpJsonWarning = "stdio requires 'command'";
         if (['sse','http','streamable-http'].includes(t) && !cfg.url) this.mcpJsonWarning = t + " requires 'url'";
       }
@@ -802,6 +802,7 @@ def get_admin_js() -> str:
       const name = this.mcpForm.name.trim();
       if (!name || this.mcpJsonError) return;
       let config; try { config = JSON.parse(this.mcpForm.jsonConfig || '{}'); } catch(e){ this.mcpJsonError='invalid JSON'; return; }
+      if (config && typeof config === 'object' && !Array.isArray(config) && !config.type) config.type = this.mcpForm.type;
       this.mcpBusy = true;
       try {
         const r = await this.api('/admin/api/mcp-servers', {
@@ -814,7 +815,11 @@ def get_admin_js() -> str:
     },
     editMcpServer(s) {
       this.mcpEditName = s.name;
-      this.mcpForm = { name: s.name, type: s.type, jsonConfig: JSON.stringify(s.config ?? {}, null, 2) };
+      // A type-less stored config surfaces as type "unknown" (admin_service
+      // default); the backend treats it as stdio. Bind a real select option so
+      // the on-save type injection can't produce an invalid "unknown" type.
+      const t = (s.type && s.type !== 'unknown') ? s.type : 'stdio';
+      this.mcpForm = { name: s.name, type: t, jsonConfig: JSON.stringify(s.config ?? {}, null, 2) };
       this.validateMcpJson();
     },
     cancelMcpEdit() { this.mcpEditName = null; this.resetMcpForm(); },
@@ -822,6 +827,7 @@ def get_admin_js() -> str:
     async saveMcpServer() {
       if (!this.mcpEditName || this.mcpJsonError) return;
       let config; try { config = JSON.parse(this.mcpForm.jsonConfig || '{}'); } catch(e){ this.mcpJsonError='invalid JSON'; return; }
+      if (config && typeof config === 'object' && !Array.isArray(config) && !config.type) config.type = this.mcpForm.type;
       this.mcpBusy = true;
       try {
         const r = await this.api('/admin/api/mcp-servers/' + encodeURIComponent(this.mcpEditName), {

--- a/src/admin_js.py
+++ b/src/admin_js.py
@@ -37,6 +37,15 @@ def get_admin_js() -> str:
     showAdvancedInstall: false,
     mpForm: { repo: '', branch: 'main', scope: 'user', git_token: '' },
     pluginForm: { name: '', marketplace: '', scope: 'user' },
+    mcpDetail: { servers: [], dropped: [] },
+    mcpForm: { name: '', type: 'stdio', jsonConfig: '' },
+    mcpBusy: false,
+    mcpEditName: null,
+    mcpJsonError: '',
+    mcpJsonWarning: '',
+    mcpPatternPreview: [],
+    mcpTestBusy: {},
+    mcpTestResult: {},
     toolsRegistry: {},
     sandboxConfig: {},
     systemPrompt: { mode: 'preset', prompt: null, resolved_prompt: null, preset_text: null, char_count: 0, active_name: null },
@@ -84,7 +93,7 @@ def get_admin_js() -> str:
       try {
         this.loading.dashboard = true;
         const r = await this.api('/admin/api/summary');
-        if (r.ok) { this.authenticated = true; this.summary = await r.json(); this.loadBackends(); this.loadMcpServers(); this.loadMetrics(); this.startPolling(); }
+        if (r.ok) { this.authenticated = true; this.summary = await r.json(); this.loadBackends(); this.loadMcpDetail(); this.loadMetrics(); this.startPolling(); }
       } catch(e) { console.error('Failed to load summary', e); this.loginError = 'Failed to load summary'; this.showToast('Failed to load summary', 'err'); } finally { this.loading.dashboard = false; }
     },
 
@@ -100,7 +109,7 @@ def get_admin_js() -> str:
           this.loginKey = '';
           await this.loadSummary();
           this.loadBackends();
-          this.loadMcpServers();
+          this.loadMcpDetail();
           this.loadMetrics();
           this.startPolling();
         } else {
@@ -145,11 +154,15 @@ def get_admin_js() -> str:
       } catch(e) { console.error('Failed to load backends', e); this.showToast('Failed to load backends', 'err'); }
       finally { this.loading.backends = false; }
     },
-    async loadMcpServers() {
+    async loadMcpDetail() {
       this.loading.mcp = true;
       try {
         const r = await this.api('/admin/api/mcp-servers');
-        if (r.ok) { const d = await r.json(); this.mcpServers = d.servers || []; }
+        if (r.ok) {
+          const d = await r.json();
+          this.mcpDetail = { servers: d.servers || [], dropped: d.dropped || [] };
+          this.mcpServers = d.servers || [];
+        }
       } catch(e) { console.error('Failed to load MCP servers', e); this.showToast('Failed to load MCP servers', 'err'); }
       finally { this.loading.mcp = false; }
     },
@@ -171,7 +184,7 @@ def get_admin_js() -> str:
     },
 
     async refreshAll() {
-      await Promise.all([this.loadSummary(), this.loadConfig(), this.loadBackends(), this.loadMcpServers(), this.loadMetrics()]);
+      await Promise.all([this.loadSummary(), this.loadConfig(), this.loadBackends(), this.loadMcpDetail(), this.loadMetrics()]);
       this.showToast('ALL SYSTEMS REFRESHED', 'ok');
     },
 
@@ -763,6 +776,79 @@ def get_admin_js() -> str:
         }
       } catch(e) { this.showToast('Connection error', 'err'); }
       finally { this.pluginBusy = false; }
+    },
+
+    // --- MCP server management (MCP tab) ---
+    async refreshMcp() { await Promise.all([this.loadMcpDetail(), this.loadTools()]); },
+
+    validateMcpJson() {
+      this.mcpJsonError = ''; this.mcpJsonWarning = ''; this.mcpPatternPreview = [];
+      const nm = this.mcpForm.name.trim();
+      if (nm && !/^[A-Za-z0-9._@/-]+$/.test(nm)) this.mcpJsonError = 'invalid name: letters, digits, ._@/- only';
+      const raw = this.mcpForm.jsonConfig.trim();
+      if (raw) {
+        let cfg;
+        try { cfg = JSON.parse(raw); }
+        catch(e) { this.mcpJsonError = 'invalid JSON: ' + e.message; return; }
+        if (typeof cfg !== 'object' || Array.isArray(cfg)) { this.mcpJsonError = 'config must be a JSON object'; return; }
+        const t = cfg.type || 'stdio';
+        if (t === 'stdio' && !cfg.command) this.mcpJsonWarning = "stdio requires 'command'";
+        if (['sse','http','streamable-http'].includes(t) && !cfg.url) this.mcpJsonWarning = t + " requires 'url'";
+      }
+      if (nm && !this.mcpJsonError) this.mcpPatternPreview = ['mcp__' + nm.replace(/-/g,'_') + '__*'];
+    },
+
+    async createMcpServer() {
+      const name = this.mcpForm.name.trim();
+      if (!name || this.mcpJsonError) return;
+      let config; try { config = JSON.parse(this.mcpForm.jsonConfig || '{}'); } catch(e){ this.mcpJsonError='invalid JSON'; return; }
+      this.mcpBusy = true;
+      try {
+        const r = await this.api('/admin/api/mcp-servers', {
+          method: 'POST', headers: {'Content-Type':'application/json'},
+          body: JSON.stringify({ name, config }) });
+        if (r.ok) { this.showToast('MCP SERVER ADDED: ' + name, 'ok'); this.resetMcpForm(); await this.refreshMcp(); }
+        else { const d = await r.json().catch(()=>({})); this.showToast(d.error || 'Add failed', 'err'); }
+      } catch(e) { this.showToast('Connection error', 'err'); }
+      finally { this.mcpBusy = false; }
+    },
+    editMcpServer(s) {
+      this.mcpEditName = s.name;
+      this.mcpForm = { name: s.name, type: s.type, jsonConfig: JSON.stringify(s.config ?? {}, null, 2) };
+      this.validateMcpJson();
+    },
+    cancelMcpEdit() { this.mcpEditName = null; this.resetMcpForm(); },
+    resetMcpForm() { this.mcpForm = { name:'', type:'stdio', jsonConfig:'' }; this.mcpJsonError=''; this.mcpJsonWarning=''; this.mcpPatternPreview=[]; },
+    async saveMcpServer() {
+      if (!this.mcpEditName || this.mcpJsonError) return;
+      let config; try { config = JSON.parse(this.mcpForm.jsonConfig || '{}'); } catch(e){ this.mcpJsonError='invalid JSON'; return; }
+      this.mcpBusy = true;
+      try {
+        const r = await this.api('/admin/api/mcp-servers/' + encodeURIComponent(this.mcpEditName), {
+          method: 'PUT', headers: {'Content-Type':'application/json'},
+          body: JSON.stringify({ name: this.mcpEditName, config }) });
+        if (r.ok) { this.showToast('MCP SERVER SAVED', 'ok'); this.mcpEditName=null; this.resetMcpForm(); await this.refreshMcp(); }
+        else { const d = await r.json().catch(()=>({})); this.showToast(d.error || 'Save failed', 'err'); }
+      } catch(e) { this.showToast('Connection error', 'err'); }
+      finally { this.mcpBusy = false; }
+    },
+    async deleteMcpServer(name) {
+      if (!confirm('Delete MCP server "' + name + '"?')) return;
+      try {
+        const r = await this.api('/admin/api/mcp-servers/' + encodeURIComponent(name), { method: 'DELETE' });
+        if (r.ok) { this.showToast('MCP SERVER DELETED', 'ok'); await this.refreshMcp(); }
+        else { const d = await r.json().catch(()=>({})); this.showToast(d.error || 'Delete failed', 'err'); }
+      } catch(e) { this.showToast('Connection error', 'err'); }
+    },
+    async testMcpServer(name) {
+      this.mcpTestBusy[name] = true;
+      try {
+        const r = await this.api('/admin/api/mcp-servers/' + encodeURIComponent(name) + '/test', { method: 'POST' });
+        const d = await r.json().catch(()=>({}));
+        if (r.ok && d.ok) { this.mcpTestResult[name] = {ok:true, message:(d.detail||'reachable')+' ('+(d.latency_ms||0)+'ms)'}; this.showToast('MCP OK: '+name, 'ok'); }
+        else { this.mcpTestResult[name] = {ok:false, message: d.detail || d.error || 'unreachable'}; this.showToast('MCP FAIL: '+name, 'err'); }
+      } catch(e) { this.mcpTestResult[name] = {ok:false, message:'connection error'}; this.showToast('Connection error', 'err'); }
+      finally { delete this.mcpTestBusy[name]; }
     },
 
     async toggleSessionHistory(sessionId) {

--- a/src/admin_page.py
+++ b/src/admin_page.py
@@ -11,6 +11,7 @@ from functools import lru_cache
 from src.admin_html_config import get_config_html
 from src.admin_html_dashboard import get_dashboard_html
 from src.admin_html_logs import get_logs_html
+from src.admin_html_mcp import get_mcp_html
 from src.admin_html_plugins import get_plugins_html
 from src.admin_html_ratelimits import get_ratelimits_html
 from src.admin_html_sessions import get_sessions_html
@@ -114,6 +115,7 @@ def build_admin_page() -> str:
         <button role="tab" :aria-selected="tab === 'ratelimits'" @click="tab='ratelimits'; loadRateLimits()">Limits</button>
         <button role="tab" :aria-selected="tab === 'skills'" @click="tab='skills'; loadSkills()">Skills</button>
         <button role="tab" :aria-selected="tab === 'plugins'" @click="tab='plugins'; loadPlugins(); loadCatalog()">Plugins</button>
+        <button role="tab" :aria-selected="tab === 'mcp'" @click="tab='mcp'; loadMcpDetail()">MCP</button>
         <button role="tab" :aria-selected="tab === 'config'" @click="tab='config'; loadConfig(); loadRuntimeConfig(); loadSystemPrompt(); loadTools(); loadSandbox()">Config</button>
         <a href="/admin/chat" role="tab" class="tab-link">Chat ↗</a>
       </nav>
@@ -130,6 +132,8 @@ def build_admin_page() -> str:
         + get_skills_html()
         + "\n\n"
         + get_plugins_html()
+        + "\n\n"
+        + get_mcp_html()
         + "\n\n"
         + get_sessions_html()
         + "\n\n"

--- a/src/admin_service.py
+++ b/src/admin_service.py
@@ -135,6 +135,12 @@ def get_redacted_config() -> Dict[str, Any]:
         "MCP_CONFIG",
         "CLAUDE_SANDBOX_ENABLED",
         "PERMISSION_MODE",
+        "BACKENDS",
+        "OPENCODE_USE_WRAPPER_MCP_CONFIG",
+        "OPENCODE_BASE_URL",
+        "CODEX_APPROVAL_POLICY",
+        "DISALLOWED_TOOLS",
+        "GATEWAY_MCP_MANIFEST",
     ]
 
     env_snapshot = {}
@@ -171,8 +177,8 @@ def get_redacted_config() -> Dict[str, Any]:
         "rate_limits": dict(RATE_LIMITS),
         "mcp_servers": mcp_servers_info,
         "environment": env_snapshot,
-        "_note": "Values marked ***REDACTED*** contain secrets. "
-        "Most settings require server restart to take effect.",
+        "_note": "Values marked ***REDACTED*** contain secrets. MCP servers "
+        "hot-reload for new sessions; most other settings require a server restart.",
     }
 
 
@@ -251,7 +257,9 @@ def get_sandbox_config() -> Dict[str, Any]:
         "sandbox_enabled": os.getenv("CLAUDE_SANDBOX_ENABLED", "true"),
         "sandbox_auto_allow_bash": os.getenv("CLAUDE_SANDBOX_AUTO_ALLOW_BASH", "false"),
         "metadata_env_allowlist": sorted(
-            k.strip() for k in os.getenv("METADATA_ENV_ALLOWLIST", "").split(",") if k.strip()
+            k.strip()
+            for k in os.getenv("METADATA_ENV_ALLOWLIST", "").split(",")
+            if k.strip()
         ),
     }
 
@@ -287,29 +295,166 @@ def get_tools_registry() -> Dict[str, Any]:
 
 
 def get_mcp_servers_detail() -> List[Dict[str, Any]]:
-    """Return detailed MCP server configuration (names, types, tool patterns)."""
+    """Return detailed MCP server configuration (names, types, tool patterns).
+
+    Also surfaces ``source`` (env vs. manifest), ``editable``, the redacted
+    ``config``, the tool ``pattern``, and per-backend ``reach`` (display only).
+    """
     try:
-        from src.mcp_config import get_mcp_servers, get_mcp_tool_patterns
+        from src.mcp_config import get_mcp_servers, get_mcp_tool_patterns, mcp_safe_name
+        from src import mcp_manifest
 
         servers = get_mcp_servers()
         if not servers:
             return []
 
+        try:
+            manifest_names = set(mcp_manifest.list_servers().keys())
+        except Exception:
+            manifest_names = set()
+
         patterns = get_mcp_tool_patterns(servers)
         result = []
         for name, config in servers.items():
-            server_patterns = [p for p in patterns if p.startswith(f"mcp__{name}__")]
+            safe_prefix = f"mcp__{mcp_safe_name(name)}__"
+            server_patterns = [p for p in patterns if p.startswith(safe_prefix)]
+            source = "manifest" if name in manifest_names else "env"
             result.append(
                 {
                     "name": name,
                     "type": config.get("type", "unknown"),
                     "tools": server_patterns,
                     "config_keys": [k for k in config.keys() if k not in ("type",)],
+                    "pattern": f"{safe_prefix}*",
+                    "source": source,
+                    "editable": source == "manifest",
+                    "config": _redact_mcp_config(config),
+                    "reach": compute_mcp_server_reach(name, config),
                 }
             )
         return result
     except Exception:
         logger.warning("Failed to read MCP servers detail", exc_info=True)
+        return []
+
+
+def _redact_mcp_config(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Redact a single MCP server config for display.
+
+    Masks secret-looking top-level keys, every ``headers`` value, and any
+    secret-looking ``env`` value (server configs carry tokens/credentials).
+    """
+    out: Dict[str, Any] = {}
+    for k, v in config.items():
+        if _SECRET_PATTERNS.search(k):
+            out[k] = "***REDACTED***"
+        elif k in ("env", "headers") and isinstance(v, dict):
+            out[k] = {
+                kk: (
+                    "***REDACTED***"
+                    if (_SECRET_PATTERNS.search(kk) or k == "headers")
+                    else vv
+                )
+                for kk, vv in v.items()
+            }
+        else:
+            out[k] = v
+    return out
+
+
+def compute_mcp_server_reach(name: str, config: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Per-backend reach for one MCP server. DISPLAY ONLY (no enforcement change).
+
+    Reflects how each enabled backend applies the server: Claude filters at
+    create-time, Codex denies at approval-time, and OpenCode bakes it into the
+    managed server at startup only (not hot-reloaded — restart required).
+    """
+    from src.backends import _enabled_backend_names
+    from src.backends.base import BackendRegistry
+    from src.backends.opencode.constants import use_wrapper_mcp_config
+    from src.mcp_config import ALLOWED_TYPES, mcp_safe_name
+
+    enabled = set(_enabled_backend_names())
+    safe = mcp_safe_name(name)
+    pattern = f"mcp__{safe}__*"
+    stype = config.get("type", "stdio")
+    out: List[Dict[str, Any]] = []
+
+    def _reg(n: str) -> bool:
+        return n in enabled and BackendRegistry.is_registered(n)
+
+    # Claude — create-time allowlist filter
+    out.append(
+        {
+            "backend": "claude",
+            "reaches": _reg("claude"),
+            "mode": "create-time",
+            "pattern": pattern,
+            "condition": "all servers when request sends no allowed_tools; "
+            f"else only if {pattern} is in allowed_tools",
+            "gated_by": ["BACKENDS", "request allowed_tools"],
+        }
+    )
+
+    # Codex — create-time forward + approval-time deny
+    approval = None
+    if _reg("codex"):
+        try:
+            approval = (
+                BackendRegistry.get("codex").runtime_metadata().get("approval_policy")
+            )
+        except Exception:
+            pass
+    out.append(
+        {
+            "backend": "codex",
+            "reaches": _reg("codex"),
+            "mode": "approval-time",
+            "pattern": pattern,
+            "condition": "forwarded at create-time; per-tool deny only when a tool "
+            "policy is active (approvalPolicy off 'never')",
+            "gated_by": ["BACKENDS", "CODEX_APPROVAL_POLICY", "DISALLOWED_TOOLS"],
+            "approval_policy": approval,
+        }
+    )
+
+    # OpenCode — startup-only, doubly gated, type-dependent
+    oc_mode, wrapper = None, use_wrapper_mcp_config()
+    if _reg("opencode"):
+        try:
+            oc_mode = BackendRegistry.get("opencode").runtime_metadata().get("mode")
+        except Exception:
+            oc_mode = None
+    oc_reaches = (
+        _reg("opencode") and oc_mode == "managed" and wrapper and stype in ALLOWED_TYPES
+    )
+    out.append(
+        {
+            "backend": "opencode",
+            "reaches": bool(oc_reaches),
+            "mode": "startup-only",
+            "pattern": None,
+            "condition": "baked into managed server at startup only when "
+            "OPENCODE_USE_WRAPPER_MCP_CONFIG=true; NOT hot-reloaded — restart required",
+            "gated_by": [
+                "BACKENDS",
+                "OPENCODE_USE_WRAPPER_MCP_CONFIG",
+                "OPENCODE_BASE_URL",
+            ],
+            "opencode_mode": oc_mode,
+        }
+    )
+    return out
+
+
+def get_dropped_mcp_servers() -> List[Dict[str, Any]]:
+    """Return MCP servers dropped from the effective config, with reasons."""
+    try:
+        from src.mcp_config import list_dropped_servers
+
+        return list_dropped_servers()
+    except Exception:
+        logger.warning("Failed to read dropped MCP servers", exc_info=True)
         return []
 
 
@@ -327,7 +472,9 @@ def get_session_detail(session_id: str) -> Optional[Dict[str, Any]]:
         "turn_counter": session.turn_counter,
         "ttl_minutes": session.ttl_minutes,
         "created_at": session.created_at.isoformat() if session.created_at else None,
-        "last_accessed": session.last_accessed.isoformat() if session.last_accessed else None,
+        "last_accessed": (
+            session.last_accessed.isoformat() if session.last_accessed else None
+        ),
         "expires_at": session.expires_at.isoformat() if session.expires_at else None,
         "message_count": len(session.messages),
         "has_system_prompt": session.base_system_prompt is not None,
@@ -360,4 +507,3 @@ def export_session_json(session_id: str) -> Optional[Dict[str, Any]]:
         "created_at": session.created_at.isoformat() if session.created_at else None,
         "messages": messages,
     }
-

--- a/src/config_check.py
+++ b/src/config_check.py
@@ -261,7 +261,9 @@ def _check_api_key() -> List[ConfigIssue]:
 def _check_sanitizer() -> List[ConfigIssue]:
     """SANITIZER_ENABLED without ANTHROPIC_BASE_URL is a documented no-op
     (src/sanitizer/config.py requires an explicit upstream)."""
-    if parse_bool_env("SANITIZER_ENABLED", "false") and not _is_set("ANTHROPIC_BASE_URL"):
+    if parse_bool_env("SANITIZER_ENABLED", "false") and not _is_set(
+        "ANTHROPIC_BASE_URL"
+    ):
         return [
             ConfigIssue(
                 "warning",
@@ -295,6 +297,27 @@ def _check_default_model(backends: List[str]) -> List[ConfigIssue]:
     ]
 
 
+def _check_mcp_manifest() -> List[ConfigIssue]:
+    """The admin-managed MCP manifest is persisted to GATEWAY_MCP_MANIFEST (see
+    src/mcp_manifest.py). If the override points at a directory that does not
+    exist, admin CRUD writes will fail. Only os.environ is read here to keep the
+    module's early-import invariant (no src.mcp_manifest import)."""
+    override = (os.getenv("GATEWAY_MCP_MANIFEST") or "").strip()
+    if (
+        override
+        and not os.path.isfile(override)
+        and not os.path.isdir(os.path.dirname(override) or ".")
+    ):
+        return [
+            ConfigIssue(
+                "warning",
+                f"GATEWAY_MCP_MANIFEST={override!r} directory does not exist; the "
+                "admin-managed MCP manifest cannot be persisted there.",
+            )
+        ]
+    return []
+
+
 def check_config() -> List[ConfigIssue]:
     """Inspect the environment and return all detected configuration issues."""
     backends = _enabled_backends()
@@ -307,6 +330,7 @@ def check_config() -> List[ConfigIssue]:
     issues.extend(_check_api_key())
     issues.extend(_check_sanitizer())
     issues.extend(_check_default_model(backends))
+    issues.extend(_check_mcp_manifest())
     return issues
 
 
@@ -317,7 +341,9 @@ def run_startup_config_check() -> List[ConfigIssue]:
     operators who accept the flagged configuration).
     """
     if parse_bool_env("SKIP_CONFIG_CHECK", "false"):
-        logger.warning("SKIP_CONFIG_CHECK=true — startup configuration validation skipped")
+        logger.warning(
+            "SKIP_CONFIG_CHECK=true — startup configuration validation skipped"
+        )
         return []
 
     issues = check_config()

--- a/src/constants.py
+++ b/src/constants.py
@@ -10,7 +10,7 @@ import fnmatch
 import os
 from dotenv import dotenv_values, load_dotenv
 
-from src.env_utils import parse_bool_env, parse_int_env
+from src.env_utils import parse_bool_env, parse_float_env, parse_int_env
 
 load_dotenv()
 
@@ -64,6 +64,13 @@ USER_WORKSPACES_DIR = os.getenv("USER_WORKSPACES_DIR", "")
 # Path to MCP config JSON file or inline JSON string
 # Format: {"mcpServers": {"name": {"type": "stdio", "command": "...", "args": [...]}}}
 MCP_CONFIG = os.getenv("MCP_CONFIG", "")
+
+# MCP connection-test (admin diagnostics). Short + bounded so a hung server
+# cannot wedge the request thread. Do NOT reuse DEFAULT_TIMEOUT_MS (whole-turn budget).
+MCP_TEST_TIMEOUT_SECONDS = parse_float_env("MCP_TEST_TIMEOUT_SECONDS", 5.0)
+# stdio "test" defaults to resolvable-on-PATH ONLY (no spawn). Spawning admin-
+# supplied commands is an RCE surface; gate any actual spawn behind this flag.
+MCP_TEST_ALLOW_SPAWN = parse_bool_env("MCP_TEST_ALLOW_SPAWN", "false")
 
 # SSE keepalive interval (seconds).  During long SDK operations (tool
 # execution, context compaction) no events flow to the client.  Emitting
@@ -154,6 +161,7 @@ ASK_USER_TIMEOUT_SECONDS = parse_int_env("ASK_USER_TIMEOUT_SECONDS", 300)
 DEBUG_MODE = parse_bool_env("DEBUG_MODE", "false")
 VERBOSE = parse_bool_env("VERBOSE", "false")
 
+
 # ---------------------------------------------------------------------------
 # Vision capability gating (text-only model denylist)
 # ---------------------------------------------------------------------------
@@ -173,7 +181,9 @@ def is_text_only_model(model: str | None) -> bool:
     """
     if not model:
         return False
-    patterns = [m.strip() for m in os.getenv("TEXT_ONLY_MODELS", "").split(",") if m.strip()]
+    patterns = [
+        m.strip() for m in os.getenv("TEXT_ONLY_MODELS", "").split(",") if m.strip()
+    ]
     if not patterns:
         return False
     name = model.lower()

--- a/src/env_utils.py
+++ b/src/env_utils.py
@@ -8,7 +8,6 @@ circular dependencies — any module can safely import from here.
 
 import os
 
-
 _BOOL_TRUE = {"true", "1", "yes", "on"}
 
 
@@ -34,5 +33,19 @@ def parse_int_env(name: str, default: int) -> int:
         return default
     try:
         return int(raw)
+    except ValueError:
+        return default
+
+
+def parse_float_env(name: str, default: float) -> float:
+    """Parse a float environment variable with a safe fallback.
+
+    If the variable is unset or not a valid float, *default* is returned.
+    """
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
     except ValueError:
         return default

--- a/src/mcp_admin_service.py
+++ b/src/mcp_admin_service.py
@@ -1,0 +1,148 @@
+"""Runtime MCP-server CRUD + validation + connection-test for the admin panel.
+
+Env servers (from MCP_CONFIG) are the immutable base and are NOT editable via
+this service; only manifest-layer servers are mutable. Every successful mutation
+persists to :mod:`src.mcp_manifest` and hot-reloads into NEW sessions. All
+functions synchronous except :func:`test_connection` (async); routes wrap the
+sync functions in ``fastapi.concurrency.run_in_threadpool``.
+
+Mirrors the typed-error + validate-before-write shape of
+:mod:`src.plugin_admin_service` (:class:`PluginAdminError`, ``_NAME_RE``,
+``_validate_name``). Far simpler than plugins: pure JSON, no git/subprocess for
+CRUD.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional
+
+from src import mcp_manifest
+from src.mcp_config import (
+    get_mcp_tool_patterns,
+    load_mcp_config,
+    mcp_safe_name,
+    validate_server,
+)
+
+
+class McpAdminError(ValueError):
+    """Invalid MCP admin input (bad name/type/collision/not-editable)."""
+
+
+# Server names: letters, digits and a small punctuation set. No whitespace, no
+# shell metacharacters. Copy of ``plugin_admin_service._NAME_RE``.
+_NAME_RE = re.compile(r"^[A-Za-z0-9._@/-]+$")
+
+
+def _validate_name(name: str) -> str:
+    name = (name or "").strip()
+    if not name:
+        raise McpAdminError("server name is required")
+    if not _NAME_RE.match(name) or name.startswith("-"):
+        raise McpAdminError(
+            f"invalid server name {name!r}: only letters, digits and ._@/- are allowed"
+        )
+    return name
+
+
+def _env_names() -> set:
+    """Names originating from the MCP_CONFIG base (immutable)."""
+    return set(load_mcp_config().keys())
+
+
+def _collision(name: str, existing: set) -> Optional[str]:
+    """A different name that normalizes to the same ``mcp__<safe>__`` namespace."""
+    safe = mcp_safe_name(name)
+    for other in existing:
+        if other != name and mcp_safe_name(other) == safe:
+            return other
+    return None
+
+
+def validate_config(name: str, config: Any) -> Dict[str, Any]:
+    """Pure preview for the /validate endpoint. NEVER raises, NEVER persists."""
+    errors: List[str] = []
+    n = (name or "").strip()
+    if n and (not _NAME_RE.match(n) or n.startswith("-")):
+        errors.append("invalid name: only letters, digits and ._@/- are allowed")
+    if not isinstance(config, dict):
+        errors.append("config must be a JSON object")
+    else:
+        ok, reason = validate_server(n or "x", config)
+        if not ok:
+            errors.append(reason)
+    safe = mcp_safe_name(n) if n else ""
+    return {
+        "valid": not errors,
+        "errors": errors,
+        "normalized_name": safe,
+        "tool_pattern": f"mcp__{safe}__*" if safe else "",
+        "server_type": (
+            config.get("type", "stdio") if isinstance(config, dict) else None
+        ),
+    }
+
+
+def create_server(name: str, config: Dict[str, Any]) -> Dict[str, Any]:
+    return _write(name, config, updating=False)
+
+
+def update_server(name: str, config: Dict[str, Any]) -> Dict[str, Any]:
+    return _write(name, config, updating=True)
+
+
+def _write(name: str, config: Any, *, updating: bool) -> Dict[str, Any]:
+    name = _validate_name(name)
+    if not isinstance(config, dict):
+        raise McpAdminError("config must be a JSON object")
+    ok, reason = validate_server(name, config)
+    if not ok:
+        raise McpAdminError(reason)
+    env_names = _env_names()
+    manifest_names = set(mcp_manifest.list_servers().keys())
+    if name in env_names and name not in manifest_names:
+        # env base is immutable (route maps this to 409).
+        raise McpAdminError(
+            f"'{name}' is defined by MCP_CONFIG (env) and is not editable"
+        )
+    if not updating and name in manifest_names:
+        raise McpAdminError(f"server '{name}' already exists")
+    if updating and name not in manifest_names:
+        raise McpAdminError(f"server '{name}' not found")
+    hit = _collision(name, env_names | manifest_names)
+    if hit:
+        raise McpAdminError(
+            f"name collides with '{hit}': both map to tool namespace "
+            f"'mcp__{mcp_safe_name(name)}__*'"
+        )
+    mcp_manifest.upsert_server(name, config)  # reloads
+    return {
+        "status": "saved" if updating else "created",
+        "server": name,
+        "patterns": get_mcp_tool_patterns({name: config}),
+    }
+
+
+def delete_server(name: str) -> Dict[str, Any]:
+    name = _validate_name(name)
+    if name in _env_names() and name not in set(mcp_manifest.list_servers().keys()):
+        raise McpAdminError(
+            f"'{name}' is defined by MCP_CONFIG (env) and cannot be deleted"
+        )
+    existed = mcp_manifest.delete_server(name)  # reloads
+    if not existed:
+        raise McpAdminError(f"server '{name}' not found")
+    return {"status": "deleted", "server": name}
+
+
+async def test_connection(name: str) -> Dict[str, Any]:
+    """Look up the server in the effective config and probe it. Never raises."""
+    from src import mcp_connection_test
+    from src.mcp_config import get_mcp_servers
+
+    servers = get_mcp_servers()
+    config = servers.get(name)
+    if config is None:
+        return {"ok": False, "detail": f"server '{name}' not found"}
+    return await mcp_connection_test.test_mcp_server(name, config)

--- a/src/mcp_admin_service.py
+++ b/src/mcp_admin_service.py
@@ -31,8 +31,15 @@ class McpAdminError(ValueError):
 
 
 # Server names: letters, digits and a small punctuation set. No whitespace, no
-# shell metacharacters. Copy of ``plugin_admin_service._NAME_RE``.
-_NAME_RE = re.compile(r"^[A-Za-z0-9._@/-]+$")
+# shell metacharacters. Unlike ``plugin_admin_service._NAME_RE`` this omits
+# ``/``: update/delete/test address a server as a single ``/{name}`` path
+# segment, so a name containing ``/`` (even percent-encoded) 404s in FastAPI.
+_NAME_RE = re.compile(r"^[A-Za-z0-9._@-]+$")
+
+# Sentinel the admin read layer substitutes for secret values (see
+# ``admin_service._redact_mcp_config``). On update it means "keep the stored
+# value" so the redacted edit view never overwrites a real secret with the mask.
+_REDACTED = "***REDACTED***"
 
 
 def _validate_name(name: str) -> str:
@@ -41,7 +48,7 @@ def _validate_name(name: str) -> str:
         raise McpAdminError("server name is required")
     if not _NAME_RE.match(name) or name.startswith("-"):
         raise McpAdminError(
-            f"invalid server name {name!r}: only letters, digits and ._@/- are allowed"
+            f"invalid server name {name!r}: only letters, digits and ._@- are allowed"
         )
     return name
 
@@ -60,12 +67,40 @@ def _collision(name: str, existing: set) -> Optional[str]:
     return None
 
 
+def _merge_redacted(new: Dict[str, Any], existing: Dict[str, Any]) -> Dict[str, Any]:
+    """Restore secrets masked by the admin read layer on update.
+
+    The list/detail API returns configs with secret values replaced by
+    ``_REDACTED`` (``admin_service._redact_mcp_config``), and the edit form
+    round-trips that masked view. So on update any ``_REDACTED`` value means
+    "keep the stored value" rather than persisting the mask over a real secret.
+    Mirrors the redaction shape: top-level keys plus nested ``env``/``headers``.
+    A newly typed value (anything but the sentinel) always wins; dropping a key
+    still drops it.
+    """
+    if not isinstance(existing, dict):
+        return new
+    merged: Dict[str, Any] = {}
+    for k, v in new.items():
+        ev = existing.get(k)
+        if v == _REDACTED and k in existing:
+            merged[k] = ev
+        elif k in ("env", "headers") and isinstance(v, dict) and isinstance(ev, dict):
+            merged[k] = {
+                kk: (ev[kk] if vv == _REDACTED and kk in ev else vv)
+                for kk, vv in v.items()
+            }
+        else:
+            merged[k] = v
+    return merged
+
+
 def validate_config(name: str, config: Any) -> Dict[str, Any]:
     """Pure preview for the /validate endpoint. NEVER raises, NEVER persists."""
     errors: List[str] = []
     n = (name or "").strip()
     if n and (not _NAME_RE.match(n) or n.startswith("-")):
-        errors.append("invalid name: only letters, digits and ._@/- are allowed")
+        errors.append("invalid name: only letters, digits and ._@- are allowed")
     if not isinstance(config, dict):
         errors.append("config must be a JSON object")
     else:
@@ -96,11 +131,9 @@ def _write(name: str, config: Any, *, updating: bool) -> Dict[str, Any]:
     name = _validate_name(name)
     if not isinstance(config, dict):
         raise McpAdminError("config must be a JSON object")
-    ok, reason = validate_server(name, config)
-    if not ok:
-        raise McpAdminError(reason)
     env_names = _env_names()
-    manifest_names = set(mcp_manifest.list_servers().keys())
+    manifest = mcp_manifest.list_servers()
+    manifest_names = set(manifest.keys())
     if name in env_names and name not in manifest_names:
         # env base is immutable (route maps this to 409).
         raise McpAdminError(
@@ -110,6 +143,12 @@ def _write(name: str, config: Any, *, updating: bool) -> Dict[str, Any]:
         raise McpAdminError(f"server '{name}' already exists")
     if updating and name not in manifest_names:
         raise McpAdminError(f"server '{name}' not found")
+    if updating:
+        # The edit form round-trips the redacted view; keep stored secrets.
+        config = _merge_redacted(config, manifest.get(name) or {})
+    ok, reason = validate_server(name, config)
+    if not ok:
+        raise McpAdminError(reason)
     hit = _collision(name, env_names | manifest_names)
     if hit:
         raise McpAdminError(

--- a/src/mcp_config.py
+++ b/src/mcp_config.py
@@ -7,7 +7,7 @@ import copy
 import json
 import logging
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Tuple
 
 from src.constants import MCP_CONFIG
 
@@ -17,15 +17,66 @@ McpServersDict = Dict[str, Dict[str, Any]]
 
 ALLOWED_TYPES = {"stdio", "sse", "http", "streamable-http"}
 
+# Required fields per server type (module-level: shared by the loader, the
+# manifest overlay, and the diagnostics).
+REQUIRED_FIELDS: Dict[str, tuple] = {
+    "stdio": ("command",),
+    "sse": ("url",),
+    "http": ("url",),
+    "streamable-http": ("url",),
+}
 
-def load_mcp_config() -> McpServersDict:
-    """Load MCP server config from MCP_CONFIG environment variable.
 
-    Accepts a JSON file path or inline JSON string.
-    Format: {"mcpServers": {"name": {...}}} or {"name": {...}}
+def mcp_safe_name(name: str) -> str:
+    """Dash->underscore: the Claude/Codex MCP tool-namespace convention (mcp__<name>__*)."""
+    return "_".join(name.split("-"))
+
+
+def validate_server(name: str, config: Any) -> Tuple[bool, Optional[str]]:
+    """One accept/drop rule set shared by loader, manifest overlay, and diagnostics."""
+    if not isinstance(config, dict):
+        return False, "not a dict"
+    server_type = config.get("type", "stdio")
+    if server_type not in ALLOWED_TYPES:
+        return False, f"unsupported type '{server_type}'"
+    missing = [f for f in REQUIRED_FIELDS.get(server_type, ()) if not config.get(f)]
+    if missing:
+        return False, f"missing required field(s) {missing} for type '{server_type}'"
+    return True, None
+
+
+def validate_mcp_servers(raw: McpServersDict) -> Tuple[McpServersDict, List[dict]]:
+    """Split raw servers into (validated, dropped=[{name,type,reason}]). Never raises.
+
+    Emits the same per-server ``logger.warning`` the old inline loop did, so
+    ``test_edge_cases_unit.py``'s warning-scrape assertion still holds.
+    """
+    validated: McpServersDict = {}
+    dropped: List[dict] = []
+    for name, config in raw.items():
+        ok, reason = validate_server(name, config)
+        if ok:
+            validated[name] = config
+        else:
+            dropped.append(
+                {
+                    "name": name,
+                    "type": config.get("type") if isinstance(config, dict) else None,
+                    "reason": reason,
+                }
+            )
+            logger.warning(f"Skipping invalid MCP server config '{name}': {reason}")
+    return validated, dropped
+
+
+def _read_mcp_config_source() -> Optional[dict]:
+    """Parse the ``MCP_CONFIG`` env source (file path or inline JSON).
+
+    Returns the raw parsed dict, or ``None`` when unset / unparseable / not a
+    JSON object. Single parser shared by ``load_mcp_config`` and the diagnostics.
     """
     if not MCP_CONFIG:
-        return {}
+        return None
 
     config_str = MCP_CONFIG.strip()
 
@@ -38,49 +89,39 @@ def load_mcp_config() -> McpServersDict:
             logger.info(f"Loaded MCP config from file: {config_path}")
         except (json.JSONDecodeError, OSError) as e:
             logger.error(f"Failed to load MCP config file {config_path}: {e}")
-            return {}
+            return None
     else:
         try:
             raw = json.loads(config_str)
         except json.JSONDecodeError as e:
             logger.error(f"Failed to parse MCP_CONFIG as JSON: {e}")
-            return {}
+            return None
 
     if not isinstance(raw, dict):
         logger.error("MCP_CONFIG must be a JSON object")
+        return None
+
+    return raw
+
+
+def load_mcp_config() -> McpServersDict:
+    """Load MCP server config from MCP_CONFIG environment variable.
+
+    Accepts a JSON file path or inline JSON string.
+    Format: {"mcpServers": {"name": {...}}} or {"name": {...}}
+    """
+    raw = _read_mcp_config_source()
+    if raw is None:
         return {}
 
     servers = raw.get("mcpServers", raw)
+    if not isinstance(servers, dict):
+        logger.error("MCP_CONFIG servers must be a JSON object")
+        return {}
 
-    # Required fields per server type
-    _REQUIRED_FIELDS = {
-        "stdio": ("command",),
-        "sse": ("url",),
-        "http": ("url",),
-        "streamable-http": ("url",),
-    }
-
-    validated: McpServersDict = {}
-    for name, config in servers.items():
-        if not isinstance(config, dict):
-            logger.warning(f"Skipping invalid MCP server config '{name}': not a dict")
-            continue
-        server_type = config.get("type", "stdio")
-        if server_type not in ALLOWED_TYPES:
-            logger.warning(f"Skipping MCP server '{name}': unsupported type '{server_type}'")
-            continue
-        required = _REQUIRED_FIELDS.get(server_type, ())
-        missing = [f for f in required if not config.get(f)]
-        if missing:
-            logger.warning(
-                f"Skipping MCP server '{name}': missing required field(s) {missing} for type '{server_type}'"
-            )
-            continue
-        validated[name] = config
-
+    validated, _ = validate_mcp_servers(servers)
     if validated:
         logger.info(f"Loaded {len(validated)} MCP server(s): {list(validated.keys())}")
-
     return validated
 
 
@@ -92,10 +133,48 @@ def get_mcp_tool_patterns(servers: McpServersDict) -> List[str]:
     the SDK manages tool schemas internally — the gateway never needs to
     serialize full MCP tool JSON schemas into the API request payload.
     """
-    return [f"mcp__{'_'.join(name.split('-'))}__*" for name in servers]
+    return [f"mcp__{mcp_safe_name(name)}__*" for name in servers]
 
 
-_server_mcp_config: McpServersDict = load_mcp_config()
+def _validated_manifest_servers() -> McpServersDict:
+    """Admin-managed overlay from the manifest, validated. Never raises."""
+    try:
+        from src import mcp_manifest  # lazy: mcp_manifest lazily imports us back
+
+        raw = mcp_manifest.list_servers()
+    except Exception:
+        logger.warning("Failed to read MCP manifest; ignoring overlay", exc_info=True)
+        return {}
+    validated, _ = validate_mcp_servers(raw)
+    return validated
+
+
+def _compute_effective_config() -> McpServersDict:
+    """env base (MCP_CONFIG) OVERLAID by manifest (manifest wins on name).
+
+    Returns a FRESH top-level dict every call so a reload never rebinds to a
+    dict object that a prior session's ``options.mcp_servers`` already
+    references (claude/client.py stores the passed dict by reference).
+    """
+    merged: McpServersDict = dict(load_mcp_config())  # env base, re-read each call
+    merged.update(_validated_manifest_servers())  # overlay wins on collision
+    return merged
+
+
+_server_mcp_config: McpServersDict = _compute_effective_config()
+
+
+def reload_mcp_config() -> McpServersDict:
+    """Recompute effective config and atomically REBIND the singleton.
+
+    Rebinding (not in-place mutation) is what lets already-created sessions keep
+    the MCP set they pinned at create_client time; only new ``get_mcp_servers()``
+    callers see the new dict.
+    """
+    global _server_mcp_config
+    new_config = _compute_effective_config()
+    _server_mcp_config = new_config
+    return new_config
 
 
 def get_mcp_servers() -> McpServersDict:
@@ -106,3 +185,43 @@ def get_mcp_servers() -> McpServersDict:
 def get_validated_mcp_config() -> McpServersDict:
     """Return a copy of the already validated gateway MCP config."""
     return copy.deepcopy(_server_mcp_config)
+
+
+def _dropped_env_servers() -> List[dict]:
+    """Re-parse ``MCP_CONFIG`` raw source and return validation rejects. Never raises."""
+    raw = _read_mcp_config_source()
+    if raw is None:
+        return []
+    servers = raw.get("mcpServers", raw)
+    if not isinstance(servers, dict):
+        return []
+    _, dropped = validate_mcp_servers(servers)
+    return dropped
+
+
+def list_dropped_servers() -> List[dict]:
+    """Servers the effective config dropped (invalid), with reasons. Never raises.
+
+    Re-parses env source + manifest overlay and re-runs validation, collecting
+    rejects. Manifest entries overshadow env entries of the same name, so an
+    env server later fixed by the manifest is not reported as dropped.
+    """
+    dropped: List[dict] = []
+    seen = set()
+    try:
+        from src import mcp_manifest
+
+        manifest_raw = mcp_manifest.list_servers()
+    except Exception:
+        manifest_raw = {}
+    _, man_drop = validate_mcp_servers(manifest_raw)
+    for d in man_drop:
+        d = {**d, "source": "manifest"}
+        dropped.append(d)
+        seen.add(d["name"])
+    # env drops, but skip names the manifest supplies (overlay wins)
+    for d in _dropped_env_servers():
+        if d["name"] in manifest_raw or d["name"] in seen:
+            continue
+        dropped.append({**d, "source": "env"})
+    return dropped

--- a/src/mcp_connection_test.py
+++ b/src/mcp_connection_test.py
@@ -1,0 +1,133 @@
+"""Safe, timeout-bounded, non-destructive per-server MCP reachability probe.
+
+SECURITY: stdio 'command' is admin input. By default a stdio "test" only
+resolves the executable on PATH (shutil.which + X_OK) -- it does NOT spawn it.
+Spawning arbitrary operator-supplied commands is an RCE surface with side
+effects; gate any spawn behind MCP_TEST_ALLOW_SPAWN. Remote types get a bounded
+httpx reachability probe: ANY HTTP response == reachable (MCP endpoints expect
+POST/JSON-RPC or SSE, so 4xx/405 is still "reachable"); only connect/timeout/DNS
+errors are failure. Never raises into the caller. Never echoes env/headers/secrets.
+"""
+
+import asyncio
+import os
+import shutil
+import time
+from typing import Any, Dict
+
+import httpx
+
+from src.constants import MCP_TEST_ALLOW_SPAWN, MCP_TEST_TIMEOUT_SECONDS
+
+
+async def test_mcp_server(
+    name: str,
+    config: Dict[str, Any],
+    *,
+    timeout: float = MCP_TEST_TIMEOUT_SECONDS,
+) -> Dict[str, Any]:
+    """Probe one MCP server for reachability. Never raises.
+
+    Returns ``{ok, detail, latency_ms, transport}``. Secrets in the config
+    (env, headers, tokens) are never echoed into ``detail``.
+    """
+    transport = config.get("type", "stdio")
+    start = time.monotonic()
+    try:
+        if transport == "stdio":
+            result = await asyncio.wait_for(_test_stdio(config), timeout=timeout)
+        else:
+            result = await asyncio.wait_for(
+                _test_remote(config, timeout), timeout=timeout
+            )
+    except asyncio.TimeoutError:
+        result = {"ok": False, "detail": f"timed out after {timeout}s"}
+    except Exception as e:
+        result = {"ok": False, "detail": f"{type(e).__name__}: {e}"}
+    result["latency_ms"] = round((time.monotonic() - start) * 1000, 1)
+    result["transport"] = transport
+    return result
+
+
+async def _test_stdio(config: Dict[str, Any]) -> Dict[str, Any]:
+    command = config.get("command")
+    args = config.get("args") if isinstance(config.get("args"), list) else []
+    if isinstance(command, list) and command:
+        exe = command[0]
+        args = list(command[1:]) + list(args)
+    else:
+        exe = command
+    if not exe or not isinstance(exe, str):
+        return {"ok": False, "detail": "no command"}
+    resolved = await asyncio.to_thread(shutil.which, exe)
+    if not resolved:
+        if os.path.isabs(exe) and os.path.isfile(exe) and os.access(exe, os.X_OK):
+            resolved = exe
+        else:
+            return {"ok": False, "detail": f"command not found on PATH: {exe}"}
+    if not MCP_TEST_ALLOW_SPAWN:
+        return {
+            "ok": True,
+            "detail": (
+                f"resolvable: {resolved} "
+                "(not spawned; set MCP_TEST_ALLOW_SPAWN to launch)"
+            ),
+        }
+    return await _spawn_stdio(resolved, [str(a) for a in args])
+
+
+async def _spawn_stdio(resolved: str, args: list) -> Dict[str, Any]:
+    """Opt-in spawn: minimal env, short-lived, success == stayed alive briefly.
+
+    NEVER uses shell=True: the resolved path and args are passed as an arg list
+    to ``create_subprocess_exec``. The child gets a minimal env (no inherited
+    secrets) and is hard-killed regardless of outcome.
+    """
+    minimal_env = {
+        k: os.environ[k]
+        for k in ("PATH", "HOME", "LANG", "LC_ALL", "SYSTEMROOT")
+        if k in os.environ
+    }
+    proc = await asyncio.create_subprocess_exec(
+        resolved,
+        *args,
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+        env=minimal_env,
+    )
+    try:
+        # If it exits within ~1s it failed to come up; if it is still running
+        # it started successfully. Either way we tear it down immediately.
+        try:
+            rc = await asyncio.wait_for(proc.wait(), timeout=1.0)
+        except asyncio.TimeoutError:
+            return {"ok": True, "detail": "spawned; still running (killed)"}
+        return {"ok": False, "detail": f"exited immediately with rc={rc}"}
+    finally:
+        if proc.returncode is None:
+            proc.terminate()
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=1.0)
+            except asyncio.TimeoutError:
+                proc.kill()
+                try:
+                    await proc.wait()
+                except Exception:
+                    pass
+
+
+async def _test_remote(config: Dict[str, Any], timeout: float) -> Dict[str, Any]:
+    url = config.get("url")
+    if not url:
+        return {"ok": False, "detail": "no url"}
+    headers = config.get("headers") if isinstance(config.get("headers"), dict) else {}
+    try:
+        async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+            resp = await client.get(url, headers=headers)
+        # Any response == reachable (MCP endpoints reject GET but still answer).
+        return {"ok": True, "detail": f"HTTP {resp.status_code}"}
+    except (httpx.ConnectError, httpx.ConnectTimeout) as e:
+        return {"ok": False, "detail": f"connect failed: {type(e).__name__}"}
+    except httpx.HTTPError as e:
+        return {"ok": False, "detail": f"{type(e).__name__}"}

--- a/src/mcp_manifest.py
+++ b/src/mcp_manifest.py
@@ -1,0 +1,127 @@
+"""Persistent admin-managed MCP server manifest.
+
+The manifest is the admin-managed overlay on top of the ``MCP_CONFIG`` env
+base. ``MCP_CONFIG`` stays the respected base; this file layers on top
+(manifest wins on name collision) and hot-reloads into NEW sessions via
+``mcp_config.reload_mcp_config()``.
+
+The file is JSON at ``GATEWAY_MCP_MANIFEST`` (or ``<project>/data/
+gateway-mcp.json``). ``load()`` never raises; ``save()`` is atomic (temp file
+in the same directory + ``os.replace``) so a partial write can never corrupt
+the manifest under a Docker bind mount.
+"""
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+from threading import RLock
+
+logger = logging.getLogger(__name__)
+
+# Reentrant so a mutator can hold the lock across its whole read-modify-write
+# while still calling save() (which re-acquires it). This serializes concurrent
+# admin mutations — run_in_threadpool can issue several at once — so two requests
+# can't both read the same manifest and clobber each other's entry.
+_lock = RLock()
+
+_DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+_DEFAULT_PATH = _DATA_DIR / "gateway-mcp.json"
+
+
+def manifest_path() -> Path:
+    """Resolve the manifest path (env override > project ``data/`` default)."""
+    override = os.getenv("GATEWAY_MCP_MANIFEST")
+    if override:
+        return Path(override)
+    return _DEFAULT_PATH
+
+
+def _defaults() -> dict:
+    return {"version": 1, "servers": {}}
+
+
+def load() -> dict:
+    """Return a well-formed manifest; corrupt/missing -> defaults, never raises."""
+    path = manifest_path()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return _defaults()
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning("Failed to load MCP manifest, using defaults: %s", e)
+        return _defaults()
+    if not isinstance(data, dict):
+        return _defaults()
+    servers = data.get("servers")
+    if not isinstance(servers, dict):
+        servers = {}
+    else:
+        servers = {k: v for k, v in servers.items() if isinstance(v, dict)}
+    version = data.get("version")
+    if not isinstance(version, int):
+        version = 1
+    return {"version": version, "servers": servers}
+
+
+def save(data: dict) -> None:
+    """Atomically persist the manifest (temp file in the same dir + replace)."""
+    path = manifest_path()
+    with _lock:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(
+            dir=str(path.parent), prefix=path.name + ".", suffix=".tmp"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(data, f, ensure_ascii=False, indent=2)
+            os.replace(tmp, path)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+
+
+def list_servers() -> dict:
+    """Return the name -> config map. Read-only; never raises."""
+    return load()["servers"]
+
+
+def get_server(name: str) -> dict:
+    """Return the config for ``name`` (empty dict if absent)."""
+    rec = load()["servers"].get(name)
+    return rec if isinstance(rec, dict) else {}
+
+
+def upsert_server(name: str, config: dict) -> None:
+    """Add or replace a server entry, then hot-reload the effective config."""
+    with _lock:
+        data = load()
+        data["servers"][name] = config
+        save(data)
+    _reload()
+
+
+def delete_server(name: str) -> bool:
+    """Remove a server entry (returns whether it existed), then hot-reload."""
+    with _lock:
+        data = load()
+        existed = name in data["servers"]
+        data["servers"].pop(name, None)
+        save(data)
+    _reload()
+    return existed
+
+
+def _reload() -> None:
+    """Hot-apply to new sessions. OUTSIDE the lock: reload re-load()s the file
+    (the source of truth), so a lost in-memory race self-heals. Never raises."""
+    try:
+        from src import mcp_config
+
+        mcp_config.reload_mcp_config()
+    except Exception:
+        logger.warning("MCP manifest saved but reload failed", exc_info=True)

--- a/src/routes/admin.py
+++ b/src/routes/admin.py
@@ -19,6 +19,12 @@ Session msgs:   GET  /admin/api/sessions/{session_id}/messages
 System prompt:  GET/PUT/DELETE /admin/api/system-prompt
 Named prompts:  GET/PUT/DELETE /admin/api/prompts/{name}
                 POST /admin/api/prompts/{name}/activate
+MCP servers:    GET  /admin/api/mcp-servers
+                POST /admin/api/mcp-servers
+                PUT  /admin/api/mcp-servers/{name}
+                DELETE /admin/api/mcp-servers/{name}
+MCP validate:   POST /admin/api/mcp-servers/validate
+MCP test:       POST /admin/api/mcp-servers/{name}/test
 Plugins:        GET  /admin/api/plugins
 Plugin detail:  GET  /admin/api/plugins/{id}
 Plugin skills:  GET  /admin/api/plugins/{id}/skills/{name}
@@ -50,6 +56,7 @@ from src.rate_limiter import rate_limit_endpoint
 from src.admin_service import (
     export_session_json,
     get_backends_health,
+    get_dropped_mcp_servers,
     get_mcp_servers_detail,
     get_redacted_config,
     get_sandbox_config,
@@ -98,6 +105,16 @@ class PluginInstallRequest(BaseModel):
     scope: str = "user"
     repo: str = ""
     branch: str = "main"
+
+
+class McpServerUpsert(BaseModel):
+    name: str
+    config: dict[str, Any]
+
+
+class McpServerValidate(BaseModel):
+    name: str = ""
+    config: dict[str, Any] = {}
 
 
 # ---------------------------------------------------------------------------
@@ -204,7 +221,9 @@ async def get_server_info(request: Request, _=Depends(require_admin)):
     from src.session_manager import session_manager
 
     started_at = getattr(request.app.state, "started_at", None)
-    uptime_seconds = round(time.time() - started_at, 1) if started_at is not None else None
+    uptime_seconds = (
+        round(time.time() - started_at, 1) if started_at is not None else None
+    )
 
     return {
         "version": __version__,
@@ -234,8 +253,97 @@ async def get_backends(_=Depends(require_admin)):
 
 @router.get("/api/mcp-servers")
 async def get_mcp_servers_endpoint(_=Depends(require_admin)):
-    """Return detailed MCP server configuration and tool patterns."""
-    return {"servers": get_mcp_servers_detail()}
+    """Return detailed MCP servers (effective) plus any dropped by overlay merge."""
+    return {
+        "servers": get_mcp_servers_detail(),
+        "dropped": get_dropped_mcp_servers(),
+    }
+
+
+# --- MCP server mutations + diagnostics (admin-managed) -------------------
+#
+# Route ordering: the literal /api/mcp-servers/validate MUST be declared
+# before the parametrised /api/mcp-servers/{name} routes. FastAPI resolves in
+# declaration order, so a single-segment {name} would otherwise capture
+# "validate". Mirrors the plugin-CRUD shape: lazy run_in_threadpool + service
+# import, McpAdminError -> JSONResponse, require_admin dependency last.
+
+
+@router.post("/api/mcp-servers")
+async def create_mcp_server_endpoint(body: McpServerUpsert, _=Depends(require_admin)):
+    """Create a new manifest-layer MCP server (env-base servers are immutable)."""
+    from fastapi.concurrency import run_in_threadpool
+
+    from src import mcp_admin_service
+
+    try:
+        return await run_in_threadpool(
+            mcp_admin_service.create_server, body.name, body.config
+        )
+    except mcp_admin_service.McpAdminError as e:
+        code = 409 if "already exists" in str(e) or "not editable" in str(e) else 400
+        return JSONResponse(status_code=code, content={"error": str(e)})
+
+
+@router.post("/api/mcp-servers/validate")
+async def validate_mcp_server_endpoint(
+    body: McpServerValidate, _=Depends(require_admin)
+):
+    """Pure preview (never persists): always 200 with a valid:false payload for
+    a bad config. Safe to call on every keystroke in the editor UI."""
+    from src import mcp_admin_service
+
+    return mcp_admin_service.validate_config(body.name, body.config)
+
+
+@router.put("/api/mcp-servers/{name}")
+async def update_mcp_server_endpoint(
+    name: str, body: McpServerUpsert, _=Depends(require_admin)
+):
+    """Update an existing manifest-layer MCP server in place."""
+    from fastapi.concurrency import run_in_threadpool
+
+    from src import mcp_admin_service
+
+    try:
+        return await run_in_threadpool(
+            mcp_admin_service.update_server, name, body.config
+        )
+    except mcp_admin_service.McpAdminError as e:
+        if "not found" in str(e):
+            code = 404
+        elif "not editable" in str(e):
+            code = 409
+        else:
+            code = 400
+        return JSONResponse(status_code=code, content={"error": str(e)})
+
+
+@router.delete("/api/mcp-servers/{name}")
+async def delete_mcp_server_endpoint(name: str, _=Depends(require_admin)):
+    """Delete a manifest-layer MCP server (env-base servers cannot be deleted)."""
+    from fastapi.concurrency import run_in_threadpool
+
+    from src import mcp_admin_service
+
+    try:
+        return await run_in_threadpool(mcp_admin_service.delete_server, name)
+    except mcp_admin_service.McpAdminError as e:
+        if "not found" in str(e):
+            code = 404
+        elif "cannot be deleted" in str(e):
+            code = 409
+        else:
+            code = 400
+        return JSONResponse(status_code=code, content={"error": str(e)})
+
+
+@router.post("/api/mcp-servers/{name}/test")
+async def test_mcp_server_endpoint(name: str, _=Depends(require_admin)):
+    """Probe an effective MCP server's connectivity. Self-bounded; never raises."""
+    from src import mcp_admin_service
+
+    return await mcp_admin_service.test_connection(name)
 
 
 # ---------------------------------------------------------------------------
@@ -565,7 +673,9 @@ async def set_system_prompt_endpoint(
     except ValueError as e:
         return JSONResponse(status_code=422, content={"error": str(e)})
     except OSError as e:
-        return JSONResponse(status_code=500, content={"error": f"Failed to persist: {e}"})
+        return JSONResponse(
+            status_code=500, content={"error": f"Failed to persist: {e}"}
+        )
     return {
         "status": "updated",
         "mode": get_prompt_mode(),
@@ -581,7 +691,9 @@ async def reset_system_prompt_endpoint(_=Depends(require_admin)):
     try:
         reset_system_prompt()
     except OSError as e:
-        return JSONResponse(status_code=500, content={"error": f"Failed to persist: {e}"})
+        return JSONResponse(
+            status_code=500, content={"error": f"Failed to persist: {e}"}
+        )
     return {"status": "reset", "mode": get_prompt_mode()}
 
 
@@ -611,7 +723,9 @@ def get_prompt_endpoint(name: str, _=Depends(require_admin)):
     except ValueError as e:
         return JSONResponse(status_code=422, content={"error": str(e)})
     if data is None:
-        return JSONResponse(status_code=404, content={"error": f"Prompt not found: {name}"})
+        return JSONResponse(
+            status_code=404, content={"error": f"Prompt not found: {name}"}
+        )
     return data
 
 
@@ -639,9 +753,13 @@ def delete_prompt_endpoint(name: str, _=Depends(require_admin)):
     except ValueError as e:
         return JSONResponse(status_code=422, content={"error": str(e)})
     except OSError as e:
-        return JSONResponse(status_code=500, content={"error": f"Failed to delete: {e}"})
+        return JSONResponse(
+            status_code=500, content={"error": f"Failed to delete: {e}"}
+        )
     if not deleted:
-        return JSONResponse(status_code=404, content={"error": f"Prompt not found: {name}"})
+        return JSONResponse(
+            status_code=404, content={"error": f"Prompt not found: {name}"}
+        )
     return {"status": "deleted", "name": name}
 
 
@@ -655,7 +773,9 @@ def activate_prompt_endpoint(name: str, _=Depends(require_admin)):
     except ValueError as e:
         return JSONResponse(status_code=404, content={"error": str(e)})
     except OSError as e:
-        return JSONResponse(status_code=500, content={"error": f"Failed to activate: {e}"})
+        return JSONResponse(
+            status_code=500, content={"error": f"Failed to activate: {e}"}
+        )
     return {"status": "activated", "name": name, "mode": get_prompt_mode()}
 
 
@@ -811,7 +931,9 @@ async def get_plugin_skill_endpoint(
 
     result = get_plugin_skill_content(plugin_id, skill_name, scope)
     if result is None:
-        return JSONResponse(status_code=404, content={"error": "Plugin or skill not found"})
+        return JSONResponse(
+            status_code=404, content={"error": "Plugin or skill not found"}
+        )
     return result
 
 

--- a/tests/test_admin_features.py
+++ b/tests/test_admin_features.py
@@ -6,13 +6,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from src.admin_service import (
+    compute_mcp_server_reach,
     export_session_json,
+    get_dropped_mcp_servers,
     get_mcp_servers_detail,
     get_sandbox_config,
     get_session_detail,
     get_tools_registry,
 )
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -170,7 +171,9 @@ class TestGetMcpServersDetail:
         assert result == []
 
     def test_with_servers(self):
-        servers = {"test-server": {"type": "stdio", "command": "node", "args": ["server.js"]}}
+        servers = {
+            "test-server": {"type": "stdio", "command": "node", "args": ["server.js"]}
+        }
         patterns = ["mcp__test-server__tool1"]
         with (
             patch("src.mcp_config.get_mcp_servers", return_value=servers),
@@ -180,6 +183,235 @@ class TestGetMcpServersDetail:
         assert len(result) == 1
         assert result[0]["name"] == "test-server"
         assert result[0]["type"] == "stdio"
+
+    def test_dash_name_tool_pattern_regression(self, clean_registry):
+        """Dashed server name must normalise dash->underscore in the tool pattern.
+
+        The tool namespace convention is ``mcp__<safe_name>__*`` with dashes
+        turned into underscores. ``get_mcp_tool_patterns`` already emits the
+        normalised form, so ``tools`` (which filters patterns by the normalised
+        prefix) and ``pattern`` must both use ``my_server`` — never ``my-server``.
+        """
+        servers = {"my-server": {"type": "stdio", "command": "node"}}
+        # get_mcp_tool_patterns is the real normaliser; call it for fidelity.
+        from src.mcp_config import get_mcp_tool_patterns
+
+        patterns = get_mcp_tool_patterns(servers)
+        assert patterns == ["mcp__my_server__*"]  # sanity: no dash leaks through
+
+        with (
+            patch("src.mcp_config.get_mcp_servers", return_value=servers),
+            patch("src.mcp_config.get_mcp_tool_patterns", return_value=patterns),
+        ):
+            result = get_mcp_servers_detail()
+
+        assert len(result) == 1
+        entry = result[0]
+        assert entry["name"] == "my-server"  # original name is preserved
+        assert entry["tools"] == ["mcp__my_server__*"]  # the regression assertion
+        assert "my-server" not in entry["tools"][0]
+        assert entry["pattern"] == "mcp__my_server__*"
+
+    def test_source_env_and_editable_false(self, clean_registry):
+        """A server absent from the manifest is env-sourced and not editable."""
+        servers = {"envonly": {"type": "stdio", "command": "node"}}
+        with (
+            patch("src.mcp_config.get_mcp_servers", return_value=servers),
+            patch("src.mcp_manifest.list_servers", return_value={}),
+        ):
+            result = get_mcp_servers_detail()
+        assert result[0]["source"] == "env"
+        assert result[0]["editable"] is False
+
+    def test_source_manifest_and_editable_true(self, clean_registry):
+        """A server present in the manifest is manifest-sourced and editable."""
+        cfg = {"type": "stdio", "command": "node"}
+        servers = {"managed": cfg}
+        with (
+            patch("src.mcp_config.get_mcp_servers", return_value=servers),
+            patch("src.mcp_manifest.list_servers", return_value={"managed": cfg}),
+        ):
+            result = get_mcp_servers_detail()
+        assert result[0]["source"] == "manifest"
+        assert result[0]["editable"] is True
+
+    def test_config_redacts_headers_and_env_tokens(self, clean_registry):
+        """Redacted config: every header value + secret-looking env values are masked."""
+        servers = {
+            "remote": {
+                "type": "http",
+                "url": "https://example.test/mcp",
+                "headers": {"Authorization": "Bearer sk-super-secret"},
+                "env": {"MY_TOKEN": "abc123", "REGION": "us-east"},
+            }
+        }
+        with (
+            patch("src.mcp_config.get_mcp_servers", return_value=servers),
+            patch("src.mcp_manifest.list_servers", return_value={}),
+        ):
+            result = get_mcp_servers_detail()
+
+        cfg = result[0]["config"]
+        # Every headers value is redacted regardless of key name.
+        assert cfg["headers"]["Authorization"] == "***REDACTED***"
+        # Secret-looking env keys are redacted; benign env values pass through.
+        assert cfg["env"]["MY_TOKEN"] == "***REDACTED***"
+        assert cfg["env"]["REGION"] == "us-east"
+        # Non-secret fields survive unchanged.
+        assert cfg["url"] == "https://example.test/mcp"
+
+    def test_reach_is_list_per_backend(self, clean_registry):
+        """``reach`` is a list carrying one entry per backend with a ``reaches`` flag."""
+        servers = {"srv": {"type": "stdio", "command": "node"}}
+        with (
+            patch("src.mcp_config.get_mcp_servers", return_value=servers),
+            patch("src.mcp_manifest.list_servers", return_value={}),
+        ):
+            result = get_mcp_servers_detail()
+        reach = result[0]["reach"]
+        assert isinstance(reach, list)
+        backends = {r["backend"] for r in reach}
+        assert backends == {"claude", "codex", "opencode"}
+        assert all("reaches" in r for r in reach)
+
+
+# ---------------------------------------------------------------------------
+# get_dropped_mcp_servers
+# ---------------------------------------------------------------------------
+
+
+class TestGetDroppedMcpServers:
+    def test_delegates_to_list_dropped_servers(self):
+        dropped = [{"name": "bad", "type": "stdio", "reason": "boom", "source": "env"}]
+        with patch("src.mcp_config.list_dropped_servers", return_value=dropped):
+            result = get_dropped_mcp_servers()
+        assert result == dropped
+
+    def test_empty_when_none_dropped(self):
+        with patch("src.mcp_config.list_dropped_servers", return_value=[]):
+            assert get_dropped_mcp_servers() == []
+
+    def test_swallows_errors(self):
+        with patch(
+            "src.mcp_config.list_dropped_servers", side_effect=RuntimeError("boom")
+        ):
+            assert get_dropped_mcp_servers() == []
+
+
+# ---------------------------------------------------------------------------
+# compute_mcp_server_reach (display-only, gated by BACKENDS + registration)
+# ---------------------------------------------------------------------------
+
+
+def _fake_backend(metadata=None):
+    """A registrable backend stub whose runtime_metadata returns *metadata*."""
+    backend = MagicMock()
+    backend.runtime_metadata.return_value = metadata or {}
+    return backend
+
+
+def _reach_for(reach, backend):
+    return next(r for r in reach if r["backend"] == backend)
+
+
+class TestComputeMcpServerReach:
+    def test_returns_entry_per_backend(self, clean_registry, monkeypatch):
+        monkeypatch.setenv("BACKENDS", "claude")
+        reach = compute_mcp_server_reach("srv", {"type": "stdio", "command": "node"})
+        assert {r["backend"] for r in reach} == {"claude", "codex", "opencode"}
+
+    def test_claude_follows_backends_and_registration(
+        self, clean_registry, monkeypatch
+    ):
+        from src.backends.base import BackendRegistry
+
+        # Enabled AND registered -> reaches. clean_registry registers only
+        # descriptors, so a client must be registered too.
+        monkeypatch.setenv("BACKENDS", "claude")
+        BackendRegistry.register("claude", _fake_backend())
+        reach = compute_mcp_server_reach("srv", {"type": "stdio", "command": "node"})
+        assert _reach_for(reach, "claude")["reaches"] is True
+
+    def test_claude_not_reached_when_not_in_backends(self, clean_registry, monkeypatch):
+        from src.backends.base import BackendRegistry
+
+        # Registered but disabled via BACKENDS -> does not reach.
+        monkeypatch.setenv("BACKENDS", "codex")
+        BackendRegistry.register("claude", _fake_backend())
+        reach = compute_mcp_server_reach("srv", {"type": "stdio", "command": "node"})
+        assert _reach_for(reach, "claude")["reaches"] is False
+
+    def test_claude_not_reached_when_unregistered(self, clean_registry, monkeypatch):
+        # Enabled in BACKENDS but no client registered -> does not reach.
+        monkeypatch.setenv("BACKENDS", "claude")
+        reach = compute_mcp_server_reach("srv", {"type": "stdio", "command": "node"})
+        assert _reach_for(reach, "claude")["reaches"] is False
+
+    def test_codex_follows_backends(self, clean_registry, monkeypatch):
+        from src.backends.base import BackendRegistry
+
+        monkeypatch.setenv("BACKENDS", "codex")
+        BackendRegistry.register(
+            "codex", _fake_backend({"approval_policy": "on-request"})
+        )
+        reach = compute_mcp_server_reach("srv", {"type": "stdio", "command": "node"})
+        codex = _reach_for(reach, "codex")
+        assert codex["reaches"] is True
+        assert codex["approval_policy"] == "on-request"
+
+    def test_opencode_false_without_wrapper(self, clean_registry, monkeypatch):
+        from src.backends.base import BackendRegistry
+
+        # Managed mode but wrapper disabled -> does not reach.
+        monkeypatch.setenv("BACKENDS", "opencode")
+        monkeypatch.setattr(
+            "src.backends.opencode.constants.use_wrapper_mcp_config",
+            lambda: False,
+        )
+        BackendRegistry.register("opencode", _fake_backend({"mode": "managed"}))
+        reach = compute_mcp_server_reach("srv", {"type": "stdio", "command": "node"})
+        assert _reach_for(reach, "opencode")["reaches"] is False
+
+    def test_opencode_false_when_external(self, clean_registry, monkeypatch):
+        from src.backends.base import BackendRegistry
+
+        # Wrapper on but external mode -> does not reach (managed-only).
+        monkeypatch.setenv("BACKENDS", "opencode")
+        monkeypatch.setattr(
+            "src.backends.opencode.constants.use_wrapper_mcp_config",
+            lambda: True,
+        )
+        BackendRegistry.register("opencode", _fake_backend({"mode": "external"}))
+        reach = compute_mcp_server_reach("srv", {"type": "stdio", "command": "node"})
+        assert _reach_for(reach, "opencode")["reaches"] is False
+
+    def test_opencode_true_when_managed_and_wrapper(self, clean_registry, monkeypatch):
+        from src.backends.base import BackendRegistry
+
+        # Managed + wrapper + allowed type -> reaches.
+        monkeypatch.setenv("BACKENDS", "opencode")
+        monkeypatch.setattr(
+            "src.backends.opencode.constants.use_wrapper_mcp_config",
+            lambda: True,
+        )
+        BackendRegistry.register("opencode", _fake_backend({"mode": "managed"}))
+        reach = compute_mcp_server_reach("srv", {"type": "stdio", "command": "node"})
+        oc = _reach_for(reach, "opencode")
+        assert oc["reaches"] is True
+        assert oc["opencode_mode"] == "managed"
+
+    def test_opencode_false_for_unsupported_type(self, clean_registry, monkeypatch):
+        from src.backends.base import BackendRegistry
+
+        # Managed + wrapper but a type outside ALLOWED_TYPES -> does not reach.
+        monkeypatch.setenv("BACKENDS", "opencode")
+        monkeypatch.setattr(
+            "src.backends.opencode.constants.use_wrapper_mcp_config",
+            lambda: True,
+        )
+        BackendRegistry.register("opencode", _fake_backend({"mode": "managed"}))
+        reach = compute_mcp_server_reach("srv", {"type": "bogus"})
+        assert _reach_for(reach, "opencode")["reaches"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_admin_service.py
+++ b/tests/test_mcp_admin_service.py
@@ -338,3 +338,113 @@ class TestConnection:
         )
         assert result["ok"] is False
         assert "timed out" in result["detail"]
+
+
+# ---------------------------------------------------------------------------
+# name validation: '/' is rejected — update/delete/test are single /{name}
+# path segments, so a name with '/' (even percent-encoded) would 404
+# ---------------------------------------------------------------------------
+
+
+class TestSlashInNameRejected:
+    def test_create_rejects_slash(self, manifest_file):
+        with env_servers({}):
+            with pytest.raises(McpAdminError, match="invalid server name"):
+                mcp_admin_service.create_server(
+                    "foo/bar", {"type": "stdio", "command": "echo"}
+                )
+
+    def test_update_rejects_slash(self, manifest_file):
+        with env_servers({}):
+            with pytest.raises(McpAdminError, match="invalid server name"):
+                mcp_admin_service.update_server(
+                    "foo/bar", {"type": "stdio", "command": "echo"}
+                )
+
+    def test_delete_rejects_slash(self, manifest_file):
+        with env_servers({}):
+            with pytest.raises(McpAdminError, match="invalid server name"):
+                mcp_admin_service.delete_server("foo/bar")
+
+    def test_validate_config_flags_slash(self):
+        result = mcp_admin_service.validate_config(
+            "foo/bar", {"type": "stdio", "command": "echo"}
+        )
+        assert result["valid"] is False
+        assert any("invalid name" in e for e in result["errors"])
+
+
+# ---------------------------------------------------------------------------
+# redacted-sentinel merge on update: a ***REDACTED*** value means "keep the
+# stored secret" so the redacted edit view never clobbers a real secret
+# ---------------------------------------------------------------------------
+
+
+class TestRedactedMergeOnUpdate:
+    def test_top_level_secret_preserved(self, manifest_file):
+        from src import mcp_manifest
+
+        with env_servers({}):
+            mcp_admin_service.create_server(
+                "svc", {"type": "stdio", "command": "echo", "token": "s3cret"}
+            )
+            # Edit form round-trips the redacted view (token masked); only the
+            # command changes.
+            mcp_admin_service.update_server(
+                "svc",
+                {"type": "stdio", "command": "ls", "token": "***REDACTED***"},
+            )
+        stored = mcp_manifest.get_server("svc")
+        assert stored["command"] == "ls"
+        assert stored["token"] == "s3cret"  # preserved, not clobbered
+
+    def test_nested_env_and_headers_secret_preserved(self, manifest_file):
+        from src import mcp_manifest
+
+        with env_servers({}):
+            mcp_admin_service.create_server(
+                "api",
+                {
+                    "type": "http",
+                    "url": "https://a.example/mcp",
+                    "headers": {"Authorization": "Bearer real"},
+                    "env": {"API_KEY": "k-real", "REGION": "us"},
+                },
+            )
+            mcp_admin_service.update_server(
+                "api",
+                {
+                    "type": "http",
+                    "url": "https://b.example/mcp",  # changed
+                    "headers": {"Authorization": "***REDACTED***"},
+                    "env": {"API_KEY": "***REDACTED***", "REGION": "eu"},
+                },
+            )
+        stored = mcp_manifest.get_server("api")
+        assert stored["url"] == "https://b.example/mcp"
+        assert stored["headers"]["Authorization"] == "Bearer real"
+        assert stored["env"]["API_KEY"] == "k-real"
+        assert stored["env"]["REGION"] == "eu"  # non-secret change applied
+
+    def test_new_value_overrides_sentinel_semantics(self, manifest_file):
+        from src import mcp_manifest
+
+        with env_servers({}):
+            mcp_admin_service.create_server(
+                "svc", {"type": "stdio", "command": "echo", "token": "old"}
+            )
+            mcp_admin_service.update_server(
+                "svc", {"type": "stdio", "command": "echo", "token": "new"}
+            )
+        assert mcp_manifest.get_server("svc")["token"] == "new"
+
+    def test_create_does_not_merge(self, manifest_file):
+        # No stored value on create: a literal sentinel is stored as-is.
+        from src import mcp_manifest
+
+        with env_servers({}):
+            mcp_admin_service.create_server(
+                "fresh",
+                {"type": "stdio", "command": "echo", "token": "***REDACTED***"},
+            )
+        assert mcp_manifest.get_server("fresh")["token"] == "***REDACTED***"

--- a/tests/test_mcp_admin_service.py
+++ b/tests/test_mcp_admin_service.py
@@ -1,0 +1,340 @@
+"""Unit tests for src/mcp_admin_service.py and src/mcp_connection_test.py.
+
+Env servers (from MCP_CONFIG) are the immutable base; only manifest-layer
+servers are mutable. Every successful mutation persists to the manifest and
+hot-reloads. These tests isolate the manifest under ``tmp_path`` via
+``GATEWAY_MCP_MANIFEST`` and drive the env base by patching
+``src.mcp_config.MCP_CONFIG`` for the duration of each service call (the
+reload triggered by a mutation re-reads that env source).
+"""
+
+import json
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from src import mcp_admin_service, mcp_connection_test
+from src.mcp_admin_service import McpAdminError
+
+
+@pytest.fixture
+def manifest_file(tmp_path, monkeypatch):
+    """Point the MCP manifest at an isolated tmp file and reload after."""
+    path = tmp_path / "m.json"
+    monkeypatch.setenv("GATEWAY_MCP_MANIFEST", str(path))
+    yield path
+    # Rebind the effective config back to the (empty) env base so a leftover
+    # tmp manifest can't leak into other tests via the module singleton.
+    import src.mcp_config as mcp_config
+
+    mcp_config.reload_mcp_config()
+
+
+@contextmanager
+def env_servers(servers):
+    """Make ``servers`` the MCP_CONFIG env base for the wrapped call(s)."""
+    with patch("src.mcp_config.MCP_CONFIG", json.dumps({"mcpServers": servers})):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# validate_config: pure preview, NEVER raises
+# ---------------------------------------------------------------------------
+
+
+class TestValidateConfig:
+    def test_valid_stdio_gives_pattern_with_dash_to_underscore(self):
+        result = mcp_admin_service.validate_config(
+            "my-server", {"type": "stdio", "command": "echo"}
+        )
+        assert result["valid"] is True
+        assert result["errors"] == []
+        assert result["normalized_name"] == "my_server"
+        assert result["tool_pattern"] == "mcp__my_server__*"
+        assert result["server_type"] == "stdio"
+
+    def test_valid_remote_gives_pattern(self):
+        result = mcp_admin_service.validate_config(
+            "docs", {"type": "streamable-http", "url": "http://localhost:3000/mcp"}
+        )
+        assert result["valid"] is True
+        assert result["tool_pattern"] == "mcp__docs__*"
+        assert result["server_type"] == "streamable-http"
+
+    def test_default_type_is_stdio(self):
+        result = mcp_admin_service.validate_config("plain", {"command": "ls"})
+        assert result["valid"] is True
+        assert result["server_type"] == "stdio"
+
+    def test_invalid_config_not_a_dict(self):
+        result = mcp_admin_service.validate_config("x", ["not", "a", "dict"])
+        assert result["valid"] is False
+        assert any("JSON object" in e for e in result["errors"])
+        assert result["server_type"] is None
+
+    def test_invalid_missing_required_field(self):
+        result = mcp_admin_service.validate_config("bad", {"type": "stdio"})
+        assert result["valid"] is False
+        assert result["errors"]
+
+    def test_invalid_unsupported_type(self):
+        result = mcp_admin_service.validate_config(
+            "weird", {"type": "grpc", "command": "foo"}
+        )
+        assert result["valid"] is False
+        assert any("unsupported type" in e for e in result["errors"])
+
+    def test_invalid_name_reported(self):
+        result = mcp_admin_service.validate_config(
+            "bad name!", {"type": "stdio", "command": "echo"}
+        )
+        assert result["valid"] is False
+        assert any("invalid name" in e for e in result["errors"])
+
+    def test_never_raises_on_none_inputs(self):
+        # No name, no config -> reports invalid but must not raise.
+        result = mcp_admin_service.validate_config(None, None)
+        assert result["valid"] is False
+        assert result["normalized_name"] == ""
+        assert result["tool_pattern"] == ""
+
+
+# ---------------------------------------------------------------------------
+# create_server
+# ---------------------------------------------------------------------------
+
+
+class TestCreateServer:
+    def test_happy_path_returns_created_and_patterns(self, manifest_file):
+        with env_servers({}):
+            result = mcp_admin_service.create_server(
+                "my-router", {"type": "stdio", "command": "echo"}
+            )
+        assert result["status"] == "created"
+        assert result["server"] == "my-router"
+        assert result["patterns"] == ["mcp__my_router__*"]
+        # Persisted to the manifest.
+        from src import mcp_manifest
+
+        assert "my-router" in mcp_manifest.list_servers()
+
+    def test_duplicate_raises_already_exists(self, manifest_file):
+        with env_servers({}):
+            mcp_admin_service.create_server("dup", {"type": "stdio", "command": "echo"})
+            with pytest.raises(McpAdminError, match="already exists"):
+                mcp_admin_service.create_server(
+                    "dup", {"type": "stdio", "command": "ls"}
+                )
+
+    def test_env_name_is_not_editable(self, manifest_file):
+        with env_servers({"envsrv": {"type": "stdio", "command": "echo"}}):
+            with pytest.raises(McpAdminError, match="not editable"):
+                mcp_admin_service.create_server(
+                    "envsrv", {"type": "stdio", "command": "ls"}
+                )
+
+    def test_collision_dash_vs_underscore(self, manifest_file):
+        # Env base has "foo_bar"; a new "foo-bar" maps to the same
+        # mcp__foo_bar__* namespace and must be rejected.
+        with env_servers({"foo_bar": {"type": "stdio", "command": "echo"}}):
+            with pytest.raises(McpAdminError, match="collides"):
+                mcp_admin_service.create_server(
+                    "foo-bar", {"type": "stdio", "command": "ls"}
+                )
+
+    def test_bad_name_raises(self, manifest_file):
+        with env_servers({}):
+            with pytest.raises(McpAdminError, match="invalid server name"):
+                mcp_admin_service.create_server(
+                    "has space", {"type": "stdio", "command": "echo"}
+                )
+
+    def test_bad_type_raises(self, manifest_file):
+        with env_servers({}):
+            with pytest.raises(McpAdminError):
+                mcp_admin_service.create_server(
+                    "weird", {"type": "carrier-pigeon", "command": "fly"}
+                )
+
+    def test_config_not_a_dict_raises(self, manifest_file):
+        with env_servers({}):
+            with pytest.raises(McpAdminError, match="JSON object"):
+                mcp_admin_service.create_server("x", ["nope"])
+
+
+# ---------------------------------------------------------------------------
+# update_server
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateServer:
+    def test_unknown_raises_not_found(self, manifest_file):
+        with env_servers({}):
+            with pytest.raises(McpAdminError, match="not found"):
+                mcp_admin_service.update_server(
+                    "ghost", {"type": "stdio", "command": "echo"}
+                )
+
+    def test_env_name_not_editable(self, manifest_file):
+        with env_servers({"envsrv": {"type": "stdio", "command": "echo"}}):
+            with pytest.raises(McpAdminError, match="not editable"):
+                mcp_admin_service.update_server(
+                    "envsrv", {"type": "stdio", "command": "ls"}
+                )
+
+    def test_update_existing_manifest_server(self, manifest_file):
+        with env_servers({}):
+            mcp_admin_service.create_server("svc", {"type": "stdio", "command": "echo"})
+            result = mcp_admin_service.update_server(
+                "svc", {"type": "stdio", "command": "ls"}
+            )
+        assert result["status"] == "saved"
+        from src import mcp_manifest
+
+        assert mcp_manifest.get_server("svc")["command"] == "ls"
+
+
+# ---------------------------------------------------------------------------
+# delete_server
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteServer:
+    def test_unknown_raises_not_found(self, manifest_file):
+        with env_servers({}):
+            with pytest.raises(McpAdminError, match="not found"):
+                mcp_admin_service.delete_server("ghost")
+
+    def test_env_only_cannot_be_deleted(self, manifest_file):
+        with env_servers({"envsrv": {"type": "stdio", "command": "echo"}}):
+            with pytest.raises(McpAdminError, match="cannot be deleted"):
+                mcp_admin_service.delete_server("envsrv")
+
+    def test_manifest_server_is_deleted(self, manifest_file):
+        with env_servers({}):
+            mcp_admin_service.create_server("svc", {"type": "stdio", "command": "echo"})
+            result = mcp_admin_service.delete_server("svc")
+        assert result["status"] == "deleted"
+        assert result["server"] == "svc"
+        from src import mcp_manifest
+
+        assert "svc" not in mcp_manifest.list_servers()
+
+
+# ---------------------------------------------------------------------------
+# test_connection (async): never raises; stdio non-spawn default; remote probe
+# ---------------------------------------------------------------------------
+
+
+class TestConnection:
+    async def test_unknown_server_returns_not_found(self, manifest_file):
+        with env_servers({}):
+            import src.mcp_config as mcp_config
+
+            mcp_config.reload_mcp_config()  # ensure singleton has no such server
+            result = await mcp_admin_service.test_connection("nope")
+        assert result["ok"] is False
+        assert "not found" in result["detail"]
+
+    async def test_stdio_resolvable_not_spawned(self, manifest_file, monkeypatch):
+        # shutil.which resolves -> reachable; default MCP_TEST_ALLOW_SPAWN is
+        # False so it must NOT spawn.
+        monkeypatch.setattr(
+            mcp_connection_test.shutil, "which", lambda exe: "/usr/bin/echo"
+        )
+        assert mcp_connection_test.MCP_TEST_ALLOW_SPAWN is False
+        with env_servers({}):
+            mcp_admin_service.create_server("cli", {"type": "stdio", "command": "echo"})
+            result = await mcp_admin_service.test_connection("cli")
+        assert result["ok"] is True
+        assert "not spawned" in result["detail"]
+        assert result["transport"] == "stdio"
+
+    async def test_stdio_command_not_on_path(self, manifest_file, monkeypatch):
+        monkeypatch.setattr(mcp_connection_test.shutil, "which", lambda exe: None)
+        with env_servers({}):
+            mcp_admin_service.create_server(
+                "cli", {"type": "stdio", "command": "definitely-not-a-real-binary"}
+            )
+            result = await mcp_admin_service.test_connection("cli")
+        assert result["ok"] is False
+        assert "not found on PATH" in result["detail"]
+
+    async def test_remote_any_status_is_reachable(self, manifest_file, monkeypatch):
+        class FakeResponse:
+            status_code = 405
+
+        class FakeClient:
+            def __init__(self, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_):
+                return False
+
+            async def get(self, url, headers=None):
+                return FakeResponse()
+
+        monkeypatch.setattr(httpx, "AsyncClient", FakeClient)
+        with env_servers({}):
+            mcp_admin_service.create_server(
+                "docs", {"type": "http", "url": "http://localhost:3000/mcp"}
+            )
+            result = await mcp_admin_service.test_connection("docs")
+        assert result["ok"] is True
+        assert "405" in result["detail"]
+        assert result["transport"] == "http"
+
+    async def test_remote_connect_error_is_unreachable(
+        self, manifest_file, monkeypatch
+    ):
+        class BoomClient:
+            def __init__(self, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_):
+                return False
+
+            async def get(self, url, headers=None):
+                raise httpx.ConnectError("refused")
+
+        monkeypatch.setattr(httpx, "AsyncClient", BoomClient)
+        with env_servers({}):
+            mcp_admin_service.create_server(
+                "docs", {"type": "http", "url": "http://localhost:3000/mcp"}
+            )
+            result = await mcp_admin_service.test_connection("docs")
+        assert result["ok"] is False
+        assert "connect failed" in result["detail"]
+
+    async def test_remote_timeout_path(self, monkeypatch):
+        # Drive the probe's timeout branch directly with a tiny timeout and a
+        # slow fake client (test_connection hardcodes the 5s default).
+        import asyncio
+
+        class SlowClient:
+            def __init__(self, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_):
+                return False
+
+            async def get(self, url, headers=None):
+                await asyncio.sleep(5)
+
+        monkeypatch.setattr(httpx, "AsyncClient", SlowClient)
+        result = await mcp_connection_test.test_mcp_server(
+            "docs", {"type": "http", "url": "http://x"}, timeout=0.05
+        )
+        assert result["ok"] is False
+        assert "timed out" in result["detail"]

--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -97,14 +97,20 @@ class TestLoadMcpConfig:
 
     def test_sse_with_url_is_accepted(self):
         """sse server with 'url' field is accepted."""
-        config = {"mcpServers": {"good-sse": {"type": "sse", "url": "http://localhost:3000"}}}
+        config = {
+            "mcpServers": {"good-sse": {"type": "sse", "url": "http://localhost:3000"}}
+        }
         with patch("src.mcp_config.MCP_CONFIG", json.dumps(config)):
             result = load_mcp_config()
             assert "good-sse" in result
 
     def test_http_with_url_is_accepted(self):
         """http server with 'url' field is accepted."""
-        config = {"mcpServers": {"good-http": {"type": "http", "url": "http://localhost:3000"}}}
+        config = {
+            "mcpServers": {
+                "good-http": {"type": "http", "url": "http://localhost:3000"}
+            }
+        }
         with patch("src.mcp_config.MCP_CONFIG", json.dumps(config)):
             result = load_mcp_config()
             assert "good-http" in result
@@ -136,7 +142,10 @@ class TestStreamableHttpSupport:
         """streamable-http server with 'url' field is accepted."""
         config = {
             "mcpServers": {
-                "sh-server": {"type": "streamable-http", "url": "http://localhost:3000/mcp"}
+                "sh-server": {
+                    "type": "streamable-http",
+                    "url": "http://localhost:3000/mcp",
+                }
             }
         }
         with patch("src.mcp_config.MCP_CONFIG", json.dumps(config)):
@@ -209,6 +218,253 @@ class TestValidatedMcpConfig:
         assert mcp_config.get_validated_mcp_config()["demo"]["command"] == "uvx"
 
 
+class TestValidateServer:
+    """Exact accept/drop reason strings for the shared validator."""
+
+    def test_non_dict_config_reason(self):
+        import src.mcp_config as mcp_config
+
+        ok, reason = mcp_config.validate_server("x", "not a dict")
+        assert ok is False
+        assert reason == "not a dict"
+
+    def test_unsupported_type_reason(self):
+        import src.mcp_config as mcp_config
+
+        ok, reason = mcp_config.validate_server("x", {"type": "grpc", "command": "y"})
+        assert ok is False
+        assert reason == "unsupported type 'grpc'"
+
+    def test_missing_field_reason_names_field_and_type(self):
+        import src.mcp_config as mcp_config
+
+        ok, reason = mcp_config.validate_server("x", {"type": "stdio"})
+        assert ok is False
+        assert "command" in reason
+        assert "stdio" in reason
+
+    def test_type_defaults_to_stdio(self):
+        """No explicit type is validated as stdio (needs command)."""
+        import src.mcp_config as mcp_config
+
+        ok, _ = mcp_config.validate_server("x", {"command": "echo"})
+        assert ok is True
+        ok, reason = mcp_config.validate_server("x", {})
+        assert ok is False
+        assert "stdio" in reason
+
+    def test_empty_command_rejected(self):
+        import src.mcp_config as mcp_config
+
+        ok, reason = mcp_config.validate_server("x", {"type": "stdio", "command": ""})
+        assert ok is False
+        assert "command" in reason
+
+    def test_valid_server_returns_none_reason(self):
+        import src.mcp_config as mcp_config
+
+        ok, reason = mcp_config.validate_server("x", {"type": "stdio", "command": "ls"})
+        assert ok is True
+        assert reason is None
+
+
+class TestValidateMcpServers:
+    """(validated, dropped) split; dropped carry name/type/reason; warns on drop."""
+
+    def test_split_and_dropped_shape(self):
+        import src.mcp_config as mcp_config
+
+        validated, dropped = mcp_config.validate_mcp_servers(
+            {
+                "good": {"type": "stdio", "command": "ls"},
+                "bad": {"type": "grpc", "command": "x"},
+            }
+        )
+        assert list(validated) == ["good"]
+        assert len(dropped) == 1
+        assert dropped[0]["name"] == "bad"
+        assert dropped[0]["type"] == "grpc"
+        assert "grpc" in dropped[0]["reason"]
+
+    def test_dropped_type_is_none_for_non_dict(self):
+        import src.mcp_config as mcp_config
+
+        _, dropped = mcp_config.validate_mcp_servers({"bad": "a string"})
+        assert dropped[0]["name"] == "bad"
+        assert dropped[0]["type"] is None
+
+    def test_warns_on_each_drop(self):
+        import src.mcp_config as mcp_config
+
+        with patch("src.mcp_config.logger") as mock_logger:
+            mcp_config.validate_mcp_servers({"bad": {"type": "grpc"}})
+        warning_calls = [str(c) for c in mock_logger.warning.call_args_list]
+        assert any("bad" in w for w in warning_calls)
+
+    def test_load_mcp_config_warns_on_drop(self):
+        """Guards the test_edge_cases_unit.py:256-257 warning-scrape contract:
+        load_mcp_config must still route drops through logger.warning."""
+        import src.mcp_config as mcp_config
+
+        config = {"mcpServers": {"bad": {"type": "grpc", "command": "x"}}}
+        with patch("src.mcp_config.MCP_CONFIG", json.dumps(config)):
+            with patch("src.mcp_config.logger") as mock_logger:
+                result = mcp_config.load_mcp_config()
+        assert "bad" not in result
+        warning_calls = [str(c) for c in mock_logger.warning.call_args_list]
+        assert any("bad" in w for w in warning_calls)
+
+
+class TestReloadMcpConfig:
+    """Overlay-merge (env base + manifest overlay) + rebind-not-mutate hot reload."""
+
+    def test_reload_overlays_env_base_with_manifest(self, tmp_path, monkeypatch):
+        import src.mcp_config as mcp_config
+
+        # pin the singleton for restoration (reload rebinds the module global)
+        monkeypatch.setattr(mcp_config, "_server_mcp_config", {})
+
+        env_config = {"mcpServers": {"env-srv": {"type": "stdio", "command": "envcmd"}}}
+        manifest = {
+            "version": 1,
+            "servers": {"man-srv": {"type": "stdio", "command": "mancmd"}},
+        }
+        manifest_file = tmp_path / "m.json"
+        manifest_file.write_text(json.dumps(manifest))
+        monkeypatch.setenv("GATEWAY_MCP_MANIFEST", str(manifest_file))
+
+        with patch("src.mcp_config.MCP_CONFIG", json.dumps(env_config)):
+            mcp_config.reload_mcp_config()
+            servers = mcp_config.get_mcp_servers()
+
+        # core Proposal-A guarantee: env base still present after overlay
+        assert "env-srv" in servers
+        assert servers["env-srv"]["command"] == "envcmd"
+        # manifest server layered on top
+        assert "man-srv" in servers
+        assert servers["man-srv"]["command"] == "mancmd"
+
+    def test_manifest_wins_on_name_collision(self, tmp_path, monkeypatch):
+        import src.mcp_config as mcp_config
+
+        monkeypatch.setattr(mcp_config, "_server_mcp_config", {})
+
+        env_config = {"mcpServers": {"dup": {"type": "stdio", "command": "from-env"}}}
+        manifest = {
+            "version": 1,
+            "servers": {"dup": {"type": "stdio", "command": "from-manifest"}},
+        }
+        manifest_file = tmp_path / "m.json"
+        manifest_file.write_text(json.dumps(manifest))
+        monkeypatch.setenv("GATEWAY_MCP_MANIFEST", str(manifest_file))
+
+        with patch("src.mcp_config.MCP_CONFIG", json.dumps(env_config)):
+            mcp_config.reload_mcp_config()
+            servers = mcp_config.get_mcp_servers()
+
+        assert servers["dup"]["command"] == "from-manifest"
+
+    def test_reload_rebinds_not_mutates(self, tmp_path, monkeypatch):
+        """An upsert must REBIND the singleton, leaving the dict a prior session
+        pinned unchanged (proves existing-session MCP-set pinning)."""
+        import src.mcp_config as mcp_config
+
+        monkeypatch.setattr(mcp_config, "_server_mcp_config", {})
+
+        manifest_file = tmp_path / "m.json"
+        manifest_file.write_text(json.dumps({"version": 1, "servers": {}}))
+        monkeypatch.setenv("GATEWAY_MCP_MANIFEST", str(manifest_file))
+
+        with patch("src.mcp_config.MCP_CONFIG", ""):
+            mcp_config.reload_mcp_config()
+            d1 = mcp_config.get_mcp_servers()
+            assert d1 == {}
+
+            # upsert a server via the manifest, then reload
+            manifest_file.write_text(
+                json.dumps(
+                    {
+                        "version": 1,
+                        "servers": {"new": {"type": "stdio", "command": "x"}},
+                    }
+                )
+            )
+            mcp_config.reload_mcp_config()
+            d2 = mcp_config.get_mcp_servers()
+
+        assert d2 is not d1  # rebound to a fresh dict
+        assert d1 == {}  # the old dict a pinned session holds is untouched
+        assert "new" in d2
+
+    def test_compute_effective_config_returns_fresh_dict(self, monkeypatch):
+        import src.mcp_config as mcp_config
+
+        monkeypatch.setenv("GATEWAY_MCP_MANIFEST", "/nonexistent/manifest.json")
+        with patch("src.mcp_config.MCP_CONFIG", ""):
+            a = mcp_config._compute_effective_config()
+            b = mcp_config._compute_effective_config()
+        assert a is not b
+
+
+class TestListDroppedServers:
+    """Diagnostics: env-dropped vs manifest-dropped, with shadowing."""
+
+    def test_env_dropped_surfaces_with_source_env(self, monkeypatch):
+        import src.mcp_config as mcp_config
+
+        monkeypatch.setenv("GATEWAY_MCP_MANIFEST", "/nonexistent/manifest.json")
+        env_config = {"mcpServers": {"bad-env": {"type": "grpc", "command": "x"}}}
+        with patch("src.mcp_config.MCP_CONFIG", json.dumps(env_config)):
+            dropped = mcp_config.list_dropped_servers()
+
+        by_name = {d["name"]: d for d in dropped}
+        assert by_name["bad-env"]["source"] == "env"
+        assert "grpc" in by_name["bad-env"]["reason"]
+
+    def test_manifest_dropped_surfaces_with_source_manifest(
+        self, tmp_path, monkeypatch
+    ):
+        import src.mcp_config as mcp_config
+
+        manifest = {
+            "version": 1,
+            "servers": {"bad-man": {"type": "carrier-pigeon", "command": "fly"}},
+        }
+        manifest_file = tmp_path / "m.json"
+        manifest_file.write_text(json.dumps(manifest))
+        monkeypatch.setenv("GATEWAY_MCP_MANIFEST", str(manifest_file))
+
+        with patch("src.mcp_config.MCP_CONFIG", ""):
+            dropped = mcp_config.list_dropped_servers()
+
+        by_name = {d["name"]: d for d in dropped}
+        assert by_name["bad-man"]["source"] == "manifest"
+
+    def test_env_drop_shadowed_by_valid_manifest_not_reported(
+        self, tmp_path, monkeypatch
+    ):
+        """An env server that is invalid but supplied validly by the manifest
+        (overlay wins) must NOT be reported as dropped."""
+        import src.mcp_config as mcp_config
+
+        env_config = {"mcpServers": {"shadowed": {"type": "grpc", "command": "x"}}}
+        # manifest supplies the SAME name (even if itself invalid here it is a
+        # manifest entry, so the env drop must be suppressed)
+        manifest = {
+            "version": 1,
+            "servers": {"shadowed": {"type": "stdio", "command": "ok"}},
+        }
+        manifest_file = tmp_path / "m.json"
+        manifest_file.write_text(json.dumps(manifest))
+        monkeypatch.setenv("GATEWAY_MCP_MANIFEST", str(manifest_file))
+
+        with patch("src.mcp_config.MCP_CONFIG", json.dumps(env_config)):
+            dropped = mcp_config.list_dropped_servers()
+
+        # valid manifest entry -> not dropped at all, and the env drop is shadowed
+        assert all(d["name"] != "shadowed" for d in dropped)
+
+
 class TestOpenCodeConfigGeneration:
     """Test conversion from wrapper MCP config into OpenCode config."""
 
@@ -221,7 +477,11 @@ class TestOpenCodeConfigGeneration:
                 "filesystem": {
                     "type": "stdio",
                     "command": "npx",
-                    "args": ["-y", "@modelcontextprotocol/server-filesystem", "/workspace"],
+                    "args": [
+                        "-y",
+                        "@modelcontextprotocol/server-filesystem",
+                        "/workspace",
+                    ],
                     "env": {"ROOT": "/workspace"},
                 },
                 "docs": {
@@ -239,7 +499,12 @@ class TestOpenCodeConfigGeneration:
         assert config["model"] == "openai/gpt-5.5"
         assert config["mcp"]["filesystem"] == {
             "type": "local",
-            "command": ["npx", "-y", "@modelcontextprotocol/server-filesystem", "/workspace"],
+            "command": [
+                "npx",
+                "-y",
+                "@modelcontextprotocol/server-filesystem",
+                "/workspace",
+            ],
             "environment": {"ROOT": "/workspace"},
         }
         assert config["mcp"]["docs"] == {
@@ -257,7 +522,9 @@ class TestOpenCodeConfigGeneration:
                 "permission": {"question": "deny"},
                 "mcp": {"filesystem": {"enabled": False}},
             },
-            mcp_servers={"filesystem": {"type": "stdio", "command": "npx", "args": ["demo"]}},
+            mcp_servers={
+                "filesystem": {"type": "stdio", "command": "npx", "args": ["demo"]}
+            },
             default_model="openai/gpt-5.5",
             question_permission="ask",
         )

--- a/tests/test_mcp_manifest.py
+++ b/tests/test_mcp_manifest.py
@@ -1,0 +1,127 @@
+"""Tests for the persistent admin-managed MCP server manifest."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from src import mcp_manifest
+
+
+@pytest.fixture
+def manifest_file(tmp_path, monkeypatch):
+    path = tmp_path / "gateway-mcp.json"
+    monkeypatch.setenv("GATEWAY_MCP_MANIFEST", str(path))
+    return path
+
+
+def test_manifest_path_env_override(manifest_file):
+    assert mcp_manifest.manifest_path() == manifest_file
+
+
+class TestLoad:
+    """load() never raises; degrades to defaults on any bad input."""
+
+    def test_missing_returns_defaults(self, manifest_file):
+        assert mcp_manifest.load() == {"version": 1, "servers": {}}
+
+    def test_corrupt_json_returns_defaults(self, manifest_file):
+        manifest_file.write_text("{not valid json", encoding="utf-8")
+        assert mcp_manifest.load() == {"version": 1, "servers": {}}
+
+    def test_non_dict_top_level_returns_defaults(self, manifest_file):
+        manifest_file.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+        assert mcp_manifest.load() == {"version": 1, "servers": {}}
+
+    def test_non_dict_servers_coerced_to_empty(self, manifest_file):
+        manifest_file.write_text(
+            json.dumps({"version": 1, "servers": "nope"}), encoding="utf-8"
+        )
+        assert mcp_manifest.load() == {"version": 1, "servers": {}}
+
+    def test_non_dict_server_entries_filtered(self, manifest_file):
+        manifest_file.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "servers": {
+                        "good": {"type": "stdio", "command": "ls"},
+                        "junk": "a string",
+                        "also-junk": [1, 2],
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        data = mcp_manifest.load()
+        assert list(data["servers"]) == ["good"]
+
+    def test_bad_version_coerced_to_one(self, manifest_file):
+        manifest_file.write_text(
+            json.dumps({"version": "x", "servers": {}}), encoding="utf-8"
+        )
+        assert mcp_manifest.load()["version"] == 1
+
+
+class TestSave:
+    """save() is atomic: round-trips and leaves no temp file behind."""
+
+    def test_save_load_roundtrip(self, manifest_file):
+        data = {
+            "version": 1,
+            "servers": {"docs": {"type": "stdio", "command": "uvx"}},
+        }
+        mcp_manifest.save(data)
+        assert json.loads(manifest_file.read_text(encoding="utf-8")) == data
+        assert mcp_manifest.load() == data
+
+    def test_save_leaves_no_tmp_file(self, manifest_file):
+        mcp_manifest.save({"version": 1, "servers": {}})
+        leftovers = list(manifest_file.parent.glob("*.tmp"))
+        assert leftovers == []
+
+    def test_save_creates_parent_dirs(self, tmp_path, monkeypatch):
+        nested = tmp_path / "deep" / "nested" / "gateway-mcp.json"
+        monkeypatch.setenv("GATEWAY_MCP_MANIFEST", str(nested))
+        mcp_manifest.save(mcp_manifest.load())
+        assert nested.is_file()
+
+
+class TestUpsertDelete:
+    """upsert/delete round-trip and hot-reload wiring."""
+
+    def test_upsert_then_get_and_list(self, manifest_file):
+        cfg = {"type": "stdio", "command": "echo"}
+        with patch("src.mcp_config.reload_mcp_config"):
+            mcp_manifest.upsert_server("srv", cfg)
+        assert mcp_manifest.get_server("srv") == cfg
+        assert mcp_manifest.list_servers() == {"srv": cfg}
+
+    def test_upsert_replaces_existing(self, manifest_file):
+        with patch("src.mcp_config.reload_mcp_config"):
+            mcp_manifest.upsert_server("srv", {"type": "stdio", "command": "a"})
+            mcp_manifest.upsert_server("srv", {"type": "stdio", "command": "b"})
+        assert mcp_manifest.get_server("srv")["command"] == "b"
+        assert list(mcp_manifest.list_servers()) == ["srv"]
+
+    def test_get_missing_returns_empty_dict(self, manifest_file):
+        assert mcp_manifest.get_server("nope") == {}
+
+    def test_delete_returns_existed_true_then_false(self, manifest_file):
+        with patch("src.mcp_config.reload_mcp_config"):
+            mcp_manifest.upsert_server("srv", {"type": "stdio", "command": "echo"})
+            assert mcp_manifest.delete_server("srv") is True
+            assert mcp_manifest.delete_server("srv") is False
+        assert mcp_manifest.get_server("srv") == {}
+
+    def test_upsert_triggers_reload(self, manifest_file):
+        with patch("src.mcp_config.reload_mcp_config") as mock_reload:
+            mcp_manifest.upsert_server("srv", {"type": "stdio", "command": "echo"})
+        mock_reload.assert_called_once()
+
+    def test_delete_triggers_reload(self, manifest_file):
+        with patch("src.mcp_config.reload_mcp_config"):
+            mcp_manifest.upsert_server("srv", {"type": "stdio", "command": "echo"})
+        with patch("src.mcp_config.reload_mcp_config") as mock_reload:
+            mcp_manifest.delete_server("srv")
+        mock_reload.assert_called_once()


### PR DESCRIPTION
## Summary

Turns the admin panel's MCP surface from **read-only** (env-only, restart-required) into **full runtime management**: create / edit / delete MCP servers from the UI, persisted to `data/gateway-mcp.json`, hot-reloaded into new sessions **without a restart**. Plus 4 diagnostics.

## Design — overlay-merge (chosen over a manifest-authoritative alternative)

- **`MCP_CONFIG` (env) stays the base.** The manifest layers on top (manifest wins on name collision). Env servers render **read-only**; only manifest servers are editable/deletable.
- **Hot-reload = atomic singleton rebind** in `mcp_config.py` (build-then-assign, never mutate in place). New `create_client` calls see fresh config; **already-running sessions keep the MCP set they pinned at creation**. env-only deployments are byte-for-byte backward compatible (no manifest ⇒ effective config `== load_mcp_config()`).
- **OpenCode is not hot-reloaded** (it reads MCP only at managed-server startup); the UI states "restart required".
- **Backend enforcement is unchanged** — reach is display-only derived data (pass-through philosophy preserved).

## Diagnostics

1. **Fix the dashboard dash→underscore tool-pattern bug** — a server named `my-server` now correctly shows `mcp__my_server__*` instead of an empty tools list.
2. **Surface silently-dropped invalid servers** (bad type / missing required field) with reasons and source (env/manifest).
3. **Per-server reach across backends** — Claude (create-time filter) / Codex (approval-time deny) / OpenCode (startup-only, gated by `OPENCODE_USE_WRAPPER_MCP_CONFIG`).
4. **Safe per-server connection test** + live JSON validation with `mcp__*` pattern preview before save.

## Security

- The stdio connection test resolves the command on `PATH` only (`shutil.which`) by default — **it does not spawn**. Actual spawning is gated behind `MCP_TEST_ALLOW_SPAWN` (arg-list, never `shell=True`, minimal env, timeout-bounded with `terminate()`→`kill()`). Remote test is a bounded HTTP GET.
- Secrets in `env` / `headers` are redacted in every read response and never echoed into test output.

## New files

- `src/mcp_manifest.py` — atomic-write JSON manifest (mirrors `plugin_manifest.py`; `RLock` + tempfile + `os.replace`).
- `src/mcp_admin_service.py` — CRUD + validation + env-server immutability + dash/underscore namespace-collision guard.
- `src/mcp_connection_test.py` — safe, timeout-bounded reachability probe.
- `src/admin_html_mcp.py` — the MCP management tab.

## New env var

- `GATEWAY_MCP_MANIFEST` (optional) — manifest path override (default `data/gateway-mcp.json`).

## Testing & verification

- **Full suite: 2673 passed, 0 regressions.** The 4 failures present are pre-existing on `main` (Claude hooks / thinking-mode / Docker packaging / AskUserQuestion) — confirmed by running them on a clean HEAD with this branch stashed.
- New/extended tests: `test_mcp_config.py` (reload overlays env, rebind-not-mutate, dropped surfacing), `test_mcp_manifest.py`, `test_mcp_admin_service.py`, `test_admin_features.py` (dash-bug regression + new fields).
- Independent reviewer verified reload semantics, import-cycle avoidance, preserved test seams, connection-test security, and route order.
- **UI verified live** (Playwright + real server): MCP tab renders; env/manifest source split with read-only vs editable actions; dropped banner; per-backend reach chips; live JSON validation + pattern preview; and the non-spawning connection test (`✓ resolvable: .../npx (not spawned; set MCP_TEST_ALLOW_SPAWN to launch)`) all work end-to-end. Data-layer redaction of `headers.Authorization` and `env.*` tokens confirmed via the admin API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
