### PR TITLE
feat(mcp): per-request MCP context header for server-side authorization (issue #124)

### DIFF
--- a/src/backends/claude/client.py
+++ b/src/backends/claude/client.py
@@ -386,9 +386,9 @@ class ClaudeCodeCLI(TokenEstimateMixin):
 
         - ``MCP_FORWARD_USER_HEADER: <user>`` — the server-authoritative user
           *identity* (a tool argument would be tamperable).
-        - ``forward_headers`` — inbound request headers the gateway passes
-          through verbatim (see ``MCP_FORWARD_REQUEST_HEADERS``); these carry the
-          caller's own credentials the downstream validates itself.
+        - ``forward_headers`` — the caller-supplied context header(s) the route
+          resolved from ``MCP_FORWARD_CONTEXT`` (identity + caller-owned
+          credentials the downstream validates itself).
 
         Deep-copies first so the shared, process-wide MCP config is never mutated
         per request. No-op when neither source yields a header.

--- a/src/backends/claude/client.py
+++ b/src/backends/claude/client.py
@@ -917,6 +917,7 @@ class ClaudeCodeCLI(TokenEstimateMixin):
         model_params: Optional[Dict[str, Any]] = None,
         output_format: Optional[Dict[str, Any]] = None,
         _custom_base: object = _UNSET,
+        user: Optional[str] = None,
     ) -> ClaudeSDKClient:
         """Create and connect a :class:`ClaudeSDKClient` for *session*.
 
@@ -954,6 +955,7 @@ class ClaudeCodeCLI(TokenEstimateMixin):
             cwd=Path(cwd) if cwd else None,
             extra_env=extra_env,
             _custom_base=_custom_base,
+            user=user,
         )
         pre_tool_use = [
             HookMatcher(

--- a/src/backends/claude/client.py
+++ b/src/backends/claude/client.py
@@ -361,11 +361,48 @@ class ClaudeCodeCLI(TokenEstimateMixin):
         else:
             options.system_prompt = {"type": "preset", "preset": "claude_code"}
 
+    def _inject_mcp_user_header(
+        self, mcp_servers: Dict[str, Any], user: Optional[str]
+    ) -> Dict[str, Any]:
+        """Return *mcp_servers* with the authenticated user injected as a header.
+
+        Adds ``MCP_FORWARD_USER_HEADER: <user>`` to every http/SSE MCP server so
+        downstream servers (e.g. ragaas) can authorize on the user server-side,
+        out of the LLM's reach (a tool argument would be tamperable). Deep-copies
+        first so the shared, process-wide MCP config is never mutated per request.
+        No-op when the header is unconfigured or there is no user.
+        """
+        from src.constants import MCP_FORWARD_USER_HEADER
+
+        header_name = (MCP_FORWARD_USER_HEADER or "").strip()
+        if not header_name or not user:
+            return mcp_servers
+
+        try:
+            user.encode("ascii")
+            value = user
+        except UnicodeEncodeError:
+            from urllib.parse import quote
+
+            value = quote(user)
+
+        import copy
+
+        result = copy.deepcopy(mcp_servers)
+        http_types = {"http", "sse", "streamable-http"}
+        for config in result.values():
+            if isinstance(config, dict) and config.get("type", "stdio") in http_types:
+                headers = config.setdefault("headers", {})
+                if isinstance(headers, dict):
+                    headers[header_name] = value
+        return result
+
     def _configure_mcp_servers(
         self,
         options: ClaudeAgentOptions,
         mcp_servers: Optional[Dict[str, Any]],
         allowed_tools: Optional[List[str]],
+        user: Optional[str] = None,
     ) -> None:
         if not mcp_servers:
             return
@@ -382,7 +419,7 @@ class ClaudeCodeCLI(TokenEstimateMixin):
                 logger.debug("No MCP servers match allowed_tools, skipping MCP")
                 return
 
-            options.mcp_servers = filtered
+            options.mcp_servers = self._inject_mcp_user_header(filtered, user)
             if options.allowed_tools is not None:
                 for pattern in get_mcp_tool_patterns(filtered):
                     if pattern not in options.allowed_tools:
@@ -390,7 +427,7 @@ class ClaudeCodeCLI(TokenEstimateMixin):
             logger.debug(f"MCP servers filtered to: {list(filtered.keys())}")
             return
 
-        options.mcp_servers = mcp_servers
+        options.mcp_servers = self._inject_mcp_user_header(mcp_servers, user)
         if not options.allowed_tools:
             self._set_allowed_tools(options, list(DEFAULT_ALLOWED_TOOLS))
         # The caller passed no allowed_tools, so the gateway is choosing the
@@ -513,7 +550,7 @@ class ClaudeCodeCLI(TokenEstimateMixin):
             options.permission_mode = cast(Any, permission_mode)
         if output_format:
             options.output_format = output_format
-        self._configure_mcp_servers(options, mcp_servers, allowed_tools)
+        self._configure_mcp_servers(options, mcp_servers, allowed_tools, user=user)
         from src.runtime_config import get_token_streaming
 
         if get_token_streaming():

--- a/src/backends/claude/client.py
+++ b/src/backends/claude/client.py
@@ -363,14 +363,18 @@ class ClaudeCodeCLI(TokenEstimateMixin):
 
     @staticmethod
     def _header_safe(value: str) -> str:
-        """Return *value* usable as an HTTP header value (percent-encode non-ascii)."""
-        try:
-            value.encode("ascii")
-            return value
-        except UnicodeEncodeError:
-            from urllib.parse import quote
+        """Return *value* usable as an HTTP header value.
 
