### PR TITLE
feat(streaming): forward task_updated events; add task_type to task_started

### DIFF
--- a/docs/streaming-events.md
+++ b/docs/streaming-events.md
@@ -255,6 +255,8 @@ name when applicable. Both are `null` on CLI versions that don't report them.
   "status": "killed",
   "patch": { "status": "killed", "end_time": "2026-07-06T00:00:00Z" },
   "session_id": null,
+  "tool_use_id": null,
+  "parent_tool_use_id": null,
   "sequence_number": 11
 }
 ```
@@ -266,8 +268,10 @@ teammates. Clients tracking active tasks should clear a task on a terminal
 `status` from *either* event. Statuses are passed through raw: `task_updated`
 reports `killed` where `task_notification` would report `stopped`; terminal
 values across both are `completed`, `failed`, `stopped`, `killed`. Unlike the
-other task events, `task_updated` carries no `tool_use_id` on the wire, so it
-is forwarded regardless of `SUBAGENT_STREAM_PROGRESS`.
+other task events, `task_updated` is a registry-level patch not tied to a
+spawning `Task` tool call: the CLI reports no `tool_use_id` for it, so it is
+forwarded regardless of `SUBAGENT_STREAM_PROGRESS`. The `tool_use_id` /
+`parent_tool_use_id` keys are still present in the event JSON — always `null`.
 
 Subagent visibility is controlled by:
 

--- a/docs/streaming-events.md
+++ b/docs/streaming-events.md
@@ -42,6 +42,7 @@ response.tool_result            # zero or more
 response.task_started           # zero or more
 response.task_progress          # zero or more
 response.task_notification      # zero or more
+response.task_updated           # zero or more
 response.hook_event             # zero or more (liveness)
 response.compaction             # zero or more (liveness)
 response.output_text.done
@@ -214,9 +215,16 @@ Subagent task system messages are forwarded as structured progress events:
   "task_id": "task_abc123",
   "description": "Research API patterns",
   "session_id": "sdk-session-id",
+  "task_type": "local_agent",
+  "subagent_type": "Explore",
   "sequence_number": 8
 }
 ```
+
+`task_type` distinguishes what kind of task spawned: `local_agent` for a
+regular subagent, `in_process_teammate` for an agent-team teammate,
+`local_workflow` for a workflow run. `subagent_type` is the agent definition
+name when applicable. Both are `null` on CLI versions that don't report them.
 
 ```json
 {
@@ -239,6 +247,27 @@ Subagent task system messages are forwarded as structured progress events:
   "sequence_number": 10
 }
 ```
+
+```json
+{
+  "type": "response.task_updated",
+  "task_id": "task_abc123",
+  "status": "killed",
+  "patch": { "status": "killed", "end_time": "2026-07-06T00:00:00Z" },
+  "session_id": null,
+  "sequence_number": 11
+}
+```
+
+`response.task_updated` mirrors the SDK's task-registry patches. A task's
+terminal state can arrive **only** here, with no `response.task_notification`
+— e.g. a task killed via `TaskStop`, background tasks, and in-process
+teammates. Clients tracking active tasks should clear a task on a terminal
+`status` from *either* event. Statuses are passed through raw: `task_updated`
+reports `killed` where `task_notification` would report `stopped`; terminal
+values across both are `completed`, `failed`, `stopped`, `killed`. Unlike the
+other task events, `task_updated` carries no `tool_use_id` on the wire, so it
+is forwarded regardless of `SUBAGENT_STREAM_PROGRESS`.
 
 Subagent visibility is controlled by:
 

--- a/src/chat_page.py
+++ b/src/chat_page.py
@@ -1183,7 +1183,8 @@ function attachToolResult(card, content, isError) {
 }
 
 // Maintain ONE live status line per subagent, nested under the spawning agent,
