### PR TITLE
feat(workspace): Open Terminal-compatible read-only file server

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -603,6 +603,12 @@ app.include_router(sessions_router)
 app.include_router(general_router)
 app.include_router(admin_router)
 
+# Open Terminal-compatible read-only file server over per-user workspaces, so
+# open-webui can browse a user's Claude workspace in its file-explorer sidebar.
+from src.routes.terminal_files import router as terminal_files_router  # noqa: E402
+
+app.include_router(terminal_files_router)
+
 # Anthropic Messages SSE sanitizer for upstream LiteLLM-like proxies that emit
 # non-spec-conforming streams (LiteLLM #21128). The route is always mounted so
 # the admin panel can flip it on/off at runtime; the handler short-circuits to

--- a/src/routes/terminal_files.py
+++ b/src/routes/terminal_files.py
@@ -1,0 +1,193 @@
+"""Open Terminal-compatible, read-only file server over per-user Claude workspaces.
+
+Implements the subset of the open-webui "Open Terminal" server HTTP contract that
+the ``FileNav`` right-sidebar explorer needs to BROWSE and PREVIEW files, scoped
+to a single user's Claude workspace. It is **read-only**: no write/exec endpoints
+are served, so the gateway can be registered in open-webui as a terminal
+connection and its workspace browsed exactly as the agent sees it.
+
+Contract (what FileNav calls):
+- ``GET /api/config``                 -> ``{"features": {"terminal": false}}`` (handshake)
+- ``GET /files/cwd``                  -> ``{"cwd": "/"}`` (workspace root is the virtual "/")
+- ``GET /files/list?directory=<p>``   -> ``{"entries": [{name,type,size,modified}]}``
+- ``GET /files/read?path=<p>``        -> text ``{path,total_lines,content}`` | raw bytes (binary)
+- ``GET /files/view?path=<p>``        -> raw bytes (download)
+
+Identity: the open-webui backend proxy injects ``X-OpenWebUI-User-Name`` — the
+same identity the pipe forwards to ``/v1/responses`` — so the workspace resolves
+to the very files the agent wrote.
+
+Security:
+- ``API_KEY`` MUST be configured; otherwise ``verify_api_key`` is a no-op and
+  these endpoints would expose every user's files unauthenticated, so we fail
+  closed here.
+- Every path is confined to the single workspace root via ``_safe_resolve``
+  (``Path.resolve()`` collapses ``..`` and follows symlinks before the
+  containment check). No extra roots (never ``~/.claude`` etc.).
+"""
+
+import mimetypes
+import os
+import stat as stat_module
+from pathlib import Path
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from fastapi.responses import FileResponse
+from fastapi.security import HTTPAuthorizationCredentials
+
+from src.auth import auth_manager, security, verify_api_key
+from src.workspace_manager import workspace_manager
+
+router = APIRouter(tags=["workspace-files"])
+
+_USER_HEADER = "x-openwebui-user-name"
+_BACKEND = "claude"
+# Cap in-band text previews; larger files must be fetched via /files/view.
+_MAX_READ_BYTES = 5 * 1024 * 1024
+
+
+def _ensure_api_key() -> None:
+    """Fail closed unless an API key is configured (verify_api_key no-ops without one)."""
+    if not auth_manager.get_api_key():
+        raise HTTPException(
+            status_code=503,
+            detail="workspace file browser is disabled: API_KEY is not configured",
+        )
+
+
+def _require_user(request: Request) -> str:
+    user = (request.headers.get(_USER_HEADER) or "").strip()
+    if not user:
+        raise HTTPException(status_code=400, detail="missing user identity header")
+    return user
+
+
+def _workspace_root(user: str) -> Path:
+    try:
+        return workspace_manager.resolve(user, backend=_BACKEND)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="invalid user identity")
+
+
+def _safe_resolve(root: Path, rel: str) -> Optional[Path]:
+    """Resolve *rel* (relative to the workspace root) and confine it to that root.
+
+    ``rel`` is treated as workspace-relative; ``"/"`` or ``""`` is the root.
+    ``Path.resolve()`` collapses ``..`` and follows symlinks, so an escape via
+    either is caught by the ``relative_to`` containment check. Returns ``None``
+    on any escape or resolution error.
+    """
+    rel = (rel or "/").lstrip("/")
+    candidate = root / rel if rel else root
+    try:
+        resolved = candidate.resolve()
+        root_resolved = root.resolve()
+    except (OSError, RuntimeError):
+        return None
+    try:
+        resolved.relative_to(root_resolved)
+    except ValueError:
+        return None
+    return resolved
+
+
+@router.get("/api/config")
+async def terminal_config(
+    request: Request,
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+):
+    """Handshake: advertise a read-only, no-terminal file server."""
+    await verify_api_key(request, credentials)
+    _ensure_api_key()
+    return {"features": {"terminal": False}}
+
+
+@router.get("/files/cwd")
+async def get_cwd(
+    request: Request,
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+):
+    await verify_api_key(request, credentials)
+    _ensure_api_key()
+    _require_user(request)  # require identity even though the root is virtual "/"
+    return {"cwd": "/"}
+
+
+@router.get("/files/list")
+async def list_files(
+    request: Request,
+    directory: str = "/",
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+):
+    await verify_api_key(request, credentials)
+    _ensure_api_key()
+    root = _workspace_root(_require_user(request))
+    target = _safe_resolve(root, directory)
+    if target is None or not target.is_dir():
+        raise HTTPException(status_code=404, detail="directory not found")
+
+    entries = []
+    with os.scandir(target) as it:
+        for entry in it:
+            try:
+                st = entry.stat()  # follow symlinks; broken links are skipped
+            except OSError:
+                continue
+            entries.append(
+                {
+                    "name": entry.name,
+                    "type": "directory" if stat_module.S_ISDIR(st.st_mode) else "file",
+                    "size": st.st_size,
+                    "modified": int(st.st_mtime),
+                }
+            )
+    entries.sort(key=lambda e: (e["type"] != "directory", e["name"].lower()))
+    return {"entries": entries}
+
+
+@router.get("/files/read")
+async def read_file(
+    request: Request,
+    path: str,
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+):
+    await verify_api_key(request, credentials)
+    _ensure_api_key()
+    root = _workspace_root(_require_user(request))
+    target = _safe_resolve(root, path)
+    if target is None or not target.is_file():
+        raise HTTPException(status_code=404, detail="file not found")
+
+    if target.stat().st_size > _MAX_READ_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"file too large to preview (> {_MAX_READ_BYTES} bytes); use download",
+        )
+
+    data = target.read_bytes()
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError:
+        # Binary: return raw bytes so FileNav renders a preview / placeholder.
+        media = mimetypes.guess_type(target.name)[0] or "application/octet-stream"
+        return Response(content=data, media_type=media)
+
+    return {"path": path, "total_lines": text.count("\n") + 1, "content": text}
+
+
+@router.get("/files/view")
+async def view_file(
+    request: Request,
+    path: str,
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+):
+    await verify_api_key(request, credentials)
+    _ensure_api_key()
+    root = _workspace_root(_require_user(request))
+    target = _safe_resolve(root, path)
+    if target is None or not target.is_file():
+        raise HTTPException(status_code=404, detail="file not found")
+
+    media = mimetypes.guess_type(target.name)[0] or "application/octet-stream"
+    return FileResponse(target, media_type=media, filename=target.name)