-            return quote(value)
+        Percent-encodes non-ascii AND any control characters (CR/LF/NUL/…) so a
+        value derived from request input can neither inject extra headers (CRLF)
+        nor break the outbound MCP request. Plain printable-ascii passes through
+        unchanged.
+        """
+        from urllib.parse import quote
+
+        if value.isascii() and not any(ord(c) < 0x20 or ord(c) == 0x7F for c in value):
+            return value
+        return quote(value)
 
     def _inject_mcp_user_header(
         self,
@@ -384,8 +388,9 @@ class ClaudeCodeCLI(TokenEstimateMixin):
         ``headers`` so downstream servers (e.g. ragaas) receive them out of the
         LLM's reach:
 
-        - ``MCP_FORWARD_USER_HEADER: <user>`` — the server-authoritative user
-          *identity* (a tool argument would be tamperable).
+        - ``MCP_FORWARD_USER_HEADER: <user>`` — the user *identity*, kept out of
+          the LLM's reach (a tool argument would be tamperable). Its trust rests
+          on ``body.user`` coming from a trusted caller, not a direct API caller.
         - ``forward_headers`` — the caller-supplied context header(s) the route
           resolved from ``MCP_FORWARD_CONTEXT`` (identity + caller-owned
           credentials the downstream validates itself).
@@ -578,7 +583,11 @@ class ClaudeCodeCLI(TokenEstimateMixin):
         if output_format:
             options.output_format = output_format
         self._configure_mcp_servers(
-            options, mcp_servers, allowed_tools, user=user, forward_headers=forward_headers
+            options,
+            mcp_servers,
+            allowed_tools,
+            user=user,
+            forward_headers=forward_headers,
         )
         from src.runtime_config import get_token_streaming
 

--- a/src/backends/claude/client.py
+++ b/src/backends/claude/client.py
@@ -361,30 +361,51 @@ class ClaudeCodeCLI(TokenEstimateMixin):
         else:
             options.system_prompt = {"type": "preset", "preset": "claude_code"}
 
-    def _inject_mcp_user_header(
-        self, mcp_servers: Dict[str, Any], user: Optional[str]
-    ) -> Dict[str, Any]:
-        """Return *mcp_servers* with the authenticated user injected as a header.
-
-        Adds ``MCP_FORWARD_USER_HEADER: <user>`` to every http/SSE MCP server so
-        downstream servers (e.g. ragaas) can authorize on the user server-side,
-        out of the LLM's reach (a tool argument would be tamperable). Deep-copies
-        first so the shared, process-wide MCP config is never mutated per request.
-        No-op when the header is unconfigured or there is no user.
-        """
-        from src.constants import MCP_FORWARD_USER_HEADER
-
-        header_name = (MCP_FORWARD_USER_HEADER or "").strip()
-        if not header_name or not user:
-            return mcp_servers
-
+    @staticmethod
+    def _header_safe(value: str) -> str:
+        """Return *value* usable as an HTTP header value (percent-encode non-ascii)."""
         try:
-            user.encode("ascii")
-            value = user
+            value.encode("ascii")
+            return value
         except UnicodeEncodeError:
             from urllib.parse import quote
 
-            value = quote(user)
+            return quote(value)
+
+    def _inject_mcp_user_header(
+        self,
+        mcp_servers: Dict[str, Any],
+        user: Optional[str],
+        forward_headers: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, Any]:
+        """Return *mcp_servers* with per-request headers injected.
+
+        Two independent sources are merged into every http/SSE MCP server's
+        ``headers`` so downstream servers (e.g. ragaas) receive them out of the
+        LLM's reach:
+
+        - ``MCP_FORWARD_USER_HEADER: <user>`` — the server-authoritative user
+          *identity* (a tool argument would be tamperable).
+        - ``forward_headers`` — inbound request headers the gateway passes
+          through verbatim (see ``MCP_FORWARD_REQUEST_HEADERS``); these carry the
+          caller's own credentials the downstream validates itself.
+
+        Deep-copies first so the shared, process-wide MCP config is never mutated
+        per request. No-op when neither source yields a header.
+        """
+        from src.constants import MCP_FORWARD_USER_HEADER
+
+        headers_map: Dict[str, str] = {}
+        header_name = (MCP_FORWARD_USER_HEADER or "").strip()
+        if header_name and user:
+            headers_map[header_name] = self._header_safe(user)
+        if forward_headers:
+            for name, value in forward_headers.items():
+                if name and value:
+                    headers_map[name] = self._header_safe(value)
+
+        if not headers_map:
+            return mcp_servers
 
         import copy
 
@@ -394,7 +415,7 @@ class ClaudeCodeCLI(TokenEstimateMixin):
             if isinstance(config, dict) and config.get("type", "stdio") in http_types:
                 headers = config.setdefault("headers", {})
                 if isinstance(headers, dict):
-                    headers[header_name] = value
+                    headers.update(headers_map)
         return result
 
     def _configure_mcp_servers(
@@ -403,6 +424,7 @@ class ClaudeCodeCLI(TokenEstimateMixin):
         mcp_servers: Optional[Dict[str, Any]],
         allowed_tools: Optional[List[str]],
         user: Optional[str] = None,
+        forward_headers: Optional[Dict[str, str]] = None,
     ) -> None:
         if not mcp_servers:
             return
@@ -419,7 +441,9 @@ class ClaudeCodeCLI(TokenEstimateMixin):
                 logger.debug("No MCP servers match allowed_tools, skipping MCP")
                 return
 
-            options.mcp_servers = self._inject_mcp_user_header(filtered, user)
+            options.mcp_servers = self._inject_mcp_user_header(
+                filtered, user, forward_headers
+            )
             if options.allowed_tools is not None:
                 for pattern in get_mcp_tool_patterns(filtered):
                     if pattern not in options.allowed_tools:
@@ -427,7 +451,9 @@ class ClaudeCodeCLI(TokenEstimateMixin):
             logger.debug(f"MCP servers filtered to: {list(filtered.keys())}")
             return
 
-        options.mcp_servers = self._inject_mcp_user_header(mcp_servers, user)
+        options.mcp_servers = self._inject_mcp_user_header(
+            mcp_servers, user, forward_headers
+        )
         if not options.allowed_tools:
             self._set_allowed_tools(options, list(DEFAULT_ALLOWED_TOOLS))
         # The caller passed no allowed_tools, so the gateway is choosing the
@@ -518,6 +544,7 @@ class ClaudeCodeCLI(TokenEstimateMixin):
         task_budget: Optional[int] = None,
         cwd: Optional[Path] = None,
         user: Optional[str] = None,
+        forward_headers: Optional[Dict[str, str]] = None,
     ) -> ClaudeAgentOptions:
         """Build ClaudeAgentOptions with common parameters."""
         effective_cwd = cwd or self.cwd
@@ -550,7 +577,9 @@ class ClaudeCodeCLI(TokenEstimateMixin):
             options.permission_mode = cast(Any, permission_mode)
         if output_format:
             options.output_format = output_format
-        self._configure_mcp_servers(options, mcp_servers, allowed_tools, user=user)
+        self._configure_mcp_servers(
+            options, mcp_servers, allowed_tools, user=user, forward_headers=forward_headers
+        )
         from src.runtime_config import get_token_streaming
 
         if get_token_streaming():
@@ -918,6 +947,7 @@ class ClaudeCodeCLI(TokenEstimateMixin):
         output_format: Optional[Dict[str, Any]] = None,
         _custom_base: object = _UNSET,
         user: Optional[str] = None,
+        forward_headers: Optional[Dict[str, str]] = None,
     ) -> ClaudeSDKClient:
         """Create and connect a :class:`ClaudeSDKClient` for *session*.
 
@@ -956,6 +986,7 @@ class ClaudeCodeCLI(TokenEstimateMixin):
             extra_env=extra_env,
             _custom_base=_custom_base,
             user=user,
