### PR TITLE
feat(workspace): Open Terminal-compatible workspace file server

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -603,6 +603,12 @@ app.include_router(sessions_router)
 app.include_router(general_router)
 app.include_router(admin_router)
 
+# Open Terminal-compatible read-only file server over per-user workspaces, so
+# open-webui can browse a user's Claude workspace in its file-explorer sidebar.
+from src.routes.terminal_files import router as terminal_files_router  # noqa: E402
+
+app.include_router(terminal_files_router)
+
 # Anthropic Messages SSE sanitizer for upstream LiteLLM-like proxies that emit
 # non-spec-conforming streams (LiteLLM #21128). The route is always mounted so
 # the admin panel can flip it on/off at runtime; the handler short-circuits to

--- a/src/routes/terminal_files.py
+++ b/src/routes/terminal_files.py
@@ -1,17 +1,22 @@
-"""Open Terminal-compatible, read-only file server over per-user Claude workspaces.
+"""Open Terminal-compatible file server over per-user Claude workspaces.
 
 Implements the subset of the open-webui "Open Terminal" server HTTP contract that
-the ``FileNav`` right-sidebar explorer needs to BROWSE and PREVIEW files, scoped
-to a single user's Claude workspace. It is **read-only**: no write/exec endpoints
-are served, so the gateway can be registered in open-webui as a terminal
-connection and its workspace browsed exactly as the agent sees it.
+the ``FileNav`` right-sidebar explorer uses, scoped to a single user's Claude
+workspace, so the gateway can be registered in open-webui as a terminal
+connection and its workspace browsed/edited exactly as the agent sees it.
 
 Contract (what FileNav calls):
-- ``GET /api/config``                 -> ``{"features": {"terminal": false}}`` (handshake)
-- ``GET /files/cwd``                  -> ``{"cwd": "/"}`` (workspace root is the virtual "/")
-- ``GET /files/list?directory=<p>``   -> ``{"entries": [{name,type,size,modified}]}``
-- ``GET /files/read?path=<p>``        -> text ``{path,total_lines,content}`` | raw bytes (binary)
-- ``GET /files/view?path=<p>``        -> raw bytes (download)
+- ``GET  /api/config``                -> ``{"features": {"terminal": false}}`` (handshake)
+- ``GET  /files/cwd``                 -> ``{"cwd": "/"}`` (workspace root is the virtual "/")
+- ``POST /files/cwd``  {path}         -> ``{"cwd": path}`` (validate; cwd is client-tracked)
+- ``GET  /files/list?directory=<p>``  -> ``{"entries": [{name,type,size,modified}]}``
+- ``GET  /files/read?path=<p>``       -> text ``{path,total_lines,content}`` | raw bytes (binary)
+- ``GET  /files/view?path=<p>``       -> raw bytes (download)
+- ``POST /files/upload?directory=<p>``-> ``{path,size}`` (also how "new file" is created)
+- ``POST /files/mkdir``  {path}       -> ``{path}``
+- ``DELETE /files/delete?path=<p>``   -> ``{path,type}``
+- ``POST /files/move``  {source,destination} -> ``{source,destination}``
+- ``POST /files/archive`` {paths}     -> zip stream
 
 Identity: the open-webui backend proxy forwards the standard user-info headers
 (when ``ENABLE_FORWARD_USER_INFO_HEADERS`` is on); we read ``X-OpenWebUI-User-Email``
@@ -22,23 +27,41 @@ Security:
 - ``API_KEY`` MUST be configured; otherwise ``verify_api_key`` is a no-op and
   these endpoints would expose every user's files unauthenticated, so we fail
   closed here.
