### PR TITLE
fix(streaming): non-serializable task_updated patch crashes SSE stream

### DIFF
--- a/src/sse_builders.py
+++ b/src/sse_builders.py
@@ -7,6 +7,18 @@ from src.constants import STREAM_COMPACTION_EVENTS, STREAM_HOOK_EVENTS
 from src.content_blocks import normalize_tool_result_for_sse
 
 
+def _sse_dumps(data: Any) -> str:
+    """JSON-serialize SSE event data, tolerating non-serializable values.
+
+    Some SDK payloads passed through verbatim (e.g. a ``task_updated`` registry
+    ``patch``, which can carry callables from in-process teammates/background
+    tasks) contain values that are not JSON-serializable. Coerce those to their
+    string form via ``default=str`` so a single stray field degrades gracefully
+    instead of raising ``TypeError`` and killing the entire SSE stream.
+    """
+    return json.dumps(data, default=str)
+
+
 def make_response_sse(
     event_type: str,
     response_obj: Optional[Any] = None,
@@ -33,7 +45,7 @@ def make_response_sse(
 
     data["sequence_number"] = sequence_number
 
-    return f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
+    return f"event: {event_type}\ndata: {_sse_dumps(data)}\n\n"
 
 
 def _build_task_event(chunk: Dict[str, Any]) -> Optional[Dict[str, Any]]:
@@ -109,7 +121,7 @@ def make_task_response_sse(task_event: Dict[str, Any], *, sequence_number: int =
     """Build an SSE line for Responses API with a custom task event type."""
     event_type = f"response.{task_event['type']}"
     data = {**task_event, "type": event_type, "sequence_number": sequence_number}
-    return f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
+    return f"event: {event_type}\ndata: {_sse_dumps(data)}\n\n"
 
 
 def _build_progress_event(chunk: Dict[str, Any]) -> Optional[Dict[str, Any]]:
@@ -195,7 +207,7 @@ def make_tool_use_started_response_sse(
     }
     if parent_tool_use_id:
         data["parent_tool_use_id"] = parent_tool_use_id
-    return f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
+    return f"event: {event_type}\ndata: {_sse_dumps(data)}\n\n"
 
 
 def make_tool_use_response_sse(
@@ -215,7 +227,7 @@ def make_tool_use_response_sse(
     }
     if parent_tool_use_id:
         data["parent_tool_use_id"] = parent_tool_use_id
-    return f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
+    return f"event: {event_type}\ndata: {_sse_dumps(data)}\n\n"
 
 
 def _normalize_tool_result(result_block) -> Dict[str, Any]:
@@ -236,7 +248,7 @@ def make_tool_result_response_sse(
     data["sequence_number"] = sequence_number
     if parent_tool_use_id:
         data["parent_tool_use_id"] = parent_tool_use_id
-    return f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
+    return f"event: {event_type}\ndata: {_sse_dumps(data)}\n\n"
 
 
 def make_function_call_response_sse(
@@ -262,4 +274,4 @@ def make_function_call_response_sse(
         "response_id": response_id,
         "item": item,
     }
-    return f"event: response.output_item.added\ndata: {json.dumps(event_data)}\n\n"
+    return f"event: response.output_item.added\ndata: {_sse_dumps(event_data)}\n\n"

--- a/tests/test_streaming_coverage_unit.py
+++ b/tests/test_streaming_coverage_unit.py
@@ -1148,3 +1148,27 @@ class TestStreamResponseChunksSDKUsage:
         usage = completed[1]["response"]["usage"]
         assert usage["input_tokens"] == 100
         assert usage["output_tokens"] == 50
+
+
+class TestTaskEventSerializationResilience:
+    """task_updated passes the SDK patch through raw; a callable in it must not
+    crash the SSE stream (regression: 'object of type function is not JSON
+    serializable')."""
+
+    def test_task_updated_with_callable_in_patch_does_not_crash(self):
+        from src.sse_builders import _build_task_event, make_task_response_sse
+
+        chunk = {
+            "subtype": "task_updated",
+            "task_id": "t1",
+            "status": "completed",
+            "patch": {"status": "completed", "on_done": lambda: None},
+        }
+        event = _build_task_event(chunk)
+        assert event is not None
+        line = make_task_response_sse(event, sequence_number=1)  # must not raise
+        payload = json.loads(line.split("data: ", 1)[1])
+        assert payload["type"] == "response.task_updated"
+        assert payload["status"] == "completed"
+        # The callable is coerced to a string rather than crashing serialization.
+        assert isinstance(payload["patch"]["on_done"], str)


### PR DESCRIPTION
## Symptom

Every streamed chat through the pipe (open-webui → gateway) fails with:

```
object of type function is not JSON serializable
```

even for a plain "hi". The gateway's **admin chat works fine**, which is the tell: admin chat consumes SDK messages in-process, while `/v1/responses` serializes them to SSE JSON.

## Cause

`task_updated` (added in #127) passes the SDK's task-registry **`patch` through raw** (`sse_builders.py`, per gateway pass-through philosophy):

```python
patch = chunk.get("patch") if isinstance(chunk.get("patch"), dict) else {}
return {..., "patch": patch, ...}
```

That patch can contain **callables** (in-process teammates / background tasks now emit `task_updated` per turn). `make_task_response_sse` → `json.dumps(data)` then raises `TypeError: object of type function is not JSON serializable`, which aborts the entire SSE stream — so the client sees the error and no response. Admin chat never hits this path.

This is unrelated to the workspace file-explorer work; that branch just happened to be the first deploy carrying #127.

## Fix

Route all SSE event serialization through a small helper that uses `json.dumps(..., default=str)`, so a stray non-serializable field (a callable anywhere in the payload, at any depth) degrades to its string form instead of killing the stream:

```python
def _sse_dumps(data):
    return json.dumps(data, default=str)
```

Applied to every `event: …\ndata: …` builder in `sse_builders.py` (task events, response events, tool-use/result, output-item), so it's robust for the whole class, not just `task_updated`.

## Tests

`tests/test_streaming_coverage_unit.py::TestTaskEventSerializationResilience` — a `task_updated` whose `patch` contains a `lambda` now serializes (callable coerced to a string) instead of raising. Full streaming suite: 157 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFsj3J7EAZNr1TKZXYqoqm

---
_Generated by [Claude Code](https://claude.ai/code/session_01LFsj3J7EAZNr1TKZXYqoqm)_