+            forward_headers=forward_headers,
         )
         pre_tool_use = [
             HookMatcher(

--- a/src/backends/claude/client.py
+++ b/src/backends/claude/client.py
@@ -44,6 +44,7 @@ from src.backends.claude.constants import (
     CLAUDE_SANDBOX_WEAKER_NESTED,
 )
 from src.backends.common import TokenEstimateMixin, error_chunk
+from src.backends.mcp_headers import inject_mcp_headers
 from src.constants import ASK_USER_TIMEOUT_SECONDS, DEFAULT_TIMEOUT_MS
 from src.message_adapter import MessageAdapter
 from src.image_handler import ImageHandler
@@ -361,74 +362,11 @@ class ClaudeCodeCLI(TokenEstimateMixin):
         else:
             options.system_prompt = {"type": "preset", "preset": "claude_code"}
 
-    @staticmethod
-    def _header_safe(value: str) -> str:
-        """Return *value* usable as an HTTP header value.
-
-        Percent-encodes non-ascii AND any control characters (CR/LF/NUL/…) so a
-        value derived from request input can neither inject extra headers (CRLF)
-        nor break the outbound MCP request. Plain printable-ascii passes through
-        unchanged.
-        """
-        from urllib.parse import quote
-
-        if value.isascii() and not any(ord(c) < 0x20 or ord(c) == 0x7F for c in value):
-            return value
-        return quote(value)
-
-    def _inject_mcp_user_header(
-        self,
-        mcp_servers: Dict[str, Any],
-        user: Optional[str],
-        forward_headers: Optional[Dict[str, str]] = None,
-    ) -> Dict[str, Any]:
-        """Return *mcp_servers* with per-request headers injected.
-
-        Two independent sources are merged into every http/SSE MCP server's
-        ``headers`` so downstream servers (e.g. ragaas) receive them out of the
-        LLM's reach:
-
-        - ``MCP_FORWARD_USER_HEADER: <user>`` — the user *identity*, kept out of
-          the LLM's reach (a tool argument would be tamperable). Its trust rests
-          on ``body.user`` coming from a trusted caller, not a direct API caller.
-        - ``forward_headers`` — the caller-supplied context header(s) the route
-          resolved from ``MCP_FORWARD_CONTEXT`` (identity + caller-owned
-          credentials the downstream validates itself).
-
-        Deep-copies first so the shared, process-wide MCP config is never mutated
-        per request. No-op when neither source yields a header.
-        """
-        from src.constants import MCP_FORWARD_USER_HEADER
-
-        headers_map: Dict[str, str] = {}
-        header_name = (MCP_FORWARD_USER_HEADER or "").strip()
-        if header_name and user:
-            headers_map[header_name] = self._header_safe(user)
-        if forward_headers:
-            for name, value in forward_headers.items():
-                if name and value:
-                    headers_map[name] = self._header_safe(value)
-
-        if not headers_map:
-            return mcp_servers
-
-        import copy
-
-        result = copy.deepcopy(mcp_servers)
-        http_types = {"http", "sse", "streamable-http"}
-        for config in result.values():
-            if isinstance(config, dict) and config.get("type", "stdio") in http_types:
-                headers = config.setdefault("headers", {})
-                if isinstance(headers, dict):
-                    headers.update(headers_map)
-        return result
-
     def _configure_mcp_servers(
         self,
         options: ClaudeAgentOptions,
         mcp_servers: Optional[Dict[str, Any]],
         allowed_tools: Optional[List[str]],
-        user: Optional[str] = None,
         forward_headers: Optional[Dict[str, str]] = None,
     ) -> None:
         if not mcp_servers:
@@ -446,9 +384,7 @@ class ClaudeCodeCLI(TokenEstimateMixin):
                 logger.debug("No MCP servers match allowed_tools, skipping MCP")
                 return
 
-            options.mcp_servers = self._inject_mcp_user_header(
-                filtered, user, forward_headers
-            )
+            options.mcp_servers = inject_mcp_headers(filtered, forward_headers)
             if options.allowed_tools is not None:
                 for pattern in get_mcp_tool_patterns(filtered):
                     if pattern not in options.allowed_tools:
@@ -456,9 +392,7 @@ class ClaudeCodeCLI(TokenEstimateMixin):
             logger.debug(f"MCP servers filtered to: {list(filtered.keys())}")
             return
 
-        options.mcp_servers = self._inject_mcp_user_header(
-            mcp_servers, user, forward_headers
-        )
+        options.mcp_servers = inject_mcp_headers(mcp_servers, forward_headers)
         if not options.allowed_tools:
             self._set_allowed_tools(options, list(DEFAULT_ALLOWED_TOOLS))
         # The caller passed no allowed_tools, so the gateway is choosing the
@@ -583,11 +517,7 @@ class ClaudeCodeCLI(TokenEstimateMixin):
         if output_format:
             options.output_format = output_format
         self._configure_mcp_servers(
-            options,
-            mcp_servers,
-            allowed_tools,
-            user=user,
-            forward_headers=forward_headers,
+            options, mcp_servers, allowed_tools, forward_headers=forward_headers
         )
         from src.runtime_config import get_token_streaming
 

--- a/src/backends/codex/client.py
+++ b/src/backends/codex/client.py
@@ -33,6 +33,7 @@ from src.backends.codex.constants import (
     sandbox_mode,
 )
 from src.backends.base import SessionHandle
+from src.backends.mcp_headers import inject_mcp_headers
 from src.backends.common import (
     TokenEstimateMixin,
     combine_system_prompt,
@@ -540,9 +541,15 @@ class CodexClient(TokenEstimateMixin):
         extra_env: Optional[Dict[str, str]] = None,
         model_params: Optional[Dict[str, Any]] = None,
         _custom_base: Any = None,
+        forward_headers: Optional[Dict[str, str]] = None,
     ) -> CodexSessionClient:
         _ = (task_budget,)
         env = self._metadata_env(extra_env)
+        # Inject the gateway-resolved MCP context header (identity + caller-owned
+        # credentials) into http/SSE server configs before forwarding them to the
+        # app-server, mirroring the claude backend. NOTE: this rides on the codex
+        # app-server honoring a per-server ``headers`` field on http MCP configs.
+        mcp_servers = inject_mcp_headers(mcp_servers, forward_headers)
         async with self._rpc_lock:
             try:
                 rpc = await self._ensure_rpc_locked(env)

--- a/src/backends/mcp_headers.py
+++ b/src/backends/mcp_headers.py
@@ -1,0 +1,71 @@
+"""Shared per-request header injection into MCP server configs.
+
+Used by the claude and codex backends to merge gateway-resolved context headers
+(identity + caller-owned credentials — see ``MCP_FORWARD_CONTEXT`` in
+``src/constants.py``) into every http/SSE MCP server's ``headers`` so downstream
+MCP servers can authorize server-side, out of the LLM's reach.
+"""
+
+import copy
+import logging
+from typing import Any, Dict, Optional
+from urllib.parse import quote
+
+logger = logging.getLogger(__name__)
+
+_HTTP_TYPES = {"http", "sse", "streamable-http"}
+
+
+def header_safe(value: str) -> str:
+    """Return *value* usable as an HTTP header value.
+
+    Percent-encodes non-ascii AND any control characters (CR/LF/NUL/…) so a
+    value derived from request input can neither inject extra headers (CRLF) nor
+    break the outbound MCP request. Plain printable-ascii passes through
+    unchanged.
+    """
+    if value.isascii() and not any(ord(c) < 0x20 or ord(c) == 0x7F for c in value):
+        return value
+    return quote(value)
+
+
+def inject_mcp_headers(
+    mcp_servers: Optional[Dict[str, Any]],
+    forward_headers: Optional[Dict[str, str]],
+) -> Optional[Dict[str, Any]]:
+    """Return *mcp_servers* with *forward_headers* merged into every http/SSE
+    server's ``headers``.
+
+    Deep-copies first so a shared, process-wide config is never mutated per
+    request. Returns the input object unchanged (same identity) when there is
+    nothing to inject. ``stdio`` servers are left untouched; a server whose
+    existing ``headers`` is not a dict is skipped with a warning rather than
+    silently dropped.
+    """
+    if not mcp_servers or not forward_headers:
+        return mcp_servers
+    headers_map = {
+        name: header_safe(value)
+        for name, value in forward_headers.items()
+        if name and value
+    }
+    if not headers_map:
+        return mcp_servers
+
+    result = copy.deepcopy(mcp_servers)
+    for name, config in result.items():
+        if not isinstance(config, dict) or config.get("type", "stdio") not in _HTTP_TYPES:
+            continue
+        existing = config.get("headers")
+        if existing is None:
+            config["headers"] = dict(headers_map)
+        elif isinstance(existing, dict):
+            existing.update(headers_map)
+        else:
+            logger.warning(
+                "MCP server %r has non-dict 'headers' (%s); skipping context "
+                "header injection for it",
+                name,
+                type(existing).__name__,
+            )
+    return result

--- a/src/constants.py
+++ b/src/constants.py
@@ -65,6 +65,13 @@ USER_WORKSPACES_DIR = os.getenv("USER_WORKSPACES_DIR", "")
 # Format: {"mcpServers": {"name": {"type": "stdio", "command": "...", "args": [...]}}}
 MCP_CONFIG = os.getenv("MCP_CONFIG", "")
 
+# When set, the gateway injects this HTTP header (value = the request's
+# authenticated user identity) into every http/SSE MCP server config, per
+# request, so downstream MCP servers (e.g. ragaas) can authorize on the user
+# server-side. Unlike a user_id tool argument, the LLM cannot tamper with it.
+# Empty (default) = disabled. Example: "X-OpenWebUI-User-Name".
+MCP_FORWARD_USER_HEADER = os.getenv("MCP_FORWARD_USER_HEADER", "")
+
 # MCP connection-test (admin diagnostics). Short + bounded so a hung server
 # cannot wedge the request thread. Do NOT reuse DEFAULT_TIMEOUT_MS (whole-turn budget).
 MCP_TEST_TIMEOUT_SECONDS = parse_float_env("MCP_TEST_TIMEOUT_SECONDS", 5.0)

--- a/src/constants.py
+++ b/src/constants.py
@@ -67,15 +67,19 @@ USER_WORKSPACES_DIR = os.getenv("USER_WORKSPACES_DIR", "")
 # Format: {"mcpServers": {"name": {"type": "stdio", "command": "...", "args": [...]}}}
 MCP_CONFIG = os.getenv("MCP_CONFIG", "")
 
-# When set, the gateway injects this HTTP header (value = the request's
-# authenticated user identity) into every http/SSE MCP server config, per
-# request, so downstream MCP servers (e.g. ragaas) can authorize on the user
-# server-side. Unlike a user_id tool argument, the LLM cannot tamper with it.
+# When set, the gateway injects this HTTP header (value = the request's user
+# identity, ``body.user``) into every http/SSE MCP server config, per request, so
+# downstream MCP servers (e.g. ragaas) can authorize on the user server-side.
+# This keeps identity out of the LLM's reach (a user_id *tool argument* is
+# tamperable by the model). NOTE: ``body.user`` is a request-body field, so it is
+# only as trustworthy as the caller — this is safe only when the gateway is
+# reachable solely via a trusted caller (the pipe, which sets it from the
+# authenticated ``__user__``) and not directly by end users.
 # Empty (default) = disabled. Example: "X-OpenWebUI-User-Name".
 MCP_FORWARD_USER_HEADER = os.getenv("MCP_FORWARD_USER_HEADER", "")
 
 # Generalized per-request MCP context. A JSON object template whose values may
-# contain ``{{user}}`` (the server-authoritative authenticated identity) and
+# contain ``{{user}}`` (the authenticated identity, from ``body.user``) and
 # ``{{header:NAME}}`` (an inbound request header, e.g. a caller-owned session
 # token the downstream MCP server validates itself). The gateway resolves the
 # template per request and injects the result as ONE JSON header
@@ -86,13 +90,18 @@ MCP_FORWARD_USER_HEADER = os.getenv("MCP_FORWARD_USER_HEADER", "")
 # Example: {"user_id":"{{user}}","dscrowd_token":"{{header:X-Cookie-dscrowd.token_key}}"}
 #
 # Identity vs credential: use ``{{user}}`` (not ``{{header:...}}``) for identity —
-# it is derived server-side and cannot be spoofed. ``{{header:...}}`` is for the
-# caller's own bearer credentials, which the downstream authenticates.
+# it stays out of the LLM's reach. Its trust still rests on ``body.user`` being
+# set by a trusted caller (see MCP_FORWARD_USER_HEADER note above), not spoofed by
+# a direct API caller. ``{{header:...}}`` is for the caller's own bearer
+# credentials, which the downstream authenticates.
 MCP_FORWARD_CONTEXT = os.getenv("MCP_FORWARD_CONTEXT", "")
 MCP_FORWARD_CONTEXT_HEADER = os.getenv("MCP_FORWARD_CONTEXT_HEADER", "X-MCP-Context")
 
 
-_MCP_CONTEXT_TOKEN_RE = re.compile(r"\{\{\s*(user|header:[^}]+?)\s*\}\}")
+# ``header:`` accepts an empty name (``[^}]*?``) so a misconfigured
+# ``{{header:}}`` resolves to "" (and its key is dropped) rather than leaking the
+# literal token into the downstream context payload.
+_MCP_CONTEXT_TOKEN_RE = re.compile(r"\{\{\s*(user|header:[^}]*?)\s*\}\}")
 
 
 def _resolve_mcp_context_value(template, user, header_getter) -> str:

--- a/src/constants.py
+++ b/src/constants.py
@@ -67,19 +67,8 @@ USER_WORKSPACES_DIR = os.getenv("USER_WORKSPACES_DIR", "")
 # Format: {"mcpServers": {"name": {"type": "stdio", "command": "...", "args": [...]}}}
 MCP_CONFIG = os.getenv("MCP_CONFIG", "")
 
-# When set, the gateway injects this HTTP header (value = the request's user
-# identity, ``body.user``) into every http/SSE MCP server config, per request, so
-# downstream MCP servers (e.g. ragaas) can authorize on the user server-side.
-# This keeps identity out of the LLM's reach (a user_id *tool argument* is
-# tamperable by the model). NOTE: ``body.user`` is a request-body field, so it is
-# only as trustworthy as the caller — this is safe only when the gateway is
-# reachable solely via a trusted caller (the pipe, which sets it from the
-# authenticated ``__user__``) and not directly by end users.
-# Empty (default) = disabled. Example: "X-OpenWebUI-User-Name".
-MCP_FORWARD_USER_HEADER = os.getenv("MCP_FORWARD_USER_HEADER", "")
-
-# Generalized per-request MCP context. A JSON object template whose values may
-# contain ``{{user}}`` (the authenticated identity, from ``body.user``) and
+# Per-request MCP context. A JSON object template whose values may contain
+# ``{{user}}`` (the authenticated identity, from ``body.user``) and
 # ``{{header:NAME}}`` (an inbound request header, e.g. a caller-owned session
 # token the downstream MCP server validates itself). The gateway resolves the
 # template per request and injects the result as ONE JSON header
@@ -91,9 +80,9 @@ MCP_FORWARD_USER_HEADER = os.getenv("MCP_FORWARD_USER_HEADER", "")
 #
 # Identity vs credential: use ``{{user}}`` (not ``{{header:...}}``) for identity —
 # it stays out of the LLM's reach. Its trust still rests on ``body.user`` being
-# set by a trusted caller (see MCP_FORWARD_USER_HEADER note above), not spoofed by
-# a direct API caller. ``{{header:...}}`` is for the caller's own bearer
-# credentials, which the downstream authenticates.
+# set by a trusted caller (the pipe, from the authenticated ``__user__``), not
+# spoofed by a direct API caller reaching the gateway. ``{{header:...}}`` is for
+# the caller's own bearer credentials, which the downstream authenticates.
 MCP_FORWARD_CONTEXT = os.getenv("MCP_FORWARD_CONTEXT", "")
 MCP_FORWARD_CONTEXT_HEADER = os.getenv("MCP_FORWARD_CONTEXT_HEADER", "X-MCP-Context")
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -72,6 +72,40 @@ MCP_CONFIG = os.getenv("MCP_CONFIG", "")
 # Empty (default) = disabled. Example: "X-OpenWebUI-User-Name".
 MCP_FORWARD_USER_HEADER = os.getenv("MCP_FORWARD_USER_HEADER", "")
 
+# Comma-separated inbound request headers the gateway passes through, verbatim,
+# to every http/SSE MCP server config (in addition to MCP_FORWARD_USER_HEADER).
+# Unlike the user header (a server-authoritative *identity* the gateway derives
+# and the LLM must not tamper with), these carry the caller's OWN credentials —
+# e.g. a session cookie/token the downstream MCP server validates itself. The
+# caller can only forward their own credential, and the downstream authenticates
+# it, so passing the inbound value through is the correct model here (it is not
+# an authorization claim that could be spoofed to impersonate another user).
+# Each entry is an inbound header name, optionally ``inbound:outbound`` to rename
+# on the way out. Empty (default) = disabled. Example: "X-Cookie-dscrowd.token_key".
+MCP_FORWARD_REQUEST_HEADERS = os.getenv("MCP_FORWARD_REQUEST_HEADERS", "")
+
+
+def parse_mcp_forward_request_headers() -> list[tuple[str, str]]:
+    """Parse ``MCP_FORWARD_REQUEST_HEADERS`` into ``(inbound, outbound)`` pairs.
+
+    Read from the environment on each call so runtime/test overrides take effect
+    without a module reload (mirrors :func:`is_text_only_model`).
+    """
+    raw = os.getenv("MCP_FORWARD_REQUEST_HEADERS", "")
+    pairs: list[tuple[str, str]] = []
+    for entry in raw.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        if ":" in entry:
+            inbound, outbound = (part.strip() for part in entry.split(":", 1))
+        else:
+            inbound = outbound = entry
+        if inbound and outbound:
+            pairs.append((inbound, outbound))
+    return pairs
+
+
 # MCP connection-test (admin diagnostics). Short + bounded so a hung server
 # cannot wedge the request thread. Do NOT reuse DEFAULT_TIMEOUT_MS (whole-turn budget).
 MCP_TEST_TIMEOUT_SECONDS = parse_float_env("MCP_TEST_TIMEOUT_SECONDS", 5.0)

--- a/src/constants.py
+++ b/src/constants.py
@@ -7,7 +7,9 @@ All configurable values can be overridden via environment variables.
 """
 
 import fnmatch
+import json
 import os
+import re
 from dotenv import dotenv_values, load_dotenv
 
 from src.env_utils import parse_bool_env, parse_float_env, parse_int_env
@@ -72,38 +74,72 @@ MCP_CONFIG = os.getenv("MCP_CONFIG", "")
 # Empty (default) = disabled. Example: "X-OpenWebUI-User-Name".
 MCP_FORWARD_USER_HEADER = os.getenv("MCP_FORWARD_USER_HEADER", "")
 
-# Comma-separated inbound request headers the gateway passes through, verbatim,
-# to every http/SSE MCP server config (in addition to MCP_FORWARD_USER_HEADER).
-# Unlike the user header (a server-authoritative *identity* the gateway derives
-# and the LLM must not tamper with), these carry the caller's OWN credentials —
-# e.g. a session cookie/token the downstream MCP server validates itself. The
-# caller can only forward their own credential, and the downstream authenticates
-# it, so passing the inbound value through is the correct model here (it is not
-# an authorization claim that could be spoofed to impersonate another user).
-# Each entry is an inbound header name, optionally ``inbound:outbound`` to rename
-# on the way out. Empty (default) = disabled. Example: "X-Cookie-dscrowd.token_key".
-MCP_FORWARD_REQUEST_HEADERS = os.getenv("MCP_FORWARD_REQUEST_HEADERS", "")
+# Generalized per-request MCP context. A JSON object template whose values may
+# contain ``{{user}}`` (the server-authoritative authenticated identity) and
+# ``{{header:NAME}}`` (an inbound request header, e.g. a caller-owned session
+# token the downstream MCP server validates itself). The gateway resolves the
+# template per request and injects the result as ONE JSON header
+# (``MCP_FORWARD_CONTEXT_HEADER``) into every http/SSE MCP server config, so the
+# downstream can read whatever keys it needs — adding a new value is a config-only
+# change (add a key to the JSON), never a code change. Keys whose resolved value
+# is empty are dropped. Empty (default) = disabled.
+# Example: {"user_id":"{{user}}","dscrowd_token":"{{header:X-Cookie-dscrowd.token_key}}"}
+#
+# Identity vs credential: use ``{{user}}`` (not ``{{header:...}}``) for identity —
+# it is derived server-side and cannot be spoofed. ``{{header:...}}`` is for the
+# caller's own bearer credentials, which the downstream authenticates.
+MCP_FORWARD_CONTEXT = os.getenv("MCP_FORWARD_CONTEXT", "")
+MCP_FORWARD_CONTEXT_HEADER = os.getenv("MCP_FORWARD_CONTEXT_HEADER", "X-MCP-Context")
 
 
-def parse_mcp_forward_request_headers() -> list[tuple[str, str]]:
-    """Parse ``MCP_FORWARD_REQUEST_HEADERS`` into ``(inbound, outbound)`` pairs.
+_MCP_CONTEXT_TOKEN_RE = re.compile(r"\{\{\s*(user|header:[^}]+?)\s*\}\}")
 
-    Read from the environment on each call so runtime/test overrides take effect
-    without a module reload (mirrors :func:`is_text_only_model`).
+
+def _resolve_mcp_context_value(template, user, header_getter) -> str:
+    """Substitute ``{{user}}`` / ``{{header:NAME}}`` tokens in *template*."""
+
+    def repl(match):
+        token = match.group(1).strip()
+        if token == "user":
+            return user or ""
+        name = token[len("header:") :].strip()
+        value = header_getter(name) if header_getter else None
+        return value or ""
+
+    return _MCP_CONTEXT_TOKEN_RE.sub(repl, template)
+
+
+def build_mcp_context_headers(user, header_getter) -> dict:
+    """Resolve ``MCP_FORWARD_CONTEXT`` into the single JSON context header.
+
+    *header_getter* is a callable ``name -> value | None`` (e.g.
+    ``request.headers.get``). Read from the environment on each call so
+    runtime/test overrides take effect without a module reload. Returns an empty
+    dict when disabled, misconfigured, or nothing resolves to a non-empty value.
     """
-    raw = os.getenv("MCP_FORWARD_REQUEST_HEADERS", "")
-    pairs: list[tuple[str, str]] = []
-    for entry in raw.split(","):
-        entry = entry.strip()
-        if not entry:
+    raw = os.getenv("MCP_FORWARD_CONTEXT", "").strip()
+    if not raw:
+        return {}
+    try:
+        template = json.loads(raw)
+    except (ValueError, TypeError):
+        return {}
+    if not isinstance(template, dict):
+        return {}
+
+    resolved = {}
+    for key, value in template.items():
+        if not isinstance(value, str):
             continue
-        if ":" in entry:
-            inbound, outbound = (part.strip() for part in entry.split(":", 1))
-        else:
-            inbound = outbound = entry
-        if inbound and outbound:
-            pairs.append((inbound, outbound))
-    return pairs
+        out = _resolve_mcp_context_value(value, user, header_getter)
+        if out:
+            resolved[key] = out
+    if not resolved:
+        return {}
+
+    header_name = os.getenv("MCP_FORWARD_CONTEXT_HEADER", "X-MCP-Context").strip()
+    header_name = header_name or "X-MCP-Context"
+    return {header_name: json.dumps(resolved, ensure_ascii=True, separators=(",", ":"))}
 
 
 # MCP connection-test (admin diagnostics). Short + bounded so a hung server

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -803,25 +803,19 @@ async def _refresh_existing_client_policy(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
-def _collect_mcp_forward_headers(request: Request) -> Dict[str, str]:
-    """Pick configured inbound headers to pass through to MCP servers.
+def _collect_mcp_forward_headers(
+    request: Request, body: ResponseCreateRequest
+) -> Dict[str, str]:
+    """Build the per-request MCP context header from ``MCP_FORWARD_CONTEXT``.
 
-    See ``MCP_FORWARD_REQUEST_HEADERS``. These carry the caller's own
-    credentials (e.g. a session token) that the downstream MCP server
-    validates itself, so forwarding the inbound value verbatim is safe —
-    unlike the user *identity* header, which the gateway derives server-side.
+    Resolves ``{{user}}`` from the server-authoritative identity (``body.user``)
+    and ``{{header:NAME}}`` from inbound request headers (caller-owned
+    credentials the downstream MCP server validates itself), then returns a
+    single JSON header for injection into the MCP server configs.
     """
-    from src.constants import parse_mcp_forward_request_headers
+    from src.constants import build_mcp_context_headers
 
-    pairs = parse_mcp_forward_request_headers()
-    if not pairs:
-        return {}
-    result: Dict[str, str] = {}
-    for inbound, outbound in pairs:
-        value = request.headers.get(inbound)
-        if value:
-            result[outbound] = value
-    return result
+    return build_mcp_context_headers(body.user, request.headers.get)
 
 
 async def _ensure_response_session_client(
@@ -1356,8 +1350,8 @@ async def create_response(
     validate_model_vision_support(body, resolved)
     _validate_output_format_backend(_response_output_format(body), resolved.backend)
 
-    # Inbound headers to pass through to MCP servers (caller-owned credentials).
-    forward_headers = _collect_mcp_forward_headers(request)
+    # Per-request MCP context header (identity + caller-owned credentials).
+    forward_headers = _collect_mcp_forward_headers(request, body)
 
     is_new_session = body.previous_response_id is None
     _validate_response_continuation(body)

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -808,10 +808,11 @@ def _collect_mcp_forward_headers(
 ) -> Dict[str, str]:
     """Build the per-request MCP context header from ``MCP_FORWARD_CONTEXT``.
 
-    Resolves ``{{user}}`` from the server-authoritative identity (``body.user``)
-    and ``{{header:NAME}}`` from inbound request headers (caller-owned
-    credentials the downstream MCP server validates itself), then returns a
-    single JSON header for injection into the MCP server configs.
+    Resolves ``{{user}}`` from the request identity (``body.user`` — trustworthy
+    only when set by a trusted caller, not a direct API caller) and
+    ``{{header:NAME}}`` from inbound request headers (caller-owned credentials
+    the downstream MCP server validates itself), then returns a single JSON
+    header for injection into the MCP server configs.
     """
     from src.constants import build_mcp_context_headers
 
@@ -1351,7 +1352,13 @@ async def create_response(
     _validate_output_format_backend(_response_output_format(body), resolved.backend)
 
     # Per-request MCP context header (identity + caller-owned credentials).
-    forward_headers = _collect_mcp_forward_headers(request, body)
+    # Only the claude backend consumes it, so skip the env-read + JSON parse for
+    # codex/opencode.
+    forward_headers = (
+        _collect_mcp_forward_headers(request, body)
+        if resolved.backend == "claude"
+        else {}
+    )
 
     is_new_session = body.previous_response_id is None
     _validate_response_continuation(body)

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -803,6 +803,27 @@ async def _refresh_existing_client_policy(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
+def _collect_mcp_forward_headers(request: Request) -> Dict[str, str]:
+    """Pick configured inbound headers to pass through to MCP servers.
+
+    See ``MCP_FORWARD_REQUEST_HEADERS``. These carry the caller's own
+    credentials (e.g. a session token) that the downstream MCP server
+    validates itself, so forwarding the inbound value verbatim is safe —
+    unlike the user *identity* header, which the gateway derives server-side.
+    """
+    from src.constants import parse_mcp_forward_request_headers
+
+    pairs = parse_mcp_forward_request_headers()
+    if not pairs:
+        return {}
+    result: Dict[str, str] = {}
+    for inbound, outbound in pairs:
+        value = request.headers.get(inbound)
+        if value:
+            result[outbound] = value
+    return result
+
+
 async def _ensure_response_session_client(
     body: ResponseCreateRequest,
     resolved: ResolvedModel,
@@ -812,6 +833,7 @@ async def _ensure_response_session_client(
     is_new_session: bool,
     system_prompt: Optional[str],
     workspace_str: str,
+    forward_headers: Optional[Dict[str, str]] = None,
 ) -> None:
     """Create the persistent backend client after session preflight has passed."""
     output_format = _response_output_format(body)
@@ -837,6 +859,8 @@ async def _ensure_response_session_client(
     # gate it so codex/opencode create_client() aren't passed an unknown kwarg.
     if resolved.backend == "claude":
         create_kwargs["user"] = body.user
+        if forward_headers:
+            create_kwargs["forward_headers"] = forward_headers
     try:
         session.client = await backend.create_client(
             session=session,
@@ -1332,6 +1356,9 @@ async def create_response(
     validate_model_vision_support(body, resolved)
     _validate_output_format_backend(_response_output_format(body), resolved.backend)
 
+    # Inbound headers to pass through to MCP servers (caller-owned credentials).
+    forward_headers = _collect_mcp_forward_headers(request)
+
     is_new_session = body.previous_response_id is None
     _validate_response_continuation(body)
     session_id, session = _resolve_response_session(body, resolved.backend)
@@ -1397,6 +1424,7 @@ async def create_response(
                 is_new_session,
                 system_prompt,
                 workspace_str,
+                forward_headers=forward_headers,
             )
         except Exception:
             if preflight["lock_acquired"]:
@@ -1588,6 +1616,7 @@ async def create_response(
                 is_new_session,
                 system_prompt,
                 workspace_str,
+                forward_headers=forward_headers,
             )
             # Execute backend through the persistent client.
             chunks = []

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -832,6 +832,11 @@ async def _ensure_response_session_client(
     create_kwargs: Dict[str, Any] = {}
     if output_format is not None:
         create_kwargs["output_format"] = output_format
+    # Server-authoritative user identity for MCP header injection (persistent
+    # session path). Only the claude backend's create_client accepts ``user``;
+    # gate it so codex/opencode create_client() aren't passed an unknown kwarg.
+    if resolved.backend == "claude":
+        create_kwargs["user"] = body.user
     try:
         session.client = await backend.create_client(
             session=session,

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -849,13 +849,14 @@ async def _ensure_response_session_client(
     create_kwargs: Dict[str, Any] = {}
     if output_format is not None:
         create_kwargs["output_format"] = output_format
-    # Server-authoritative user identity for MCP header injection (persistent
-    # session path). Only the claude backend's create_client accepts ``user``;
-    # gate it so codex/opencode create_client() aren't passed an unknown kwarg.
+    # Per-request MCP header injection (persistent session path). ``user`` is
+    # consumed by the claude backend only (system-prompt identity); the resolved
+    # context header goes to both claude and codex. opencode's create_client
+    # accepts neither, so gate to avoid an unknown-kwarg TypeError.
     if resolved.backend == "claude":
         create_kwargs["user"] = body.user
-        if forward_headers:
-            create_kwargs["forward_headers"] = forward_headers
+    if resolved.backend in {"claude", "codex"} and forward_headers:
+        create_kwargs["forward_headers"] = forward_headers
     try:
         session.client = await backend.create_client(
             session=session,
@@ -1352,11 +1353,11 @@ async def create_response(
     _validate_output_format_backend(_response_output_format(body), resolved.backend)
 
     # Per-request MCP context header (identity + caller-owned credentials).
-    # Only the claude backend consumes it, so skip the env-read + JSON parse for
-    # codex/opencode.
+    # Only the claude and codex backends consume it, so skip the env-read + JSON
+    # parse for opencode.
     forward_headers = (
         _collect_mcp_forward_headers(request, body)
-        if resolved.backend == "claude"
+        if resolved.backend in {"claude", "codex"}
         else {}
     )
 

--- a/tests/test_claude_client_more_coverage.py
+++ b/tests/test_claude_client_more_coverage.py
@@ -6,6 +6,7 @@ Targets uncovered lines found in the 88%-coverage run:
 """
 
 import asyncio
+import json
 import os
 import tempfile
 from pathlib import Path
@@ -683,33 +684,75 @@ class TestInjectMcpUserHeader:
         assert cli._inject_mcp_user_header(mcp, None, {}) is mcp
 
 
-class TestParseMcpForwardRequestHeaders:
-    """MCP_FORWARD_REQUEST_HEADERS parsing (issue #124 follow-up)."""
+class TestBuildMcpContextHeaders:
+    """MCP_FORWARD_CONTEXT resolution into a single JSON header (issue #124)."""
 
-    def test_empty_returns_no_pairs(self, monkeypatch):
-        monkeypatch.delenv("MCP_FORWARD_REQUEST_HEADERS", raising=False)
-        from src.constants import parse_mcp_forward_request_headers
+    def _headers(self, **kw):
+        # Case-insensitive getter mirroring Starlette request.headers.get.
+        lowered = {k.lower(): v for k, v in kw.items()}
+        return lambda name: lowered.get(name.lower())
 
-        assert parse_mcp_forward_request_headers() == []
+    def test_disabled_when_unset(self, monkeypatch):
+        monkeypatch.delenv("MCP_FORWARD_CONTEXT", raising=False)
+        from src.constants import build_mcp_context_headers
 
-    def test_plain_names_map_to_themselves(self, monkeypatch):
-        monkeypatch.setenv("MCP_FORWARD_REQUEST_HEADERS", "X-A, X-B")
-        from src.constants import parse_mcp_forward_request_headers
+        assert build_mcp_context_headers("alice", self._headers()) == {}
 
-        assert parse_mcp_forward_request_headers() == [("X-A", "X-A"), ("X-B", "X-B")]
+    def test_resolves_user_and_header_tokens(self, monkeypatch):
+        monkeypatch.setenv(
+            "MCP_FORWARD_CONTEXT",
+            '{"user_id":"{{user}}","dscrowd_token":"{{header:X-Cookie-dscrowd.token_key}}"}',
+        )
+        monkeypatch.delenv("MCP_FORWARD_CONTEXT_HEADER", raising=False)
+        from src.constants import build_mcp_context_headers
 
-    def test_rename_syntax(self, monkeypatch):
-        monkeypatch.setenv("MCP_FORWARD_REQUEST_HEADERS", "X-In:X-Out, X-Same")
-        from src.constants import parse_mcp_forward_request_headers
+        out = build_mcp_context_headers(
+            "alice", self._headers(**{"X-Cookie-dscrowd.token_key": "tok123"})
+        )
+        assert set(out) == {"X-MCP-Context"}
+        payload = json.loads(out["X-MCP-Context"])
+        assert payload == {"user_id": "alice", "dscrowd_token": "tok123"}
 
-        assert parse_mcp_forward_request_headers() == [
-            ("X-In", "X-Out"),
-            ("X-Same", "X-Same"),
-        ]
+    def test_custom_header_name(self, monkeypatch):
+        monkeypatch.setenv("MCP_FORWARD_CONTEXT", '{"user_id":"{{user}}"}')
+        monkeypatch.setenv("MCP_FORWARD_CONTEXT_HEADER", "X-Ctx")
+        from src.constants import build_mcp_context_headers
 
-    def test_blank_and_malformed_entries_skipped(self, monkeypatch):
-        monkeypatch.setenv("MCP_FORWARD_REQUEST_HEADERS", " , X-A ,:, X-B: ")
-        from src.constants import parse_mcp_forward_request_headers
+        out = build_mcp_context_headers("bob", self._headers())
+        assert list(out) == ["X-Ctx"]
+        assert json.loads(out["X-Ctx"]) == {"user_id": "bob"}
 
-        # Empty entry, ":" (no names), and "X-B:" (empty outbound) are dropped.
-        assert parse_mcp_forward_request_headers() == [("X-A", "X-A")]
+    def test_empty_resolved_keys_dropped(self, monkeypatch):
+        # user is None and the header is absent -> both keys resolve empty -> {}.
+        monkeypatch.setenv(
+            "MCP_FORWARD_CONTEXT",
+            '{"user_id":"{{user}}","tok":"{{header:X-Missing}}"}',
+        )
+        from src.constants import build_mcp_context_headers
+
+        assert build_mcp_context_headers(None, self._headers()) == {}
+
+    def test_partial_resolution_keeps_present_keys(self, monkeypatch):
+        monkeypatch.setenv(
+            "MCP_FORWARD_CONTEXT",
+            '{"user_id":"{{user}}","tok":"{{header:X-Missing}}"}',
+        )
+        from src.constants import build_mcp_context_headers
+
+        out = build_mcp_context_headers("carol", self._headers())
+        assert json.loads(out["X-MCP-Context"]) == {"user_id": "carol"}
+
+    def test_invalid_json_is_ignored(self, monkeypatch):
+        monkeypatch.setenv("MCP_FORWARD_CONTEXT", "{not json")
+        from src.constants import build_mcp_context_headers
+
+        assert build_mcp_context_headers("alice", self._headers()) == {}
+
+    def test_non_ascii_value_is_json_escaped(self, monkeypatch):
+        monkeypatch.setenv("MCP_FORWARD_CONTEXT", '{"user_id":"{{user}}"}')
+        from src.constants import build_mcp_context_headers
+
+        out = build_mcp_context_headers("김철수", self._headers())
+        # ensure_ascii keeps the header value transmittable; value round-trips.
+        out["X-MCP-Context"].encode("ascii")  # must not raise
+        assert json.loads(out["X-MCP-Context"]) == {"user_id": "김철수"}

--- a/tests/test_claude_client_more_coverage.py
+++ b/tests/test_claude_client_more_coverage.py
@@ -603,12 +603,12 @@ class TestReceiveResponseFromClient:
 
 
 # ---------------------------------------------------------------------------
-# _inject_mcp_user_header() — per-request user header into MCP configs
+# inject_mcp_headers() — merge per-request context headers into MCP configs
 # ---------------------------------------------------------------------------
 
 
-class TestInjectMcpUserHeader:
-    """Gateway injects the authenticated user as an MCP header (issue #124)."""
+class TestInjectMcpHeaders:
+    """Shared header injection used by the claude + codex backends (issue #124)."""
 
     def _mcp(self):
         return {
@@ -617,81 +617,68 @@ class TestInjectMcpUserHeader:
             "sse1": {"type": "sse", "url": "y", "headers": {"A": "1"}},
         }
 
-    def test_disabled_when_header_unset(self, monkeypatch):
-        monkeypatch.setattr("src.constants.MCP_FORWARD_USER_HEADER", "")
-        cli = _make_cli()
+    def test_no_op_when_no_forward_headers(self):
+        from src.backends.mcp_headers import inject_mcp_headers
+
         mcp = self._mcp()
         # No-op returns the same object untouched.
-        assert cli._inject_mcp_user_header(mcp, "alice") is mcp
+        assert inject_mcp_headers(mcp, None) is mcp
+        assert inject_mcp_headers(mcp, {}) is mcp
 
-    def test_disabled_when_no_user(self, monkeypatch):
-        monkeypatch.setattr("src.constants.MCP_FORWARD_USER_HEADER", "X-OpenWebUI-User-Name")
-        cli = _make_cli()
+    def test_no_op_when_no_servers(self):
+        from src.backends.mcp_headers import inject_mcp_headers
+
+        assert inject_mcp_headers(None, {"X-A": "1"}) is None
+
+    def test_injects_into_http_and_sse_only(self):
+        from src.backends.mcp_headers import inject_mcp_headers
+
         mcp = self._mcp()
-        assert cli._inject_mcp_user_header(mcp, None) is mcp
+        out = inject_mcp_headers(mcp, {"X-Ctx": "v"})
 
-    def test_injects_into_http_and_sse_only(self, monkeypatch):
-        monkeypatch.setattr("src.constants.MCP_FORWARD_USER_HEADER", "X-OpenWebUI-User-Name")
-        cli = _make_cli()
-        mcp = self._mcp()
-        out = cli._inject_mcp_user_header(mcp, "alice")
-
-        assert out["ragaas"]["headers"] == {"X-OpenWebUI-User-Name": "alice"}
+        assert out["ragaas"]["headers"] == {"X-Ctx": "v"}
         # Existing headers preserved (merged, not clobbered).
-        assert out["sse1"]["headers"] == {"A": "1", "X-OpenWebUI-User-Name": "alice"}
+        assert out["sse1"]["headers"] == {"A": "1", "X-Ctx": "v"}
         # stdio servers have no headers key added.
         assert "headers" not in out["local"]
         # The shared config passed in is never mutated (deep-copied).
         assert "headers" not in mcp["ragaas"]
 
-    def test_non_ascii_user_is_quoted(self, monkeypatch):
-        monkeypatch.setattr("src.constants.MCP_FORWARD_USER_HEADER", "X-User")
-        cli = _make_cli()
-        out = cli._inject_mcp_user_header(self._mcp(), "김철수")
-        # Value is percent-encoded so it survives as an HTTP header.
+    def test_non_ascii_value_is_quoted(self):
+        from src.backends.mcp_headers import inject_mcp_headers
+
+        out = inject_mcp_headers(self._mcp(), {"X-User": "김철수"})
         assert out["ragaas"]["headers"]["X-User"].startswith("%")
         out["ragaas"]["headers"]["X-User"].encode("ascii")  # must not raise
 
-    def test_crlf_in_user_is_encoded_not_injected(self, monkeypatch):
+    def test_crlf_in_value_is_encoded_not_injected(self):
         # An ASCII value with CR/LF must be percent-encoded so it cannot smuggle
         # an extra header into the outbound MCP request (header injection).
-        monkeypatch.setattr("src.constants.MCP_FORWARD_USER_HEADER", "X-User")
-        cli = _make_cli()
-        out = cli._inject_mcp_user_header(self._mcp(), "alice\r\nX-Injected: evil")
+        from src.backends.mcp_headers import inject_mcp_headers
+
+        out = inject_mcp_headers(self._mcp(), {"X-User": "alice\r\nX-Injected: evil"})
         value = out["ragaas"]["headers"]["X-User"]
         assert "\r" not in value and "\n" not in value
         assert "%0" in value.upper()  # CR/LF percent-encoded
 
-    def test_forward_headers_injected_alongside_user(self, monkeypatch):
-        monkeypatch.setattr("src.constants.MCP_FORWARD_USER_HEADER", "X-OpenWebUI-User-Name")
-        cli = _make_cli()
-        out = cli._inject_mcp_user_header(
-            self._mcp(), "alice", {"X-Cookie-dscrowd.token_key": "tok123"}
-        )
-        assert out["ragaas"]["headers"] == {
-            "X-OpenWebUI-User-Name": "alice",
-            "X-Cookie-dscrowd.token_key": "tok123",
-        }
-        # Forwarded header rides http/SSE only; stdio untouched.
-        assert "headers" not in out["local"]
-        # Shared config never mutated.
-        assert "headers" not in self._mcp()["ragaas"]
+    def test_non_dict_existing_headers_is_skipped_with_warning(self, caplog):
+        from src.backends.mcp_headers import inject_mcp_headers
 
-    def test_forward_headers_independent_of_user_header(self, monkeypatch):
-        # Even with no user identity header configured, a forwarded credential
-        # header still reaches the MCP server.
-        monkeypatch.setattr("src.constants.MCP_FORWARD_USER_HEADER", "")
-        cli = _make_cli()
-        out = cli._inject_mcp_user_header(
-            self._mcp(), None, {"X-Cookie-dscrowd.token_key": "tok123"}
-        )
-        assert out["ragaas"]["headers"] == {"X-Cookie-dscrowd.token_key": "tok123"}
+        mcp = {"bad": {"type": "http", "url": "u", "headers": "Authorization: x"}}
+        with caplog.at_level("WARNING"):
+            out = inject_mcp_headers(mcp, {"X-Ctx": "v"})
+        # The malformed server is left as-is (string headers untouched)...
+        assert out["bad"]["headers"] == "Authorization: x"
+        # ...and the skip is surfaced, not silent.
+        assert any("non-dict 'headers'" in r.message for r in caplog.records)
 
-    def test_no_op_when_nothing_to_inject(self, monkeypatch):
-        monkeypatch.setattr("src.constants.MCP_FORWARD_USER_HEADER", "")
-        cli = _make_cli()
-        mcp = self._mcp()
-        assert cli._inject_mcp_user_header(mcp, None, {}) is mcp
+    def test_url_only_server_without_type_is_treated_as_stdio(self):
+        # Documents current behavior: a bare {"url": ...} with no explicit type
+        # defaults to stdio and is NOT injected.
+        from src.backends.mcp_headers import inject_mcp_headers
+
+        out = inject_mcp_headers({"s": {"url": "http://x/mcp"}}, {"X-Ctx": "v"})
+        assert "headers" not in out["s"]
 
 
 class TestBuildMcpContextHeaders:

--- a/tests/test_claude_client_more_coverage.py
+++ b/tests/test_claude_client_more_coverage.py
@@ -652,6 +652,16 @@ class TestInjectMcpUserHeader:
         assert out["ragaas"]["headers"]["X-User"].startswith("%")
         out["ragaas"]["headers"]["X-User"].encode("ascii")  # must not raise
 
+    def test_crlf_in_user_is_encoded_not_injected(self, monkeypatch):
+        # An ASCII value with CR/LF must be percent-encoded so it cannot smuggle
+        # an extra header into the outbound MCP request (header injection).
+        monkeypatch.setattr("src.constants.MCP_FORWARD_USER_HEADER", "X-User")
+        cli = _make_cli()
+        out = cli._inject_mcp_user_header(self._mcp(), "alice\r\nX-Injected: evil")
+        value = out["ragaas"]["headers"]["X-User"]
+        assert "\r" not in value and "\n" not in value
+        assert "%0" in value.upper()  # CR/LF percent-encoded
+
     def test_forward_headers_injected_alongside_user(self, monkeypatch):
         monkeypatch.setattr("src.constants.MCP_FORWARD_USER_HEADER", "X-OpenWebUI-User-Name")
         cli = _make_cli()
@@ -741,6 +751,14 @@ class TestBuildMcpContextHeaders:
 
         out = build_mcp_context_headers("carol", self._headers())
         assert json.loads(out["X-MCP-Context"]) == {"user_id": "carol"}
+
+    def test_empty_header_name_token_does_not_leak(self, monkeypatch):
+        # A misconfigured {{header:}} must resolve to "" (key dropped), never
+        # leak the literal token into the downstream payload.
+        monkeypatch.setenv("MCP_FORWARD_CONTEXT", '{"tok":"{{header:}}"}')
+        from src.constants import build_mcp_context_headers
+
+        assert build_mcp_context_headers("alice", self._headers()) == {}
 
     def test_invalid_json_is_ignored(self, monkeypatch):
         monkeypatch.setenv("MCP_FORWARD_CONTEXT", "{not json")

--- a/tests/test_claude_client_more_coverage.py
+++ b/tests/test_claude_client_more_coverage.py
@@ -650,3 +650,66 @@ class TestInjectMcpUserHeader:
         # Value is percent-encoded so it survives as an HTTP header.
         assert out["ragaas"]["headers"]["X-User"].startswith("%")
         out["ragaas"]["headers"]["X-User"].encode("ascii")  # must not raise
+
+    def test_forward_headers_injected_alongside_user(self, monkeypatch):
+        monkeypatch.setattr("src.constants.MCP_FORWARD_USER_HEADER", "X-OpenWebUI-User-Name")
+        cli = _make_cli()
+        out = cli._inject_mcp_user_header(
+            self._mcp(), "alice", {"X-Cookie-dscrowd.token_key": "tok123"}
+        )
+        assert out["ragaas"]["headers"] == {
+            "X-OpenWebUI-User-Name": "alice",
+            "X-Cookie-dscrowd.token_key": "tok123",
+        }
+        # Forwarded header rides http/SSE only; stdio untouched.
+        assert "headers" not in out["local"]
+        # Shared config never mutated.
+        assert "headers" not in self._mcp()["ragaas"]
+
+    def test_forward_headers_independent_of_user_header(self, monkeypatch):
+        # Even with no user identity header configured, a forwarded credential
+        # header still reaches the MCP server.
+        monkeypatch.setattr("src.constants.MCP_FORWARD_USER_HEADER", "")
+        cli = _make_cli()
+        out = cli._inject_mcp_user_header(
+            self._mcp(), None, {"X-Cookie-dscrowd.token_key": "tok123"}
+        )
+        assert out["ragaas"]["headers"] == {"X-Cookie-dscrowd.token_key": "tok123"}
+
+    def test_no_op_when_nothing_to_inject(self, monkeypatch):
+        monkeypatch.setattr("src.constants.MCP_FORWARD_USER_HEADER", "")
+        cli = _make_cli()
+        mcp = self._mcp()
+        assert cli._inject_mcp_user_header(mcp, None, {}) is mcp
+
+
+class TestParseMcpForwardRequestHeaders:
+    """MCP_FORWARD_REQUEST_HEADERS parsing (issue #124 follow-up)."""
+
+    def test_empty_returns_no_pairs(self, monkeypatch):
+        monkeypatch.delenv("MCP_FORWARD_REQUEST_HEADERS", raising=False)
+        from src.constants import parse_mcp_forward_request_headers
+
+        assert parse_mcp_forward_request_headers() == []
+
+    def test_plain_names_map_to_themselves(self, monkeypatch):
+        monkeypatch.setenv("MCP_FORWARD_REQUEST_HEADERS", "X-A, X-B")
+        from src.constants import parse_mcp_forward_request_headers
+
+        assert parse_mcp_forward_request_headers() == [("X-A", "X-A"), ("X-B", "X-B")]
+
+    def test_rename_syntax(self, monkeypatch):
+        monkeypatch.setenv("MCP_FORWARD_REQUEST_HEADERS", "X-In:X-Out, X-Same")
+        from src.constants import parse_mcp_forward_request_headers
+
+        assert parse_mcp_forward_request_headers() == [
+            ("X-In", "X-Out"),
+            ("X-Same", "X-Same"),
+        ]
+
+    def test_blank_and_malformed_entries_skipped(self, monkeypatch):
+        monkeypatch.setenv("MCP_FORWARD_REQUEST_HEADERS", " , X-A ,:, X-B: ")
+        from src.constants import parse_mcp_forward_request_headers
+
+        # Empty entry, ":" (no names), and "X-B:" (empty outbound) are dropped.
+        assert parse_mcp_forward_request_headers() == [("X-A", "X-A")]

--- a/tests/test_claude_client_more_coverage.py
+++ b/tests/test_claude_client_more_coverage.py
@@ -599,3 +599,54 @@ class TestReceiveResponseFromClient:
 
         assert len(result) == 2
         assert result[0]["type"] == "assistant"
+
+
+# ---------------------------------------------------------------------------
+# _inject_mcp_user_header() — per-request user header into MCP configs
+# ---------------------------------------------------------------------------
+
+
+class TestInjectMcpUserHeader:
+    """Gateway injects the authenticated user as an MCP header (issue #124)."""
+
+    def _mcp(self):
+        return {
+            "ragaas": {"type": "http", "url": "http://127.0.0.1:10074/mcp"},
+            "local": {"type": "stdio", "command": "x"},
+            "sse1": {"type": "sse", "url": "y", "headers": {"A": "1"}},
+        }
+
+    def test_disabled_when_header_unset(self, monkeypatch):
+        monkeypatch.setattr("src.constants.MCP_FORWARD_USER_HEADER", "")
+        cli = _make_cli()
+        mcp = self._mcp()
+        # No-op returns the same object untouched.
+        assert cli._inject_mcp_user_header(mcp, "alice") is mcp
+
+    def test_disabled_when_no_user(self, monkeypatch):
+        monkeypatch.setattr("src.constants.MCP_FORWARD_USER_HEADER", "X-OpenWebUI-User-Name")
+        cli = _make_cli()
+        mcp = self._mcp()
+        assert cli._inject_mcp_user_header(mcp, None) is mcp
+
+    def test_injects_into_http_and_sse_only(self, monkeypatch):
+        monkeypatch.setattr("src.constants.MCP_FORWARD_USER_HEADER", "X-OpenWebUI-User-Name")
+        cli = _make_cli()
+        mcp = self._mcp()
+        out = cli._inject_mcp_user_header(mcp, "alice")
+
+        assert out["ragaas"]["headers"] == {"X-OpenWebUI-User-Name": "alice"}
+        # Existing headers preserved (merged, not clobbered).
+        assert out["sse1"]["headers"] == {"A": "1", "X-OpenWebUI-User-Name": "alice"}
+        # stdio servers have no headers key added.
+        assert "headers" not in out["local"]
+        # The shared config passed in is never mutated (deep-copied).
+        assert "headers" not in mcp["ragaas"]
+
+    def test_non_ascii_user_is_quoted(self, monkeypatch):
+        monkeypatch.setattr("src.constants.MCP_FORWARD_USER_HEADER", "X-User")
+        cli = _make_cli()
+        out = cli._inject_mcp_user_header(self._mcp(), "김철수")
+        # Value is percent-encoded so it survives as an HTTP header.
+        assert out["ragaas"]["headers"]["X-User"].startswith("%")
+        out["ragaas"]["headers"]["X-User"].encode("ascii")  # must not raise


### PR DESCRIPTION
Closes #124.

Closes the **gateway → MCP hop** from #124: downstream MCP servers (e.g. ragaas) can authorize **server-side**, out of the LLM's reach. A `user_id` *tool argument* is tamperable (the model can pass any id → privilege bypass); identity/credentials the gateway sets as an HTTP header on the MCP config are not. The header rides the **session-scoped** MCP connection, so subagents inherit it automatically (verified e2e in #124).

## Mechanism — a single JSON context header

`MCP_FORWARD_CONTEXT` is a JSON object template, resolved per request and injected as **one** header (`MCP_FORWARD_CONTEXT_HEADER`, default `X-MCP-Context`) into every http/SSE MCP server config (claude + codex backends).

```
MCP_FORWARD_CONTEXT={"user_id":"{{user}}","dscrowd_token":"{{header:X-Cookie-dscrowd.token_key}}"}
```

Value tokens:
- `{{user}}` — the authenticated identity (from `body.user`); use this for identity so it stays out of the LLM's reach. Its trust rests on `body.user` being set by a trusted caller (the pipe, from the authenticated `__user__`), **not** a direct API caller reaching the gateway.
- `{{header:NAME}}` — an inbound request header, a caller-owned bearer credential the downstream MCP server validates itself.
- literals.

Adding a new context value is a **config-only** change (add a key to the JSON) — never a gateway code change. Downstream tools read `X-MCP-Context` and pick the keys they need. Keys resolving to empty are dropped; the JSON is `ensure_ascii` so the header is always transmittable.

## What's in this PR

- **`src/constants.py`** — `MCP_FORWARD_CONTEXT` / `MCP_FORWARD_CONTEXT_HEADER` + template resolver (`{{user}}` / `{{header:NAME}}`).
- **`src/backends/mcp_headers.py`** (new) — shared `inject_mcp_headers()` + `header_safe()`, used by both the claude and codex backends so injection stays consistent. `header_safe` percent-encodes non-ascii **and** control chars (CR/LF/NUL) so a request-derived value can't inject extra headers. A server whose existing `headers` isn't a dict is skipped **with a warning**, not silently.
- **`src/backends/claude/client.py`** — thread `forward_headers` through `create_client → _build_sdk_options → _configure_mcp_servers`. This also fixes the persistent-session (`create_client`) path, which the one-shot path had but multi-turn sessions did not — so injection was previously a no-op in real deployments.
- **`src/backends/codex/client.py`** — codex `create_client` accepts `forward_headers` and injects into its http/SSE MCP configs before forwarding to the app-server.
- **`src/routes/responses.py`** — resolve the context header per request (claude + codex only) and pass it into `create_client`; opencode is gated out (its `create_client` takes neither kwarg).

## Compatibility

No-op unless `MCP_FORWARD_CONTEXT` is set → zero behavior change for existing deployments. opencode never receives the new kwargs.

## Related #124 work (separate repos, done)

- **pipe/frontend**: identity derived from the authenticated `__user__`, not a client-supplied header.
- **ragaas**: drops the `user_id` tool argument and reads `user_id` (and other keys) from the `X-MCP-Context` JSON — migrated and confirmed working.

## Notes

- **codex** injection rides on the codex app-server honoring a per-server `headers` field on http MCP configs — worth confirming against your app-server version.
- **Session lifetime**: MCP connections are session-scoped, so header values are fixed at `create_client` time. A fresh client (idle expiry / restart / rehydrate) re-injects the current request's values, so resuming after a gap picks up a rotated credential; a continuously-active session outliving a short-lived credential's TTL is the only edge case.

## Tests

`tests/test_claude_client_more_coverage.py`: `TestInjectMcpHeaders` (http/sse-only injection, shared config not mutated, non-ascii + CRLF encoded, non-dict `headers` warns, url-only server behavior) and `TestBuildMcpContextHeaders` (token resolution, custom header name, empty-key drop, invalid-JSON ignore, non-ascii escape, empty `{{header:}}` doesn't leak). 312 passed incl. codex. `py_compile` clean; added lines are black-88 clean (repo has pre-existing black-version drift, so no repo-wide reformat, per CLAUDE.md). One unrelated pre-existing failure (`test_create_client_sets_hooks`, PreToolUse matcher count) is not touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFsj3J7EAZNr1TKZXYqoqm