--- a/tests/test_terminal_files.py
+++ b/tests/test_terminal_files.py
@@ -1,0 +1,138 @@
+"""Tests for the Open Terminal-compatible read-only workspace file server."""
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.routes.terminal_files import router
+from src.routes import terminal_files as tf
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    root = tmp_path / "alice" / "claude"
+    root.mkdir(parents=True)
+    (root / "notes.txt").write_text("hello\nworld\n")
+    (root / "sub").mkdir()
+    (root / "sub" / "inner.md").write_text("# inner")
+    (root / "blob.bin").write_bytes(b"\xff\xfe\x00\x01binary")
+    # A secret OUTSIDE the workspace root, reachable only via traversal.
+    (tmp_path / "secret.txt").write_text("TOP SECRET")
+    return root
+
+
+@pytest.fixture
+def client(workspace, monkeypatch):
+    monkeypatch.setattr(tf.auth_manager, "get_api_key", lambda: "testkey")
+
+    def _resolve(user, backend=None):
+        if user == "alice":
+            return workspace
+        raise ValueError("bad user")
+
+    monkeypatch.setattr(tf.workspace_manager, "resolve", _resolve)
+
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+_AUTH = {"Authorization": "Bearer testkey"}
+_USER = {"X-OpenWebUI-User-Name": "alice"}
+
+
+def test_config_advertises_readonly_no_terminal(client):
+    r = client.get("/api/config", headers=_AUTH)
+    assert r.status_code == 200
+    assert r.json() == {"features": {"terminal": False}}
+
+
+def test_cwd_is_virtual_root(client):
+    r = client.get("/files/cwd", headers={**_AUTH, **_USER})
+    assert r.status_code == 200
+    assert r.json()["cwd"] == "/"
+
+
+def test_list_root_sorts_dirs_first(client):
+    r = client.get("/files/list?directory=/", headers={**_AUTH, **_USER})
+    assert r.status_code == 200
+    entries = r.json()["entries"]
+    names = [e["name"] for e in entries]
+    assert names == ["sub", "blob.bin", "notes.txt"]  # dir first, then files a-z
+    sub = next(e for e in entries if e["name"] == "sub")
+    assert sub["type"] == "directory"
+    notes = next(e for e in entries if e["name"] == "notes.txt")
+    assert notes["type"] == "file" and notes["size"] == 12
+
+
+def test_list_subdirectory(client):
+    r = client.get("/files/list?directory=/sub", headers={**_AUTH, **_USER})
+    assert [e["name"] for e in r.json()["entries"]] == ["inner.md"]
+
+
+def test_read_text_returns_content_and_line_count(client):
+    r = client.get("/files/read?path=/notes.txt", headers={**_AUTH, **_USER})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["content"] == "hello\nworld\n"
+    assert body["total_lines"] == 3  # two lines + trailing newline
+
+
+def test_read_binary_returns_raw_bytes(client):
+    r = client.get("/files/read?path=/blob.bin", headers={**_AUTH, **_USER})
+    assert r.status_code == 200
+    assert r.content == b"\xff\xfe\x00\x01binary"
+    # Non-JSON content-type so the frontend renders a binary placeholder.
+    assert not r.headers["content-type"].startswith("application/json")
+
+
+def test_view_streams_file(client):
+    r = client.get("/files/view?path=/notes.txt", headers={**_AUTH, **_USER})
+    assert r.status_code == 200
+    assert r.content == b"hello\nworld\n"
+
+
+def test_path_traversal_is_blocked(client):
+    for p in ("/../secret.txt", "/../../secret.txt", "/sub/../../secret.txt"):
+        r = client.get(f"/files/read?path={p}", headers={**_AUTH, **_USER})
+        assert r.status_code == 404, p
+        assert "SECRET" not in r.text
+
+
+def test_missing_user_header_is_rejected(client):
+    r = client.get("/files/list?directory=/", headers=_AUTH)
+    assert r.status_code == 400
+
+
+def test_invalid_user_is_rejected(client):
+    r = client.get(
+        "/files/list?directory=/",
+        headers={**_AUTH, "X-OpenWebUI-User-Name": "../evil"},
+    )
+    assert r.status_code == 400
+
+
+def test_wrong_api_key_is_unauthorized(client):
+    r = client.get(
+        "/files/list?directory=/",
+        headers={"Authorization": "Bearer wrong", **_USER},
+    )
+    assert r.status_code == 401
+
+
+def test_fails_closed_when_api_key_unset(workspace, monkeypatch):
+    monkeypatch.setattr(tf.auth_manager, "get_api_key", lambda: "")
+    monkeypatch.setattr(tf.workspace_manager, "resolve", lambda user, backend=None: workspace)
+    app = FastAPI()
+    app.include_router(router)
+    c = TestClient(app)
+    # No API key configured -> the browser is disabled, not open to everyone.
+    r = c.get("/api/config")
+    assert r.status_code == 503
+
+
+def test_missing_file_is_404(client):
+    r = client.get("/files/read?path=/nope.txt", headers={**_AUTH, **_USER})
+    assert r.status_code == 404


