### PR TITLE
feat(claude): inject authenticated user as MCP header (issue #124, gateway→ragaas hop)

### DIFF
--- a/src/backends/claude/client.py
+++ b/src/backends/claude/client.py
@@ -361,11 +361,48 @@ class ClaudeCodeCLI(TokenEstimateMixin):
         else:
             options.system_prompt = {"type": "preset", "preset": "claude_code"}
 
+    def _inject_mcp_user_header(
+        self, mcp_servers: Dict[str, Any], user: Optional[str]
+    ) -> Dict[str, Any]:
+        """Return *mcp_servers* with the authenticated user injected as a header.
+
+        Adds ``MCP_FORWARD_USER_HEADER: <user>`` to every http/SSE MCP server so
+        downstream servers (e.g. ragaas) can authorize on the user server-side,
+        out of the LLM's reach (a tool argument would be tamperable). Deep-copies
+        first so the shared, process-wide MCP config is never mutated per request.
+        No-op when the header is unconfigured or there is no user.
+        """
+        from src.constants import MCP_FORWARD_USER_HEADER
+
+        header_name = (MCP_FORWARD_USER_HEADER or "").strip()
+        if not header_name or not user:
+            return mcp_servers
+
+        try:
+            user.encode("ascii")
+            value = user
+        except UnicodeEncodeError:
+            from urllib.parse import quote
+
+            value = quote(user)
+
+        import copy
+
+        result = copy.deepcopy(mcp_servers)
+        http_types = {"http", "sse", "streamable-http"}
+        for config in result.values():
+            if isinstance(config, dict) and config.get("type", "stdio") in http_types:
+                headers = config.setdefault("headers", {})
+                if isinstance(headers, dict):
+                    headers[header_name] = value
+        return result
+
     def _configure_mcp_servers(
         self,
         options: ClaudeAgentOptions,
         mcp_servers: Optional[Dict[str, Any]],
         allowed_tools: Optional[List[str]],
+        user: Optional[str] = None,
     ) -> None:
         if not mcp_servers:
             return
@@ -382,7 +419,7 @@ class ClaudeCodeCLI(TokenEstimateMixin):
                 logger.debug("No MCP servers match allowed_tools, skipping MCP")
                 return
 
-            options.mcp_servers = filtered
+            options.mcp_servers = self._inject_mcp_user_header(filtered, user)
             if options.allowed_tools is not None:
                 for pattern in get_mcp_tool_patterns(filtered):
                     if pattern not in options.allowed_tools:
@@ -390,7 +427,7 @@ class ClaudeCodeCLI(TokenEstimateMixin):
             logger.debug(f"MCP servers filtered to: {list(filtered.keys())}")
             return
 
-        options.mcp_servers = mcp_servers
+        options.mcp_servers = self._inject_mcp_user_header(mcp_servers, user)
         if not options.allowed_tools:
             self._set_allowed_tools(options, list(DEFAULT_ALLOWED_TOOLS))
         # The caller passed no allowed_tools, so the gateway is choosing the
@@ -513,7 +550,7 @@ class ClaudeCodeCLI(TokenEstimateMixin):
             options.permission_mode = cast(Any, permission_mode)
         if output_format:
             options.output_format = output_format
-        self._configure_mcp_servers(options, mcp_servers, allowed_tools)
+        self._configure_mcp_servers(options, mcp_servers, allowed_tools, user=user)
         from src.runtime_config import get_token_streaming
 
         if get_token_streaming():

--- a/src/constants.py
+++ b/src/constants.py
@@ -65,6 +65,13 @@ USER_WORKSPACES_DIR = os.getenv("USER_WORKSPACES_DIR", "")
 # Format: {"mcpServers": {"name": {"type": "stdio", "command": "...", "args": [...]}}}
 MCP_CONFIG = os.getenv("MCP_CONFIG", "")
 
+# When set, the gateway injects this HTTP header (value = the request's
+# authenticated user identity) into every http/SSE MCP server config, per
+# request, so downstream MCP servers (e.g. ragaas) can authorize on the user
+# server-side. Unlike a user_id tool argument, the LLM cannot tamper with it.
+# Empty (default) = disabled. Example: "X-OpenWebUI-User-Name".
+MCP_FORWARD_USER_HEADER = os.getenv("MCP_FORWARD_USER_HEADER", "")
+
 # MCP connection-test (admin diagnostics). Short + bounded so a hung server
 # cannot wedge the request thread. Do NOT reuse DEFAULT_TIMEOUT_MS (whole-turn budget).
 MCP_TEST_TIMEOUT_SECONDS = parse_float_env("MCP_TEST_TIMEOUT_SECONDS", 5.0)

--- a/tests/test_claude_client_more_coverage.py
+++ b/tests/test_claude_client_more_coverage.py
@@ -599,3 +599,54 @@ class TestReceiveResponseFromClient:
 
         assert len(result) == 2
         assert result[0]["type"] == "assistant"
+
+
+# ---------------------------------------------------------------------------
+# _inject_mcp_user_header() — per-request user header into MCP configs
+# ---------------------------------------------------------------------------
+
+
+class TestInjectMcpUserHeader:
+    """Gateway injects the authenticated user as an MCP header (issue #124)."""
+
+    def _mcp(self):
+        return {
+            "ragaas": {"type": "http", "url": "http://127.0.0.1:10074/mcp"},
+            "local": {"type": "stdio", "command": "x"},
+            "sse1": {"type": "sse", "url": "y", "headers": {"A": "1"}},
+        }
+
+    def test_disabled_when_header_unset(self, monkeypatch):
+        monkeypatch.setattr("src.constants.MCP_FORWARD_USER_HEADER", "")
+        cli = _make_cli()
+        mcp = self._mcp()
+        # No-op returns the same object untouched.
+        assert cli._inject_mcp_user_header(mcp, "alice") is mcp
+
+    def test_disabled_when_no_user(self, monkeypatch):
+        monkeypatch.setattr("src.constants.MCP_FORWARD_USER_HEADER", "X-OpenWebUI-User-Name")
+        cli = _make_cli()
+        mcp = self._mcp()
+        assert cli._inject_mcp_user_header(mcp, None) is mcp
+
+    def test_injects_into_http_and_sse_only(self, monkeypatch):
+        monkeypatch.setattr("src.constants.MCP_FORWARD_USER_HEADER", "X-OpenWebUI-User-Name")
+        cli = _make_cli()
+        mcp = self._mcp()
+        out = cli._inject_mcp_user_header(mcp, "alice")
+
+        assert out["ragaas"]["headers"] == {"X-OpenWebUI-User-Name": "alice"}
+        # Existing headers preserved (merged, not clobbered).
+        assert out["sse1"]["headers"] == {"A": "1", "X-OpenWebUI-User-Name": "alice"}
+        # stdio servers have no headers key added.
+        assert "headers" not in out["local"]
+        # The shared config passed in is never mutated (deep-copied).
+        assert "headers" not in mcp["ragaas"]
+
+    def test_non_ascii_user_is_quoted(self, monkeypatch):
+        monkeypatch.setattr("src.constants.MCP_FORWARD_USER_HEADER", "X-User")
+        cli = _make_cli()
+        out = cli._inject_mcp_user_header(self._mcp(), "김철수")
+        # Value is percent-encoded so it survives as an HTTP header.
+        assert out["ragaas"]["headers"]["X-User"].startswith("%")
+        out["ragaas"]["headers"]["X-User"].encode("ascii")  # must not raise


### PR DESCRIPTION
Closes the **gateway → ragaas MCP hop** from #124. Lets downstream MCP servers (e.g. ragaas) authorize on the authenticated user **server-side**, out of the LLM's reach — a `user_id` *tool argument* is tamperable (the model can pass any id → privilege bypass); an HTTP header the gateway sets from the request identity is not.

Confirmed viable: the SDK (`claude-agent-sdk`) supports a `headers` field on http/SSE MCP server configs (`McpHttpServerConfig` / `McpSSEServerConfig`), and the gateway already builds options per request with `user` available.

## Changes

- **`constants.py`** — `MCP_FORWARD_USER_HEADER` (env, empty = off) names the header to inject, e.g. `X-OpenWebUI-User-Name`.
- **`client.py`** — `_inject_mcp_user_header()`:
  - **deep-copies** the shared, process-wide MCP config so it's never mutated per request;
  - adds `{header: user}` to every `http` / `sse` / `streamable-http` server; `stdio` untouched; **existing headers merged** (not clobbered); **non-ascii** user percent-encoded so it survives as an HTTP header;
  - threaded `user` into `_configure_mcp_servers` (both the filtered and full paths).
- No-op unless `MCP_FORWARD_USER_HEADER` is set and a user is present → zero behavior change for existing deployments.

## Not in this PR (separate repos, per #124)

- **ragaas**: drop the `user_id` tool argument; read the header from the MCP request context (`ctx.request_context.request.headers`); fail-closed in multi-user.
- **pipe/frontend trust root**: derive identity from the authenticated `__user__`, not a client-supplied `x-openwebui-user-name` header. The value this PR injects (`body.user`) is only trustworthy if the gateway isn't directly reachable by end users and the pipe sets it from `__user__` — tracked for the open-webui side.

## Tests

`tests/test_claude_client_more_coverage.py::TestInjectMcpUserHeader` — disabled when unset / no user; injects into http+sse only (stdio untouched); existing headers merged; shared config not mutated; non-ascii quoted. 88 passed.

## Notes

- `py_compile` clean; my added lines are black-88 clean (the repo has pre-existing black-version drift, so I did not repo-wide reformat per CLAUDE.md).
- Injects into **all** http/SSE MCP servers when enabled (admin-configured, trusted endpoints). A per-server opt-in can be added later if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFsj3J7EAZNr1TKZXYqoqm

---
_Generated by [Claude Code](https://claude.ai/code/session_01LFsj3J7EAZNr1TKZXYqoqm)_