-- Every path is confined to the single workspace root via ``_safe_resolve``
-  (``Path.resolve()`` collapses ``..`` and follows symlinks before the
-  containment check). No extra roots (never ``~/.claude`` etc.).
+- Every path (read AND write) is confined to the single workspace root via
+  ``_safe_resolve`` (``Path.resolve()`` collapses ``..`` and resolves symlinks
+  before the containment check). Uploaded filenames are reduced to a basename.
+  No extra roots (never ``~/.claude`` etc.).
 """
 
+import io
 import mimetypes
 import os
+import shutil
 import stat as stat_module
+import zipfile
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Response
-from fastapi.responses import FileResponse
+from fastapi import APIRouter, Depends, File, HTTPException, Request, Response, UploadFile
+from fastapi.responses import FileResponse, StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials
+from pydantic import BaseModel
 
 from src.auth import auth_manager, security, verify_api_key
 from src.workspace_manager import workspace_manager
+
+
+class _PathBody(BaseModel):
+    path: str
+
+
+class _MoveBody(BaseModel):
+    source: str
+    destination: str
+
+
+class _ArchiveBody(BaseModel):
+    paths: List[str]
 
 router = APIRouter(tags=["workspace-files"])
 
@@ -94,6 +117,11 @@ def _safe_resolve(root: Path, rel: str) -> Optional[Path]:
     except ValueError:
         return None
     return resolved
+
+
+def _rel(root: Path, target: Path) -> str:
+    """Workspace-relative path (leading '/') for a resolved *target*."""
+    return "/" + str(target.relative_to(root.resolve()))
 
 
 @router.get("/api/config")
@@ -195,3 +223,145 @@ async def view_file(
 
     media = mimetypes.guess_type(target.name)[0] or "application/octet-stream"
     return FileResponse(target, media_type=media, filename=target.name)
+
+
+# ---------------------------------------------------------------------------
+# Write operations (all confined to the workspace root by _safe_resolve)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/files/cwd")
+async def set_cwd(
+    request: Request,
+    body: _PathBody,
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+):
+    """Validate a directory; cwd itself is tracked client-side (root is virtual)."""
+    await verify_api_key(request, credentials)
+    _ensure_api_key()
+    root = _workspace_root(_require_user(request))
+    target = _safe_resolve(root, body.path)
+    if target is None or not target.is_dir():
+        raise HTTPException(status_code=404, detail="directory not found")
+    return {"cwd": body.path}
+
+
+@router.post("/files/upload")
+async def upload_file(
+    request: Request,
+    directory: str = "/",
+    file: UploadFile = File(...),
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+):
+    await verify_api_key(request, credentials)
+    _ensure_api_key()
+    root = _workspace_root(_require_user(request))
+    dest_dir = _safe_resolve(root, directory)
+    if dest_dir is None or not dest_dir.is_dir():
+        raise HTTPException(status_code=404, detail="directory not found")
+
+    # Reduce the client filename to a basename so it can't carry path segments.
+    name = os.path.basename(file.filename or "")
+    if not name or name in (".", ".."):
+        raise HTTPException(status_code=400, detail="invalid filename")
+    target = _safe_resolve(root, f"{directory}/{name}")
+    if target is None:
+        raise HTTPException(status_code=400, detail="invalid path")
+
+    data = await file.read()
+    target.write_bytes(data)
+    return {"path": _rel(root, target), "size": len(data)}
+
+
+@router.post("/files/mkdir")
+async def make_dir(
+    request: Request,
+    body: _PathBody,
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+):
+    await verify_api_key(request, credentials)
+    _ensure_api_key()
+    root = _workspace_root(_require_user(request))
+    target = _safe_resolve(root, body.path)
+    if target is None or target == root.resolve():
+        raise HTTPException(status_code=400, detail="invalid path")
+    target.mkdir(parents=True, exist_ok=True)
+    return {"path": _rel(root, target)}
+
+
+@router.delete("/files/delete")
+async def delete_entry(
+    request: Request,
+    path: str,
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+):
+    await verify_api_key(request, credentials)
+    _ensure_api_key()
+    root = _workspace_root(_require_user(request))
+    target = _safe_resolve(root, path)
+    if target is None or target == root.resolve():
+        raise HTTPException(status_code=400, detail="invalid path")
+    if not target.exists():
+        raise HTTPException(status_code=404, detail="not found")
+    is_dir = target.is_dir() and not target.is_symlink()
+    if is_dir:
+        shutil.rmtree(target)
+    else:
+        target.unlink()
+    return {"path": path, "type": "directory" if is_dir else "file"}
+
+
+@router.post("/files/move")
+async def move_entry(
+    request: Request,
+    body: _MoveBody,
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+):
+    await verify_api_key(request, credentials)
+    _ensure_api_key()
+    root = _workspace_root(_require_user(request))
+    src = _safe_resolve(root, body.source)
+    dst = _safe_resolve(root, body.destination)
+    if src is None or dst is None or src == root.resolve() or dst == root.resolve():
+        raise HTTPException(status_code=400, detail="invalid path")
+    if not src.exists():
+        raise HTTPException(status_code=404, detail="source not found")
+    if not dst.parent.is_dir():
+        raise HTTPException(status_code=404, detail="destination directory not found")
+    shutil.move(str(src), str(dst))
+    return {"source": body.source, "destination": body.destination}
+
+
+@router.post("/files/archive")
+async def archive_entries(
+    request: Request,
+    body: _ArchiveBody,
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+):
+    await verify_api_key(request, credentials)
+    _ensure_api_key()
+    root = _workspace_root(_require_user(request))
+    root_resolved = root.resolve()
+
+    targets = []
+    for p in body.paths:
+        t = _safe_resolve(root, p)
+        if t is None or not t.exists():
+            raise HTTPException(status_code=404, detail=f"not found: {p}")
+        targets.append(t)
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for t in targets:
+            if t.is_dir():
+                for sub in t.rglob("*"):
+                    if sub.is_file() and not sub.is_symlink():
+                        zf.write(sub, arcname=str(sub.relative_to(root_resolved)))
+            elif t.is_file() and not t.is_symlink():
+                zf.write(t, arcname=str(t.relative_to(root_resolved)))
+    buf.seek(0)
+    return StreamingResponse(
+        iter([buf.getvalue()]),
+        media_type="application/zip",
+        headers={"Content-Disposition": 'attachment; filename="archive.zip"'},
+    )

--- a/src/routes/terminal_files.py
+++ b/src/routes/terminal_files.py
@@ -199,6 +199,28 @@ async def terminal_config(
     return {"features": {"terminal": False}}
 
 
+@router.get("/files/openapi.json")
+async def tool_specs(
+    request: Request,
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+):
+    """Empty OpenAPI so open-webui exposes ZERO LLM tools for this connection.
+
+    A terminal connection's ``path`` (default ``/openapi.json``) is fetched by
+    open-webui, and every operation in it becomes an LLM-callable tool (whose
+    callables it then builds — and can fail to serialize with a manifold/pipe
+    model). This gateway is a file *browser*, not a tool provider — point the
+    connection ``path`` here so no tools are built. The FileNav sidebar calls
+    ``/files/*`` directly and is unaffected.
+    """
+    await verify_api_key(request, credentials)
+    return {
+        "openapi": "3.1.0",
+        "info": {"title": "Oh My Gateway Workspace Files", "version": "1.0.0"},
+        "paths": {},
+    }
+
+
 @router.get("/files/cwd")
 async def get_cwd(
     request: Request,

--- a/src/routes/terminal_files.py
+++ b/src/routes/terminal_files.py
@@ -1,0 +1,197 @@
+"""Open Terminal-compatible, read-only file server over per-user Claude workspaces.
+
+Implements the subset of the open-webui "Open Terminal" server HTTP contract that
+the ``FileNav`` right-sidebar explorer needs to BROWSE and PREVIEW files, scoped
+to a single user's Claude workspace. It is **read-only**: no write/exec endpoints
+are served, so the gateway can be registered in open-webui as a terminal
+connection and its workspace browsed exactly as the agent sees it.
+
+Contract (what FileNav calls):
+- ``GET /api/config``                 -> ``{"features": {"terminal": false}}`` (handshake)
+- ``GET /files/cwd``                  -> ``{"cwd": "/"}`` (workspace root is the virtual "/")
+- ``GET /files/list?directory=<p>``   -> ``{"entries": [{name,type,size,modified}]}``
+- ``GET /files/read?path=<p>``        -> text ``{path,total_lines,content}`` | raw bytes (binary)
+- ``GET /files/view?path=<p>``        -> raw bytes (download)
+
+Identity: the open-webui backend proxy forwards the standard user-info headers
+(when ``ENABLE_FORWARD_USER_INFO_HEADERS`` is on); we read ``X-OpenWebUI-User-Email``
+and take its localpart — the same value the pipe uses to key ``/v1/responses``
+workspaces — so the explorer resolves the very files the agent wrote.
+
+Security:
+- ``API_KEY`` MUST be configured; otherwise ``verify_api_key`` is a no-op and
+  these endpoints would expose every user's files unauthenticated, so we fail
+  closed here.
+- Every path is confined to the single workspace root via ``_safe_resolve``
+  (``Path.resolve()`` collapses ``..`` and follows symlinks before the
+  containment check). No extra roots (never ``~/.claude`` etc.).
+"""
+
+import mimetypes
+import os
+import stat as stat_module
+from pathlib import Path
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from fastapi.responses import FileResponse
+from fastapi.security import HTTPAuthorizationCredentials
+
+from src.auth import auth_manager, security, verify_api_key
+from src.workspace_manager import workspace_manager
+
+router = APIRouter(tags=["workspace-files"])
+
+_EMAIL_HEADER = "x-openwebui-user-email"
+_BACKEND = "claude"
+# Cap in-band text previews; larger files must be fetched via /files/view.
+_MAX_READ_BYTES = 5 * 1024 * 1024
+
+
+def _ensure_api_key() -> None:
+    """Fail closed unless an API key is configured (verify_api_key no-ops without one)."""
+    if not auth_manager.get_api_key():
+        raise HTTPException(
+            status_code=503,
+            detail="workspace file browser is disabled: API_KEY is not configured",
+        )
+
+
+def _require_user(request: Request) -> str:
+    # Workspace key = email localpart (strip from '@'), matching how the pipe
+    # derives body.user. Falls back to the raw value when there is no '@'.
+    email = (request.headers.get(_EMAIL_HEADER) or "").strip()
+    user = email.split("@")[0]
+    if not user:
+        raise HTTPException(status_code=400, detail="missing user identity header")
+    return user
+
+
+def _workspace_root(user: str) -> Path:
+    try:
+        return workspace_manager.resolve(user, backend=_BACKEND)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="invalid user identity")
+
+
+def _safe_resolve(root: Path, rel: str) -> Optional[Path]:
+    """Resolve *rel* (relative to the workspace root) and confine it to that root.
+
+    ``rel`` is treated as workspace-relative; ``"/"`` or ``""`` is the root.
+    ``Path.resolve()`` collapses ``..`` and follows symlinks, so an escape via
+    either is caught by the ``relative_to`` containment check. Returns ``None``
+    on any escape or resolution error.
+    """
+    rel = (rel or "/").lstrip("/")
+    candidate = root / rel if rel else root
+    try:
+        resolved = candidate.resolve()
+        root_resolved = root.resolve()
+    except (OSError, RuntimeError):
+        return None
+    try:
+        resolved.relative_to(root_resolved)
+    except ValueError:
+        return None
+    return resolved
+
+
+@router.get("/api/config")
+async def terminal_config(
+    request: Request,
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+):
+    """Handshake: advertise a read-only, no-terminal file server."""
+    await verify_api_key(request, credentials)
+    _ensure_api_key()
+    return {"features": {"terminal": False}}
+
+
+@router.get("/files/cwd")
+async def get_cwd(
+    request: Request,
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+):
+    await verify_api_key(request, credentials)
+    _ensure_api_key()
+    _require_user(request)  # require identity even though the root is virtual "/"
+    return {"cwd": "/"}
+
+
+@router.get("/files/list")
+async def list_files(
+    request: Request,
+    directory: str = "/",
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+):
+    await verify_api_key(request, credentials)
+    _ensure_api_key()
+    root = _workspace_root(_require_user(request))
+    target = _safe_resolve(root, directory)
+    if target is None or not target.is_dir():
+        raise HTTPException(status_code=404, detail="directory not found")
+
+    entries = []
+    with os.scandir(target) as it:
+        for entry in it:
+            try:
+                st = entry.stat()  # follow symlinks; broken links are skipped
+            except OSError:
+                continue
+            entries.append(
+                {
+                    "name": entry.name,
+                    "type": "directory" if stat_module.S_ISDIR(st.st_mode) else "file",
+                    "size": st.st_size,
+                    "modified": int(st.st_mtime),
+                }
+            )
+    entries.sort(key=lambda e: (e["type"] != "directory", e["name"].lower()))
+    return {"entries": entries}
+
+
+@router.get("/files/read")
+async def read_file(
+    request: Request,
+    path: str,
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+):
+    await verify_api_key(request, credentials)
+    _ensure_api_key()
+    root = _workspace_root(_require_user(request))
+    target = _safe_resolve(root, path)
+    if target is None or not target.is_file():
+        raise HTTPException(status_code=404, detail="file not found")
+
+    if target.stat().st_size > _MAX_READ_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"file too large to preview (> {_MAX_READ_BYTES} bytes); use download",
+        )
+
+    data = target.read_bytes()
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError:
+        # Binary: return raw bytes so FileNav renders a preview / placeholder.
+        media = mimetypes.guess_type(target.name)[0] or "application/octet-stream"
+        return Response(content=data, media_type=media)
+
+    return {"path": path, "total_lines": text.count("\n") + 1, "content": text}
+
+
+@router.get("/files/view")
+async def view_file(
+    request: Request,
+    path: str,
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+):
+    await verify_api_key(request, credentials)
+    _ensure_api_key()
+    root = _workspace_root(_require_user(request))
+    target = _safe_resolve(root, path)
+    if target is None or not target.is_file():
+        raise HTTPException(status_code=404, detail="file not found")
+
+    media = mimetypes.guess_type(target.name)[0] or "application/octet-stream"
+    return FileResponse(target, media_type=media, filename=target.name)

--- a/src/routes/terminal_files.py
+++ b/src/routes/terminal_files.py
@@ -129,11 +129,26 @@ def _safe_resolve(root: Path, rel: str) -> Optional[Path]:
     entry can't be reached by typing its path). Returns ``None`` on any escape,
     hidden-path, or resolution error.
     """
-    rel = (rel or "/").lstrip("/")
-    candidate = root / rel if rel else root
     try:
-        resolved = candidate.resolve()
         root_resolved = root.resolve()
+    except (OSError, RuntimeError):
+        return None
+    p = rel or "/"
+    try:
+        # The explorer echoes the real cwd, so most paths arrive absolute; accept
+        # them when they land under the root. Anything else (a leading-slash
+        # workspace-relative path like "/sub", or an absolute path outside the
+        # root) is (re)interpreted as workspace-relative — the containment check
+        # below still guarantees confinement either way.
+        candidate = Path(p)
+        if candidate.is_absolute():
+            resolved = candidate.resolve()
+            try:
+                resolved.relative_to(root_resolved)
+            except ValueError:
+                resolved = (root_resolved / p.lstrip("/")).resolve()
+        else:
+            resolved = (root_resolved / p).resolve()
     except (OSError, RuntimeError):
         return None
     try:
@@ -143,11 +158,6 @@ def _safe_resolve(root: Path, rel: str) -> Optional[Path]:
     if _hide_dotfiles() and any(part.startswith(".") for part in relative.parts):
         return None
     return resolved
-
-
-def _rel(root: Path, target: Path) -> str:
-    """Workspace-relative path (leading '/') for a resolved *target*."""
-    return "/" + str(target.relative_to(root.resolve()))
 
 
 @router.get("/api/config")
@@ -168,8 +178,10 @@ async def get_cwd(
 ):
     await verify_api_key(request, credentials)
     _ensure_api_key()
-    _require_user(request)  # require identity even though the root is virtual "/"
-    return {"cwd": "/"}
+    root = _workspace_root(_require_user(request))
+    # Report the real workspace path so the explorer's breadcrumb matches the
+    # paths the agent uses (e.g. what MEMORY.md references).
+    return {"cwd": str(root.resolve())}
 
 
 @router.get("/files/list")
@@ -299,7 +311,7 @@ async def upload_file(
 
     data = await file.read()
     target.write_bytes(data)
-    return {"path": _rel(root, target), "size": len(data)}
+    return {"path": str(target), "size": len(data)}
 
 
 @router.post("/files/mkdir")
@@ -315,7 +327,7 @@ async def make_dir(
     if target is None or target == root.resolve():
         raise HTTPException(status_code=400, detail="invalid path")
     target.mkdir(parents=True, exist_ok=True)
-    return {"path": _rel(root, target)}
+    return {"path": str(target)}
 
 
 @router.delete("/files/delete")

--- a/src/routes/terminal_files.py
+++ b/src/routes/terminal_files.py
@@ -18,10 +18,17 @@ Contract (what FileNav calls):
 - ``POST /files/move``  {source,destination} -> ``{source,destination}``
 - ``POST /files/archive`` {paths}     -> zip stream
 
-Identity: the open-webui backend proxy forwards the standard user-info headers
-(when ``ENABLE_FORWARD_USER_INFO_HEADERS`` is on); we read ``X-OpenWebUI-User-Email``
-and take its localpart — the same value the pipe uses to key ``/v1/responses``
-workspaces — so the explorer resolves the very files the agent wrote.
+Identity: read from a configurable, vendor-neutral header (``WORKSPACE_USER_HEADER``,
+default ``X-User-Email``) and take its localpart — the same value the pipe uses to
+key ``/v1/responses`` workspaces — so the explorer resolves the very files the
+agent wrote. The caller (e.g. open-webui) forwards the user's identity under that
+header name; on open-webui set ``FORWARD_USER_INFO_HEADER_USER_EMAIL`` to the same
+name so the two agree (no code coupling to the caller's product).
+
+Config:
+- ``WORKSPACE_USER_HEADER`` — inbound identity header name (default ``X-User-Email``).
+- ``WORKSPACE_HIDE_DOTFILES`` — when true (default), dot-prefixed entries are
+  neither listed nor accessible.
 
 Security:
 - ``API_KEY`` MUST be configured; otherwise ``verify_api_key`` is a no-op and
@@ -65,10 +72,25 @@ class _ArchiveBody(BaseModel):
 
 router = APIRouter(tags=["workspace-files"])
 
-_EMAIL_HEADER = "x-openwebui-user-email"
 _BACKEND = "claude"
 # Cap in-band text previews; larger files must be fetched via /files/view.
 _MAX_READ_BYTES = 5 * 1024 * 1024
+
+# Name of the inbound header carrying the user identity. Kept generic and
+# configurable (no hard dependency on the caller's product) — the frontend just
+# has to forward the user's identity under this name. Its value is treated as an
+# email/identity whose localpart (before '@') keys the workspace, matching how
+# the pipe derives body.user. Default is deliberately vendor-neutral.
+_DEFAULT_USER_HEADER = "X-User-Email"
+
+
+def _user_header() -> str:
+    return os.getenv("WORKSPACE_USER_HEADER", _DEFAULT_USER_HEADER)
+
+
+def _hide_dotfiles() -> bool:
+    """When true (default), dot-prefixed entries are neither listed nor accessible."""
+    return os.getenv("WORKSPACE_HIDE_DOTFILES", "true").strip().lower() == "true"
 
 
 def _ensure_api_key() -> None:
@@ -81,10 +103,10 @@ def _ensure_api_key() -> None:
 
 
 def _require_user(request: Request) -> str:
-    # Workspace key = email localpart (strip from '@'), matching how the pipe
+    # Workspace key = identity localpart (strip from '@'), matching how the pipe
     # derives body.user. Falls back to the raw value when there is no '@'.
-    email = (request.headers.get(_EMAIL_HEADER) or "").strip()
-    user = email.split("@")[0]
+    identity = (request.headers.get(_user_header()) or "").strip()
+    user = identity.split("@")[0]
     if not user:
         raise HTTPException(status_code=400, detail="missing user identity header")
     return user
@@ -102,8 +124,10 @@ def _safe_resolve(root: Path, rel: str) -> Optional[Path]:
 
     ``rel`` is treated as workspace-relative; ``"/"`` or ``""`` is the root.
     ``Path.resolve()`` collapses ``..`` and follows symlinks, so an escape via
-    either is caught by the ``relative_to`` containment check. Returns ``None``
-    on any escape or resolution error.
+    either is caught by the ``relative_to`` containment check. When dotfiles are
+    hidden, any path with a dot-prefixed component is also rejected (so a hidden
+    entry can't be reached by typing its path). Returns ``None`` on any escape,
+    hidden-path, or resolution error.
     """
     rel = (rel or "/").lstrip("/")
     candidate = root / rel if rel else root
@@ -113,8 +137,10 @@ def _safe_resolve(root: Path, rel: str) -> Optional[Path]:
     except (OSError, RuntimeError):
         return None
     try:
-        resolved.relative_to(root_resolved)
+        relative = resolved.relative_to(root_resolved)
     except ValueError:
+        return None
+    if _hide_dotfiles() and any(part.startswith(".") for part in relative.parts):
         return None
     return resolved
 
@@ -159,9 +185,12 @@ async def list_files(
     if target is None or not target.is_dir():
         raise HTTPException(status_code=404, detail="directory not found")
 
+    hide_dot = _hide_dotfiles()
     entries = []
     with os.scandir(target) as it:
         for entry in it:
+            if hide_dot and entry.name.startswith("."):
+                continue
             try:
                 st = entry.stat()  # follow symlinks; broken links are skipped
             except OSError:

--- a/src/routes/terminal_files.py
+++ b/src/routes/terminal_files.py
@@ -35,9 +35,10 @@ Security:
   these endpoints would expose every user's files unauthenticated, so we fail
   closed here.
 - Every path (read AND write) is confined to the single workspace root via
-  ``_safe_resolve`` (``Path.resolve()`` collapses ``..`` and resolves symlinks
-  before the containment check). Uploaded filenames are reduced to a basename.
-  No extra roots (never ``~/.claude`` etc.).
+  ``_resolve_or_403`` (``Path.resolve()`` collapses ``..`` and resolves symlinks
+  before the containment check); anything above/outside the root is a 403.
+  Uploaded filenames are reduced to a basename. No extra roots (never
+  ``~/.claude`` etc.).
 """
 
 import io
@@ -119,45 +120,72 @@ def _workspace_root(user: str) -> Path:
         raise HTTPException(status_code=400, detail="invalid user identity")
 
 
-def _safe_resolve(root: Path, rel: str) -> Optional[Path]:
-    """Resolve *rel* (relative to the workspace root) and confine it to that root.
+def _is_under(path: Path, base: Path) -> bool:
+    """True when *path* is *base* or nested inside it."""
+    try:
+        path.relative_to(base)
+        return True
+    except ValueError:
+        return False
 
-    ``rel`` is treated as workspace-relative; ``"/"`` or ``""`` is the root.
+
+def _resolve_in_root(root: Path, rel: str) -> Optional[Path]:
+    """Resolve *rel* and confine it to *root*; ``None`` if it escapes the root.
+
     ``Path.resolve()`` collapses ``..`` and follows symlinks, so an escape via
-    either is caught by the ``relative_to`` containment check. When dotfiles are
-    hidden, any path with a dot-prefixed component is also rejected (so a hidden
-    entry can't be reached by typing its path). Returns ``None`` on any escape,
-    hidden-path, or resolution error.
+    either is caught by the containment check. This is containment only —
+    dotfile hiding is applied separately so callers can distinguish "outside
+    your workspace" (403) from "hidden/not found" (404).
+
+    The explorer echoes the real cwd, so most paths arrive absolute and under
+    the root. An absolute path that is an *ancestor* of the root (breadcrumb
+    navigation above the workspace) is rejected outright; any other stray
+    leading-slash path is reinterpreted as workspace-relative.
     """
     try:
         root_resolved = root.resolve()
     except (OSError, RuntimeError):
         return None
     p = rel or "/"
+    if p in ("/", ""):
+        return root_resolved  # workspace root (virtual "/")
     try:
-        # The explorer echoes the real cwd, so most paths arrive absolute; accept
-        # them when they land under the root. Anything else (a leading-slash
-        # workspace-relative path like "/sub", or an absolute path outside the
-        # root) is (re)interpreted as workspace-relative — the containment check
-        # below still guarantees confinement either way.
         candidate = Path(p)
         if candidate.is_absolute():
             resolved = candidate.resolve()
-            try:
-                resolved.relative_to(root_resolved)
-            except ValueError:
+            if not _is_under(resolved, root_resolved):
+                if _is_under(root_resolved, resolved):
+                    return None  # ancestor of the root -> above-workspace nav
                 resolved = (root_resolved / p.lstrip("/")).resolve()
         else:
             resolved = (root_resolved / p).resolve()
     except (OSError, RuntimeError):
         return None
-    try:
-        relative = resolved.relative_to(root_resolved)
-    except ValueError:
-        return None
-    if _hide_dotfiles() and any(part.startswith(".") for part in relative.parts):
-        return None
-    return resolved
+    return resolved if _is_under(resolved, root_resolved) else None
+
+
+def _resolve_or_403(root: Path, rel: str) -> Path:
+    """Resolve within the workspace root or raise.
+
+    - Outside the root -> **403** ("outside your workspace"), so the explorer can
+      warn the user that navigation there isn't allowed.
+    - A dot-prefixed (hidden) component, when hiding is on -> **404**, so hidden
+      entries stay invisible rather than advertising that something is blocked.
+
+    The returned path may not exist yet (callers that create paths check as
+    needed); callers reading/listing must still verify existence.
+    """
+    target = _resolve_in_root(root, rel)
+    if target is None:
+        raise HTTPException(
+            status_code=403,
+            detail="Access denied: this path is outside your workspace.",
+        )
+    if _hide_dotfiles():
+        relative = target.relative_to(root.resolve())
+        if any(part.startswith(".") for part in relative.parts):
+            raise HTTPException(status_code=404, detail="not found")
+    return target
 
 
 @router.get("/api/config")
@@ -193,8 +221,8 @@ async def list_files(
     await verify_api_key(request, credentials)
     _ensure_api_key()
     root = _workspace_root(_require_user(request))
-    target = _safe_resolve(root, directory)
-    if target is None or not target.is_dir():
+    target = _resolve_or_403(root, directory)
+    if not target.is_dir():
         raise HTTPException(status_code=404, detail="directory not found")
 
     hide_dot = _hide_dotfiles()
@@ -228,8 +256,8 @@ async def read_file(
     await verify_api_key(request, credentials)
     _ensure_api_key()
     root = _workspace_root(_require_user(request))
-    target = _safe_resolve(root, path)
-    if target is None or not target.is_file():
+    target = _resolve_or_403(root, path)
+    if not target.is_file():
         raise HTTPException(status_code=404, detail="file not found")
 
     if target.stat().st_size > _MAX_READ_BYTES:
@@ -258,8 +286,8 @@ async def view_file(
     await verify_api_key(request, credentials)
     _ensure_api_key()
     root = _workspace_root(_require_user(request))
-    target = _safe_resolve(root, path)
-    if target is None or not target.is_file():
+    target = _resolve_or_403(root, path)
+    if not target.is_file():
         raise HTTPException(status_code=404, detail="file not found")
 
     media = mimetypes.guess_type(target.name)[0] or "application/octet-stream"
@@ -267,7 +295,7 @@ async def view_file(
 
 
 # ---------------------------------------------------------------------------
-# Write operations (all confined to the workspace root by _safe_resolve)
+# Write operations (all confined to the workspace root by _resolve_or_403)
 # ---------------------------------------------------------------------------
 
 
@@ -277,12 +305,12 @@ async def set_cwd(
     body: _PathBody,
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
 ):
-    """Validate a directory; cwd itself is tracked client-side (root is virtual)."""
+    """Validate a directory; cwd itself is tracked client-side."""
     await verify_api_key(request, credentials)
     _ensure_api_key()
     root = _workspace_root(_require_user(request))
-    target = _safe_resolve(root, body.path)
-    if target is None or not target.is_dir():
+    target = _resolve_or_403(root, body.path)
+    if not target.is_dir():
         raise HTTPException(status_code=404, detail="directory not found")
     return {"cwd": body.path}
 
@@ -297,17 +325,15 @@ async def upload_file(
     await verify_api_key(request, credentials)
     _ensure_api_key()
     root = _workspace_root(_require_user(request))
-    dest_dir = _safe_resolve(root, directory)
-    if dest_dir is None or not dest_dir.is_dir():
+    dest_dir = _resolve_or_403(root, directory)
+    if not dest_dir.is_dir():
         raise HTTPException(status_code=404, detail="directory not found")
 
     # Reduce the client filename to a basename so it can't carry path segments.
     name = os.path.basename(file.filename or "")
     if not name or name in (".", ".."):
         raise HTTPException(status_code=400, detail="invalid filename")
-    target = _safe_resolve(root, f"{directory}/{name}")
-    if target is None:
-        raise HTTPException(status_code=400, detail="invalid path")
+    target = _resolve_or_403(root, f"{directory}/{name}")
 
     data = await file.read()
     target.write_bytes(data)
@@ -323,8 +349,8 @@ async def make_dir(
     await verify_api_key(request, credentials)
     _ensure_api_key()
     root = _workspace_root(_require_user(request))
-    target = _safe_resolve(root, body.path)
-    if target is None or target == root.resolve():
+    target = _resolve_or_403(root, body.path)
+    if target == root.resolve():
         raise HTTPException(status_code=400, detail="invalid path")
     target.mkdir(parents=True, exist_ok=True)
     return {"path": str(target)}
@@ -339,8 +365,8 @@ async def delete_entry(
     await verify_api_key(request, credentials)
     _ensure_api_key()
     root = _workspace_root(_require_user(request))
-    target = _safe_resolve(root, path)
-    if target is None or target == root.resolve():
+    target = _resolve_or_403(root, path)
+    if target == root.resolve():
         raise HTTPException(status_code=400, detail="invalid path")
     if not target.exists():
         raise HTTPException(status_code=404, detail="not found")
@@ -361,9 +387,9 @@ async def move_entry(
     await verify_api_key(request, credentials)
     _ensure_api_key()
     root = _workspace_root(_require_user(request))
-    src = _safe_resolve(root, body.source)
-    dst = _safe_resolve(root, body.destination)
-    if src is None or dst is None or src == root.resolve() or dst == root.resolve():
+    src = _resolve_or_403(root, body.source)
+    dst = _resolve_or_403(root, body.destination)
+    if src == root.resolve() or dst == root.resolve():
         raise HTTPException(status_code=400, detail="invalid path")
     if not src.exists():
         raise HTTPException(status_code=404, detail="source not found")
@@ -386,8 +412,8 @@ async def archive_entries(
 
     targets = []
     for p in body.paths:
-        t = _safe_resolve(root, p)
-        if t is None or not t.exists():
+        t = _resolve_or_403(root, p)
+        if not t.exists():
             raise HTTPException(status_code=404, detail=f"not found: {p}")
         targets.append(t)
 

--- a/tests/test_terminal_files.py
+++ b/tests/test_terminal_files.py
@@ -137,3 +137,120 @@ def test_fails_closed_when_api_key_unset(workspace, monkeypatch):
 def test_missing_file_is_404(client):
     r = client.get("/files/read?path=/nope.txt", headers={**_AUTH, **_USER})
     assert r.status_code == 404
+
+
+# --- write operations ---------------------------------------------------------
+
+
+def test_upload_creates_file(client, workspace):
+    r = client.post(
+        "/files/upload?directory=/",
+        headers={**_AUTH, **_USER},
+        files={"file": ("new.txt", b"content here", "text/plain")},
+    )
+    assert r.status_code == 200
+    assert r.json() == {"path": "/new.txt", "size": 12}
+    assert (workspace / "new.txt").read_bytes() == b"content here"
+
+
+def test_upload_empty_file_is_new_file(client, workspace):
+    # FileNav's "New File" uploads an empty file.
+    r = client.post(
+        "/files/upload?directory=/sub",
+        headers={**_AUTH, **_USER},
+        files={"file": ("empty.md", b"", "text/plain")},
+    )
+    assert r.status_code == 200
+    assert (workspace / "sub" / "empty.md").exists()
+
+
+def test_upload_filename_traversal_reduced_to_basename(client, workspace):
+    r = client.post(
+        "/files/upload?directory=/",
+        headers={**_AUTH, **_USER},
+        files={"file": ("../../escape.txt", b"x", "text/plain")},
+    )
+    assert r.status_code == 200
+    # Written inside the workspace as a plain basename, not outside it.
+    assert (workspace / "escape.txt").exists()
+    assert not (workspace.parent.parent / "escape.txt").exists()
+
+
+def test_mkdir(client, workspace):
+    r = client.post("/files/mkdir", headers={**_AUTH, **_USER}, json={"path": "/newdir"})
+    assert r.status_code == 200
+    assert (workspace / "newdir").is_dir()
+
+
+def test_mkdir_traversal_blocked(client, workspace):
+    r = client.post(
+        "/files/mkdir", headers={**_AUTH, **_USER}, json={"path": "/../evil"}
+    )
+    assert r.status_code == 400
+    assert not (workspace.parent / "evil").exists()
+
+
+def test_delete_file(client, workspace):
+    r = client.delete("/files/delete?path=/notes.txt", headers={**_AUTH, **_USER})
+    assert r.status_code == 200
+    assert r.json()["type"] == "file"
+    assert not (workspace / "notes.txt").exists()
+
+
+def test_delete_directory_recursive(client, workspace):
+    r = client.delete("/files/delete?path=/sub", headers={**_AUTH, **_USER})
+    assert r.status_code == 200
+    assert r.json()["type"] == "directory"
+    assert not (workspace / "sub").exists()
+
+
+def test_delete_traversal_blocked(client, workspace):
+    r = client.delete("/files/delete?path=/../../secret.txt", headers={**_AUTH, **_USER})
+    assert r.status_code in (400, 404)
+    assert (workspace.parent.parent / "secret.txt").exists()  # untouched
+
+
+def test_move_renames(client, workspace):
+    r = client.post(
+        "/files/move",
+        headers={**_AUTH, **_USER},
+        json={"source": "/notes.txt", "destination": "/renamed.txt"},
+    )
+    assert r.status_code == 200
+    assert not (workspace / "notes.txt").exists()
+    assert (workspace / "renamed.txt").read_text() == "hello\nworld\n"
+
+
+def test_move_traversal_blocked(client, workspace):
+    r = client.post(
+        "/files/move",
+        headers={**_AUTH, **_USER},
+        json={"source": "/notes.txt", "destination": "/../stolen.txt"},
+    )
+    assert r.status_code == 400
+    assert (workspace / "notes.txt").exists()  # unchanged
+
+
+def test_archive_zips_selection(client):
+    r = client.post(
+        "/files/archive",
+        headers={**_AUTH, **_USER},
+        json={"paths": ["/notes.txt", "/sub"]},
+    )
+    assert r.status_code == 200
+    assert r.headers["content-type"] == "application/zip"
+    import io as _io
+    import zipfile as _zip
+
+    names = _zip.ZipFile(_io.BytesIO(r.content)).namelist()
+    assert "notes.txt" in names and "sub/inner.md" in names
+
+
+def test_writes_fail_closed_without_api_key(workspace, monkeypatch):
+    monkeypatch.setattr(tf.auth_manager, "get_api_key", lambda: "")
+    monkeypatch.setattr(tf.workspace_manager, "resolve", lambda user, backend=None: workspace)
+    app = FastAPI()
+    app.include_router(router)
+    c = TestClient(app)
+    r = c.post("/files/mkdir", json={"path": "/x"})
+    assert r.status_code == 503

--- a/tests/test_terminal_files.py
+++ b/tests/test_terminal_files.py
@@ -54,10 +54,26 @@ def test_config_advertises_readonly_no_terminal(client):
     assert r.json() == {"features": {"terminal": False}}
 
 
-def test_cwd_is_virtual_root(client):
+def test_cwd_returns_real_workspace_path(client, workspace):
     r = client.get("/files/cwd", headers={**_AUTH, **_USER})
     assert r.status_code == 200
-    assert r.json()["cwd"] == "/"
+    assert r.json()["cwd"] == str(workspace.resolve())
+
+
+def test_absolute_paths_under_root_work(client, workspace):
+    # The explorer echoes the real cwd, so list/read arrive as absolute paths.
+    d = str(workspace.resolve())
+    r = client.get(f"/files/list?directory={d}/sub", headers={**_AUTH, **_USER})
+    assert r.status_code == 200
+    assert [e["name"] for e in r.json()["entries"]] == ["inner.md"]
+    rr = client.get(f"/files/read?path={d}/notes.txt", headers={**_AUTH, **_USER})
+    assert rr.status_code == 200 and rr.json()["content"] == "hello\nworld\n"
+
+
+def test_absolute_path_outside_root_blocked(client, workspace):
+    outside = str((workspace.parent.parent / "secret.txt"))
+    r = client.get(f"/files/read?path={outside}", headers={**_AUTH, **_USER})
+    assert r.status_code == 404
 
 
 def test_list_root_sorts_dirs_first(client):
@@ -201,7 +217,7 @@ def test_upload_creates_file(client, workspace):
         files={"file": ("new.txt", b"content here", "text/plain")},
     )
     assert r.status_code == 200
-    assert r.json() == {"path": "/new.txt", "size": 12}
+    assert r.json() == {"path": str(workspace / "new.txt"), "size": 12}
     assert (workspace / "new.txt").read_bytes() == b"content here"
 
 

--- a/tests/test_terminal_files.py
+++ b/tests/test_terminal_files.py
@@ -18,6 +18,10 @@ def workspace(tmp_path: Path) -> Path:
     (root / "sub").mkdir()
     (root / "sub" / "inner.md").write_text("# inner")
     (root / "blob.bin").write_bytes(b"\xff\xfe\x00\x01binary")
+    # Hidden entries — filtered/blocked when WORKSPACE_HIDE_DOTFILES is on.
+    (root / ".secret_dir").mkdir()
+    (root / ".secret_dir" / "k.txt").write_text("key")
+    (root / ".env").write_text("TOKEN=abc")
     # A secret OUTSIDE the workspace root, reachable only via traversal.
     (tmp_path / "secret.txt").write_text("TOP SECRET")
     return root
@@ -40,8 +44,8 @@ def client(workspace, monkeypatch):
 
 
 _AUTH = {"Authorization": "Bearer testkey"}
-# The proxy forwards the standard user-info headers; we key off the email localpart.
-_USER = {"X-OpenWebUI-User-Email": "alice@corp.com"}
+# Default identity header (WORKSPACE_USER_HEADER); we key off the localpart.
+_USER = {"X-User-Email": "alice@corp.com"}
 
 
 def test_config_advertises_readonly_no_terminal(client):
@@ -110,9 +114,24 @@ def test_missing_user_header_is_rejected(client):
 def test_invalid_user_is_rejected(client):
     r = client.get(
         "/files/list?directory=/",
-        headers={**_AUTH, "X-OpenWebUI-User-Email": "../evil@x.com"},
+        headers={**_AUTH, "X-User-Email": "../evil@x.com"},
     )
     assert r.status_code == 400
+
+
+def test_custom_user_header_name(client, monkeypatch):
+    monkeypatch.setenv("WORKSPACE_USER_HEADER", "X-Whoami")
+    r = client.get(
+        "/files/list?directory=/",
+        headers={**_AUTH, "X-Whoami": "alice@corp.com"},
+    )
+    assert r.status_code == 200
+    # The old default name is no longer honored.
+    r2 = client.get(
+        "/files/list?directory=/",
+        headers={**_AUTH, "X-User-Email": "alice@corp.com"},
+    )
+    assert r2.status_code == 400
 
 
 def test_wrong_api_key_is_unauthorized(client):
@@ -137,6 +156,39 @@ def test_fails_closed_when_api_key_unset(workspace, monkeypatch):
 def test_missing_file_is_404(client):
     r = client.get("/files/read?path=/nope.txt", headers={**_AUTH, **_USER})
     assert r.status_code == 404
+
+
+# --- dotfile hiding -----------------------------------------------------------
+
+
+def test_dotfiles_hidden_by_default(client):
+    r = client.get("/files/list?directory=/", headers={**_AUTH, **_USER})
+    names = [e["name"] for e in r.json()["entries"]]
+    assert ".env" not in names and ".secret_dir" not in names
+    assert names == ["sub", "blob.bin", "notes.txt"]
+
+
+def test_hidden_path_not_accessible_by_default(client):
+    # Even typing the path directly is blocked (list/read/inside-dir).
+    assert client.get("/files/read?path=/.env", headers={**_AUTH, **_USER}).status_code == 404
+    assert (
+        client.get("/files/list?directory=/.secret_dir", headers={**_AUTH, **_USER}).status_code
+        == 404
+    )
+    assert (
+        client.get("/files/read?path=/.secret_dir/k.txt", headers={**_AUTH, **_USER}).status_code
+        == 404
+    )
+
+
+def test_dotfiles_shown_when_disabled(client, monkeypatch):
+    monkeypatch.setenv("WORKSPACE_HIDE_DOTFILES", "false")
+    r = client.get("/files/list?directory=/", headers={**_AUTH, **_USER})
+    names = [e["name"] for e in r.json()["entries"]]
+    assert ".env" in names and ".secret_dir" in names
+    # ...and now readable.
+    rr = client.get("/files/read?path=/.env", headers={**_AUTH, **_USER})
+    assert rr.status_code == 200 and rr.json()["content"] == "TOKEN=abc"
 
 
 # --- write operations ---------------------------------------------------------

--- a/tests/test_terminal_files.py
+++ b/tests/test_terminal_files.py
@@ -54,6 +54,16 @@ def test_config_advertises_readonly_no_terminal(client):
     assert r.json() == {"features": {"terminal": False}}
 
 
+def test_tool_specs_openapi_has_no_paths(client):
+    # open-webui builds LLM tools from this; empty paths => zero tools => no
+    # tool callables to serialize (avoids the "function not serializable" crash).
+    r = client.get("/files/openapi.json", headers=_AUTH)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["paths"] == {}
+    assert "openapi" in body
+
+
 def test_cwd_returns_real_workspace_path(client, workspace):
     r = client.get("/files/cwd", headers={**_AUTH, **_USER})
     assert r.status_code == 200

--- a/tests/test_terminal_files.py
+++ b/tests/test_terminal_files.py
@@ -118,13 +118,21 @@ def test_view_streams_file(client):
 def test_path_traversal_is_blocked(client):
     for p in ("/../secret.txt", "/../../secret.txt", "/sub/../../secret.txt"):
         r = client.get(f"/files/read?path={p}", headers={**_AUTH, **_USER})
-        assert r.status_code == 404, p
+        assert r.status_code in (403, 404), p
         assert "SECRET" not in r.text
+
+
+def test_above_root_navigation_is_403(client, workspace):
+    # Clicking a breadcrumb segment above the workspace root -> "not allowed".
+    ancestor = str(workspace.resolve().parent)  # e.g. /tmp/.../alice
+    r = client.get(f"/files/list?directory={ancestor}", headers={**_AUTH, **_USER})
+    assert r.status_code == 403
+    assert "outside your workspace" in r.json()["detail"]
 
 
 def test_missing_user_header_is_rejected(client):
     r = client.get("/files/list?directory=/", headers=_AUTH)
-    assert r.status_code == 400
+    assert r.status_code in (400, 403)
 
 
 def test_invalid_user_is_rejected(client):
@@ -132,7 +140,7 @@ def test_invalid_user_is_rejected(client):
         "/files/list?directory=/",
         headers={**_AUTH, "X-User-Email": "../evil@x.com"},
     )
-    assert r.status_code == 400
+    assert r.status_code in (400, 403)
 
 
 def test_custom_user_header_name(client, monkeypatch):
@@ -254,7 +262,7 @@ def test_mkdir_traversal_blocked(client, workspace):
     r = client.post(
         "/files/mkdir", headers={**_AUTH, **_USER}, json={"path": "/../evil"}
     )
-    assert r.status_code == 400
+    assert r.status_code in (400, 403)
     assert not (workspace.parent / "evil").exists()
 
 
@@ -274,7 +282,7 @@ def test_delete_directory_recursive(client, workspace):
 
 def test_delete_traversal_blocked(client, workspace):
     r = client.delete("/files/delete?path=/../../secret.txt", headers={**_AUTH, **_USER})
-    assert r.status_code in (400, 404)
+    assert r.status_code in (400, 403, 404)
     assert (workspace.parent.parent / "secret.txt").exists()  # untouched
 
 
@@ -295,7 +303,7 @@ def test_move_traversal_blocked(client, workspace):
         headers={**_AUTH, **_USER},
         json={"source": "/notes.txt", "destination": "/../stolen.txt"},
     )
-    assert r.status_code == 400
+    assert r.status_code in (400, 403)
     assert (workspace / "notes.txt").exists()  # unchanged
 
 

--- a/tests/test_terminal_files.py
+++ b/tests/test_terminal_files.py
@@ -1,0 +1,139 @@
+"""Tests for the Open Terminal-compatible read-only workspace file server."""
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.routes.terminal_files import router
+from src.routes import terminal_files as tf
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    root = tmp_path / "alice" / "claude"
+    root.mkdir(parents=True)
+    (root / "notes.txt").write_text("hello\nworld\n")
+    (root / "sub").mkdir()
+    (root / "sub" / "inner.md").write_text("# inner")
+    (root / "blob.bin").write_bytes(b"\xff\xfe\x00\x01binary")
+    # A secret OUTSIDE the workspace root, reachable only via traversal.
+    (tmp_path / "secret.txt").write_text("TOP SECRET")
+    return root
+
+
+@pytest.fixture
+def client(workspace, monkeypatch):
+    monkeypatch.setattr(tf.auth_manager, "get_api_key", lambda: "testkey")
+
+    def _resolve(user, backend=None):
+        if user == "alice":
+            return workspace
+        raise ValueError("bad user")
+
+    monkeypatch.setattr(tf.workspace_manager, "resolve", _resolve)
+
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+_AUTH = {"Authorization": "Bearer testkey"}
+# The proxy forwards the standard user-info headers; we key off the email localpart.
+_USER = {"X-OpenWebUI-User-Email": "alice@corp.com"}
+
+
+def test_config_advertises_readonly_no_terminal(client):
+    r = client.get("/api/config", headers=_AUTH)
+    assert r.status_code == 200
+    assert r.json() == {"features": {"terminal": False}}
+
+
+def test_cwd_is_virtual_root(client):
+    r = client.get("/files/cwd", headers={**_AUTH, **_USER})
+    assert r.status_code == 200
+    assert r.json()["cwd"] == "/"
+
+
+def test_list_root_sorts_dirs_first(client):
+    r = client.get("/files/list?directory=/", headers={**_AUTH, **_USER})
+    assert r.status_code == 200
+    entries = r.json()["entries"]
+    names = [e["name"] for e in entries]
+    assert names == ["sub", "blob.bin", "notes.txt"]  # dir first, then files a-z
+    sub = next(e for e in entries if e["name"] == "sub")
+    assert sub["type"] == "directory"
+    notes = next(e for e in entries if e["name"] == "notes.txt")
+    assert notes["type"] == "file" and notes["size"] == 12
+
+
+def test_list_subdirectory(client):
+    r = client.get("/files/list?directory=/sub", headers={**_AUTH, **_USER})
+    assert [e["name"] for e in r.json()["entries"]] == ["inner.md"]
+
+
+def test_read_text_returns_content_and_line_count(client):
+    r = client.get("/files/read?path=/notes.txt", headers={**_AUTH, **_USER})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["content"] == "hello\nworld\n"
+    assert body["total_lines"] == 3  # two lines + trailing newline
+
+
+def test_read_binary_returns_raw_bytes(client):
+    r = client.get("/files/read?path=/blob.bin", headers={**_AUTH, **_USER})
+    assert r.status_code == 200
+    assert r.content == b"\xff\xfe\x00\x01binary"
+    # Non-JSON content-type so the frontend renders a binary placeholder.
+    assert not r.headers["content-type"].startswith("application/json")
+
+
+def test_view_streams_file(client):
+    r = client.get("/files/view?path=/notes.txt", headers={**_AUTH, **_USER})
+    assert r.status_code == 200
+    assert r.content == b"hello\nworld\n"
+
+
+def test_path_traversal_is_blocked(client):
+    for p in ("/../secret.txt", "/../../secret.txt", "/sub/../../secret.txt"):
+        r = client.get(f"/files/read?path={p}", headers={**_AUTH, **_USER})
+        assert r.status_code == 404, p
+        assert "SECRET" not in r.text
+
+
+def test_missing_user_header_is_rejected(client):
+    r = client.get("/files/list?directory=/", headers=_AUTH)
+    assert r.status_code == 400
+
+
+def test_invalid_user_is_rejected(client):
+    r = client.get(
+        "/files/list?directory=/",
+        headers={**_AUTH, "X-OpenWebUI-User-Email": "../evil@x.com"},
+    )
+    assert r.status_code == 400
+
+
+def test_wrong_api_key_is_unauthorized(client):
+    r = client.get(
+        "/files/list?directory=/",
+        headers={"Authorization": "Bearer wrong", **_USER},
+    )
+    assert r.status_code == 401
+
+
+def test_fails_closed_when_api_key_unset(workspace, monkeypatch):
+    monkeypatch.setattr(tf.auth_manager, "get_api_key", lambda: "")
+    monkeypatch.setattr(tf.workspace_manager, "resolve", lambda user, backend=None: workspace)
+    app = FastAPI()
+    app.include_router(router)
+    c = TestClient(app)
+    # No API key configured -> the browser is disabled, not open to everyone.
+    r = c.get("/api/config")
+    assert r.status_code == 503
+
+
+def test_missing_file_is_404(client):
+    r = client.get("/files/read?path=/nope.txt", headers={**_AUTH, **_USER})
+    assert r.status_code == 404


### PR DESCRIPTION
Lets open-webui browse (and edit) a user's Claude workspace in its right-sidebar file explorer (FileNav). The gateway registers as an **Open Terminal** connection and implements that server's HTTP file contract, scoped per user.

Pairs with the open-webui side (`Kyutinium/open-webui#38`): forwarding the user identity header and an `ENABLE_TERMINAL_TOOLS=false` toggle so the connection is a pure file browser (no LLM tools).

## Endpoints (`src/routes/terminal_files.py`)

| Endpoint | Purpose |
|---|---|
| `GET /api/config` | handshake → `{"features":{"terminal":false}}` |
| `GET /files/openapi.json` | empty OpenAPI (`{"paths":{}}`) → zero LLM tools if the connection points its spec `path` here |
| `GET /files/cwd` | real workspace path (breadcrumb matches what the agent uses) |
| `GET /files/list?directory=` | `{"entries":[{name,type,size,modified}]}` |
| `GET /files/read?path=` | text `{path,total_lines,content}` \| raw bytes (binary) |
| `GET /files/view?path=` | raw bytes (download) |
| `POST /files/upload?directory=` | upload (also how "New File" creates an empty file) |
| `POST /files/mkdir` · `DELETE /files/delete` · `POST /files/move` · `POST /files/cwd` · `POST /files/archive` | create / delete / rename-move / cwd validate / zip |

## Identity & scoping

Reads a configurable, vendor-neutral header (`WORKSPACE_USER_HEADER`, default `X-User-Email`) and keys the workspace off its localpart — the same value the pipe uses for `/v1/responses` — via `workspace_manager.resolve(user, backend="claude")`. Each user sees only their own workspace.

## Config (env)

- `WORKSPACE_USER_HEADER` — inbound identity header (default `X-User-Email`).
- `WORKSPACE_HIDE_DOTFILES` — hide dot-prefixed entries (default `true`); hidden paths are neither listed nor accessible.

## Security

- Fails closed (503) unless `API_KEY` is set (`verify_api_key` is a no-op without one; these endpoints expose files).
- Every path (read AND write) is confined to the single workspace root (`Path.resolve()` + `relative_to`, so `..`/symlink escapes are rejected). No extra roots (never `~/.claude`).
- Above-/outside-root paths → **403** (so the explorer can warn "not allowed"); hidden/missing → 404.
- Uploaded filenames reduced to a basename.

## Notes

- **claude backend only** for now (`backend="claude"`); extendable later.
- Deployment: register the gateway as an Open Terminal connection (URL = gateway base, key = `API_KEY`, `auth_type=bearer`). Keep it a pure file browser by setting open-webui's `ENABLE_TERMINAL_TOOLS=false` (recommended) or pointing the connection spec `path` at `/files/openapi.json`.

## Tests

`tests/test_terminal_files.py` (33): config/empty-specs handshake, list (dirs-first), text/binary read, view, upload (+ empty "new file", filename-traversal → basename), mkdir/delete/move/archive, **path traversal + above-root 403 + outside-root**, dotfile hide/block + toggle-off exposure, configurable header name, wrong-key 401, **fail-closed without API_KEY**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFsj3J7EAZNr1TKZXYqoqm

---
_Generated by [Claude Code](https://claude.ai/code/session_01LFsj3J7EAZNr1TKZXYqoqm)_