### PR DESCRIPTION
Lets open-webui browse a user's Claude workspace in its right-sidebar file explorer (FileNav), showing exactly the files the agent writes. The gateway is registered in open-webui as an **Open Terminal** connection; this implements the read-only subset of the Open Terminal server HTTP contract that FileNav needs to browse + preview.

Pairs with the open-webui change that forwards `X-OpenWebUI-User-Name` to terminal servers (`Kyutinium/open-webui`).

## Endpoints (`src/routes/terminal_files.py`)

| Endpoint | Returns |
|---|---|
| `GET /api/config` | `{"features": {"terminal": false}}` (handshake) |
| `GET /files/cwd` | `{"cwd": "/"}` (workspace root = virtual `/`) |
| `GET /files/list?directory=<p>` | `{"entries": [{name,type,size,modified}]}` |
| `GET /files/read?path=<p>` | text `{path,total_lines,content}` \| raw bytes (binary) |
| `GET /files/view?path=<p>` | raw bytes (download) |

## Identity & scoping

Identity comes from the `X-OpenWebUI-User-Name` header (the same identity the pipe forwards to `/v1/responses`, injected server-side by the open-webui proxy — not spoofable by the browser). The workspace resolves via `workspace_manager.resolve(user, backend="claude")`, so each user sees only their own workspace, presented rooted at a virtual `/`.

## Security

- **Fails closed (503)** unless `API_KEY` is configured — `verify_api_key` is a no-op without one, and these endpoints expose files.
- Every path is confined to the single workspace root via `Path.resolve()` + `relative_to`, so `..` / symlink escapes are rejected. No extra roots (never `~/.claude`).
- **Read-only**: no write/exec endpoints are served.
- Auth: bearer `API_KEY` (the same key the pipe uses), enforced by `verify_api_key`.

## Scope / notes

- **claude backend only** for now (workspace resolved with `backend="claude"`); can extend to codex later.
- The connection is registered in open-webui admin (Integrations → Add Terminal Server): URL = gateway base, key = `API_KEY`, `auth_type=bearer`.
- FileNav still shows write buttons (its `TerminalFeatures` only gates the terminal/exec panel); those hit unimplemented paths → 404. Hiding them cleanly would need a small `readonly` feature flag on the open-webui side (follow-up).

## Tests

`tests/test_terminal_files.py` (13): config handshake, cwd, list (dirs-first sort), text/binary read, view, **path-traversal blocked**, missing/invalid user rejected, wrong key 401, **fail-closed when API_KEY unset**, 404 for missing file. App boots with the routes mounted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFsj3J7EAZNr1TKZXYqoqm

---
_Generated by [Claude Code](https://claude.ai/code/session_01LFsj3J7EAZNr1TKZXYqoqm)_