-// updated in place across task_started / task_progress / task_notification.
+// updated in place across task_started / task_progress / task_notification /
+// task_updated.
 function upsertTaskStatus(evt) {
   const taskType = String(evt.type || '').slice('response.'.length);
   const parentId = evt.parent_tool_use_id || evt.tool_use_id;
@@ -1198,6 +1199,13 @@ function upsertTaskStatus(evt) {
   } else if (taskType === 'task_notification') {
     state = evt.status === 'failed' ? 'error' : 'done';
     text = (evt.status || 'done') + (evt.summary ? ' · ' + evt.summary : '');
+  } else if (taskType === 'task_updated') {
+    const patch = evt.patch && typeof evt.patch === 'object' ? evt.patch : {};
+    const status = evt.status || patch.status || 'updated';
+    const detail = evt.summary || patch.summary || patch.description || '';
+    const isTerminal = ['completed', 'failed', 'stopped', 'killed'].includes(status);
+    state = status === 'failed' ? 'error' : (isTerminal ? 'done' : 'running');
+    text = status + (detail ? ' · ' + detail : '');
   } else {
     return;
   }

--- a/src/constants.py
+++ b/src/constants.py
@@ -91,6 +91,8 @@ SSE_KEEPALIVE_INTERVAL = parse_int_env("SSE_KEEPALIVE_INTERVAL", 15)
 #   Default true — clients can render "View Result" for subagent tool calls.
 # SUBAGENT_STREAM_PROGRESS: Forward task_started/task_progress/task_notification events.
 #   Default true — clients can show subagent execution progress.
+#   Note: task_updated is a registry-level patch with no tool_use_id, so it bypasses
+#   this gate and is always forwarded (a task's terminal state must not be lost).
 SUBAGENT_STREAM_TEXT = parse_bool_env("SUBAGENT_STREAM_TEXT", "false")
 SUBAGENT_STREAM_TOOL_BLOCKS = parse_bool_env("SUBAGENT_STREAM_TOOL_BLOCKS", "true")
 SUBAGENT_STREAM_PROGRESS = parse_bool_env("SUBAGENT_STREAM_PROGRESS", "true")

--- a/src/sse_builders.py
+++ b/src/sse_builders.py
@@ -45,16 +45,24 @@ def _build_task_event(chunk: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     nests progress under, so we surface it as ``parent_tool_use_id`` (the field
     every other event uses for attribution). An explicit ``parent_tool_use_id``
     on the chunk still wins, for forward-compatibility and synthetic callers.
+    ``task_updated`` is a task-registry patch and carries neither id on the
+    wire; the same derivation applies if a caller supplies them.
     """
     subtype = chunk.get("subtype")
     tool_use_id = chunk.get("tool_use_id")
     parent_tool_use_id = chunk.get("parent_tool_use_id") or tool_use_id
+    # SDK-typed chunks put task_type at the top level and keep the raw CLI
+    # payload (incl. subagent_type) under ``data``; raw dict chunks carry both
+    # at the top level.
+    data = chunk.get("data") if isinstance(chunk.get("data"), dict) else {}
     if subtype == "task_started":
         return {
             "type": "task_started",
             "task_id": chunk.get("task_id", ""),
             "description": chunk.get("description", ""),
             "session_id": chunk.get("session_id", ""),
+            "task_type": chunk.get("task_type") or data.get("task_type"),
+            "subagent_type": chunk.get("subagent_type") or data.get("subagent_type"),
             "tool_use_id": tool_use_id,
             "parent_tool_use_id": parent_tool_use_id,
         }
@@ -75,6 +83,22 @@ def _build_task_event(chunk: Dict[str, Any]) -> Optional[Dict[str, Any]]:
             "status": chunk.get("status", ""),
             "summary": chunk.get("summary", ""),
             "usage": chunk.get("usage"),
+            "tool_use_id": tool_use_id,
+            "parent_tool_use_id": parent_tool_use_id,
+        }
+    if subtype == "task_updated":
+        # Terminal state (completed/failed/killed) can arrive ONLY as a
+        # task_updated patch with no task_notification (e.g. a task killed via
+        # TaskStop, background tasks, in-process teammates), so dropping this
+        # subtype loses the task's ending. Status/patch are passed through raw
+        # (``killed`` is not mapped to ``stopped``), per gateway philosophy.
+        patch = chunk.get("patch") if isinstance(chunk.get("patch"), dict) else {}
+        return {
+            "type": "task_updated",
+            "task_id": chunk.get("task_id", ""),
+            "status": chunk.get("status") or patch.get("status"),
+            "patch": patch,
+            "session_id": chunk.get("session_id"),
             "tool_use_id": tool_use_id,
             "parent_tool_use_id": parent_tool_use_id,
         }

--- a/tests/test_admin_routes_coverage.py
+++ b/tests/test_admin_routes_coverage.py
@@ -143,6 +143,9 @@ class TestAdminChatPage:
         assert "function upsertTaskStatus(" in r.text
         assert "task-status-line" in r.text
         assert "parent_tool_use_id || evt.tool_use_id" in r.text
+        assert "task_updated" in r.text
+        assert "evt.status || patch.status || 'updated'" in r.text
+        assert "['completed', 'failed', 'stopped', 'killed'].includes(status)" in r.text
 
     def test_admin_chat_page_serves_login_gate_to_unauthenticated_clients(self):
         """Anonymous GET /admin/chat should return 200 with the inline auth gate."""

--- a/tests/test_streaming_coverage_unit.py
+++ b/tests/test_streaming_coverage_unit.py
@@ -300,7 +300,12 @@ class TestBuildTaskEventUnmatched:
     def test_propagates_parent_tool_use_id(self):
         """Subagent task events carry parent_tool_use_id so the UI can attribute
         them to the agent that spawned the subagent."""
-        for subtype in ("task_started", "task_progress", "task_notification"):
+        for subtype in (
+            "task_started",
+            "task_progress",
+            "task_notification",
+            "task_updated",
+        ):
             result = _build_task_event(
                 {"subtype": subtype, "task_id": "t1", "parent_tool_use_id": "agent-1"}
             )
@@ -310,7 +315,12 @@ class TestBuildTaskEventUnmatched:
         """The real SDK task messages expose ``tool_use_id`` (the spawning Task
         tool's id) and no ``parent_tool_use_id``. Surface it as
         parent_tool_use_id so the chat UI nests progress under the agent."""
-        for subtype in ("task_started", "task_progress", "task_notification"):
+        for subtype in (
+            "task_started",
+            "task_progress",
+            "task_notification",
+            "task_updated",
+        ):
             result = _build_task_event(
                 {"subtype": subtype, "task_id": "t1", "tool_use_id": "agent-1"}
             )
@@ -333,6 +343,79 @@ class TestBuildTaskEventUnmatched:
         """Top-level (main-agent) task events have no parent → None."""
         result = _build_task_event({"subtype": "task_started", "task_id": "t1"})
         assert result["parent_tool_use_id"] is None
+
+    def test_task_started_task_type_from_sdk_message(self):
+        """SDK TaskStartedMessage puts task_type at the top level and keeps the
+        raw payload (incl. subagent_type) under ``data``. Both must surface so
+        clients can tell teammate spawns from plain subagent tasks."""
+        result = _build_task_event(
+            {
+                "subtype": "task_started",
+                "task_id": "t1",
+                "task_type": "in_process_teammate",
+                "data": {
+                    "task_type": "in_process_teammate",
+                    "subagent_type": "researcher",
+                },
+            }
+        )
+        assert result["task_type"] == "in_process_teammate"
+        assert result["subagent_type"] == "researcher"
+
+    def test_task_started_task_type_from_raw_dict(self):
+        """Raw CLI dict chunks carry task_type/subagent_type at the top level."""
+        result = _build_task_event(
+            {
+                "subtype": "task_started",
+                "task_id": "t1",
+                "task_type": "local_agent",
+                "subagent_type": "Explore",
+            }
+        )
+        assert result["task_type"] == "local_agent"
+        assert result["subagent_type"] == "Explore"
+
+    def test_task_started_task_type_absent(self):
+        """Older CLIs without task_type still build the event (fields None)."""
+        result = _build_task_event({"subtype": "task_started", "task_id": "t1"})
+        assert result["task_type"] is None
+        assert result["subagent_type"] is None
+
+    def test_task_updated_passthrough(self):
+        """task_updated surfaces the raw registry patch; terminal statuses like
+        ``killed`` may arrive ONLY here (no task_notification), so the event
+        must carry enough to close out task tracking."""
+        result = _build_task_event(
+            {
+                "subtype": "task_updated",
+                "task_id": "t1",
+                "status": "killed",
+                "patch": {"status": "killed", "end_time": "2026-07-06T00:00:00Z"},
+                "session_id": "s1",
+            }
+        )
+        assert result["type"] == "task_updated"
+        assert result["task_id"] == "t1"
+        assert result["status"] == "killed"
+        assert result["patch"] == {
+            "status": "killed",
+            "end_time": "2026-07-06T00:00:00Z",
+        }
+        assert result["session_id"] == "s1"
+
+    def test_task_updated_status_falls_back_to_patch(self):
+        """Raw CLI chunks have no top-level status — derive it from the patch,
+        matching how the SDK's TaskUpdatedMessage populates ``.status``."""
+        result = _build_task_event(
+            {"subtype": "task_updated", "task_id": "t1", "patch": {"status": "completed"}}
+        )
+        assert result["status"] == "completed"
+
+    def test_task_updated_non_dict_patch(self):
+        """A malformed/absent patch never raises; status stays None."""
+        result = _build_task_event({"subtype": "task_updated", "task_id": "t1", "patch": None})
+        assert result["patch"] == {}
+        assert result["status"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_streaming_utils_unit.py
+++ b/tests/test_streaming_utils_unit.py
@@ -537,6 +537,13 @@ async def test_stream_response_chunks_task_events_as_custom_sse():
             "status": "completed",
             "summary": "Done",
         }
+        # Registry patch — the only terminal signal for killed/background tasks
+        yield {
+            "type": "system",
+            "subtype": "task_updated",
+            "task_id": "t2",
+            "patch": {"status": "killed"},
+        }
 
     stream_result = {}
     lines = [
@@ -567,6 +574,15 @@ async def test_stream_response_chunks_task_events_as_custom_sse():
     task_done = next(p for et, p in parsed if et == "response.task_notification")
     assert task_done["type"] == "response.task_notification"
     assert task_done["status"] == "completed"
+
+    # task_updated is forwarded even without a tool_use_id (registry-level
+    # event) — status derived from the patch, raw patch passed through.
+    assert "response.task_updated" in event_types
+    task_updated = next(p for et, p in parsed if et == "response.task_updated")
+    assert task_updated["type"] == "response.task_updated"
+    assert task_updated["task_id"] == "t2"
+    assert task_updated["status"] == "killed"
+    assert task_updated["patch"] == {"status": "killed"}
 
     # Task-only stream has no assistant text → signals empty via stream_result.
     # The route converts that into a response.failed event (see


### PR DESCRIPTION
## Why

A task's terminal state (`completed`/`failed`/`killed`) can arrive **only** as a `system`/`task_updated` registry patch with no accompanying `task_notification` — e.g. a task killed via `TaskStop`, background tasks, and in-process agent-team teammates. The gateway dropped that subtype entirely, so downstream clients tracking active tasks could never see those tasks end. (The SDK's `TaskUpdatedMessage` docstring warns about exactly this.)

Additionally, `task_started` events on the wire carry `task_type` (`local_agent`, `in_process_teammate`, `local_workflow`) and `subagent_type`, but the gateway didn't forward them — clients couldn't distinguish a teammate spawn from a plain subagent task.

## What

- `_build_task_event` now maps `task_updated` → `response.task_updated`, with raw `status`/`patch` passthrough (`killed` is **not** remapped to `stopped`, per gateway pass-through philosophy). Status falls back to `patch.status` for raw dict chunks, matching how the SDK populates `TaskUpdatedMessage.status`. It carries no `tool_use_id` on the wire, so it is forwarded regardless of `SUBAGENT_STREAM_PROGRESS`.
- `response.task_started` now includes `task_type` / `subagent_type`, sourced from the top level (raw CLI dicts) or the `data` payload (SDK-typed messages). `null` on CLI versions that don't report them.
- `docs/streaming-events.md`: documents the new event, the dual status vocabulary (`stopped` vs `killed`), and the "clear tasks on terminal status from *either* event" client guidance.
- Tests: `task_updated` passthrough / patch-status fallback / malformed patch, `task_type` sourcing (SDK-typed, raw dict, absent), `task_updated` included in the parent_tool_use_id derivation loops, and an end-to-end streaming assertion that `response.task_updated` is emitted.

## Verification

- Verified against the pinned `claude-agent-sdk` 0.2.108 (bundled CLI 2.1.187) by inspecting the CLI's actual emission sites; the task/teammate event surface is byte-identical through SDK 0.2.110 (CLI 2.1.191).
- Full suite: 2729 passed; the 3 failures on this machine (`test_docker_packaging`, `test_create_client_sets_hooks`, `test_get_summary_on_sqlite`) reproduce on clean `main` and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)