### PR TITLE
fix(claude): surface AskUserQuestion via can_use_tool, not a PreToolUse hook

### DIFF
--- a/src/backends/claude/client.py
+++ b/src/backends/claude/client.py
@@ -24,6 +24,8 @@ from claude_agent_sdk.types import (
     SystemMessage,
     RateLimitEvent,
     HookMatcher,
+    PermissionResultAllow,
+    PermissionResultDeny,
 )
 from claude_agent_sdk.types import (
     SandboxSettings,
@@ -689,36 +691,42 @@ class ClaudeCodeCLI(TokenEstimateMixin):
 
         return hook
 
-    def _make_ask_user_hook(self, session):
-        """Create a PreToolUse hook that intercepts AskUserQuestion.
+    def _make_ask_user_can_use_tool(self, session):
+        """Create a ``can_use_tool`` callback that intercepts AskUserQuestion.
 
-        When AskUserQuestion is detected, parks the session and waits for
-        client input. Returns deny + user's response as the reason, which
-        the CLI converts to a tool_result that Claude reads as the answer.
+        AskUserQuestion is *not* surfaced to the model in headless SDK mode by a
+        PreToolUse hook alone — the current CLI only exposes it as a callable
+        tool when a ``can_use_tool`` permission callback is registered. (The
+        model literally reports it has no such tool otherwise; see issue #131.)
+        AskUserQuestion always falls through to this callback, even under
+        ``permission_mode=bypassPermissions`` where ordinary tools are
+        auto-approved without it — verified against claude-agent-sdk==0.2.108.
+
+        For AskUserQuestion we park the session and wait for the client's
+        answer, then deny with the answer as the message — the CLI turns the
+        deny message into a tool_result that Claude reads as the user's reply
+        (the same contract the old PreToolUse hook used). Every other tool that
+        reaches this callback is approved; hooks (workspace sandbox, Skill) run
+        before it, so this does not weaken those gates.
         """
 
-        async def hook(input_data, tool_use_id, _context):
-            tool_name = input_data.get("tool_name", "") if isinstance(input_data, dict) else ""
+        async def can_use_tool(tool_name, input_data, context):
             if tool_name != "AskUserQuestion":
-                return {}  # Allow other tools to proceed
+                return PermissionResultAllow()
 
-            tool_input = input_data.get("tool_input", {}) if isinstance(input_data, dict) else {}
-            actual_tool_use_id = (
-                input_data.get("tool_use_id", tool_use_id)
-                if isinstance(input_data, dict)
-                else tool_use_id
-            )
+            tool_input = input_data if isinstance(input_data, dict) else {}
+            call_id = getattr(context, "tool_use_id", None) or ""
 
             session.pending_tool_call = {
-                "call_id": actual_tool_use_id,
+                "call_id": call_id,
                 "name": "AskUserQuestion",
                 "arguments": tool_input,
             }
             session.input_event = asyncio.Event()
 
-            # Signal the streaming loop to break so the route can
-            # emit function_call + requires_action before the hook
-            # blocks waiting for user input.
+            # Signal the streaming loop to break so the route can emit
+            # function_call + requires_action before this callback blocks
+            # waiting for the user's answer.
             if session.stream_break_event is not None:
                 session.stream_break_event.set()
 
@@ -729,39 +737,27 @@ class ClaudeCodeCLI(TokenEstimateMixin):
                 )
             except asyncio.TimeoutError:
                 logger.warning(
-                    "AskUserQuestion hook timed out after %ds for session %s",
+                    "AskUserQuestion timed out after %ds for session %s",
                     ASK_USER_TIMEOUT_SECONDS,
                     session.session_id,
                 )
                 session.input_response = None
                 session.input_event = None
                 session.pending_tool_call = None
-                return {
-                    "hookSpecificOutput": {
-                        "hookEventName": "PreToolUse",
-                        "permissionDecision": "deny",
-                        "permissionDecisionReason": (
-                            "User did not respond within the timeout period."
-                        ),
-                    }
-                }
+                return PermissionResultDeny(
+                    message="User did not respond within the timeout period."
+                )
 
             # Capture response before clearing state
             user_response = session.input_response or ""
             session.input_response = None
             session.input_event = None
 
-            # Deny with user's response as reason — CLI converts this to
-            # a tool_result that Claude reads as the user's answer.
-            return {
-                "hookSpecificOutput": {
-                    "hookEventName": "PreToolUse",
-                    "permissionDecision": "deny",
-                    "permissionDecisionReason": f"User responded: {user_response}",
-                }
-            }
+            # Deny with the user's response as the message — the CLI converts
+            # this to a tool_result that Claude reads as the user's answer.
+            return PermissionResultDeny(message=f"User responded: {user_response}")
 
-        return hook
+        return can_use_tool
 
     async def update_request_policy(
         self,
@@ -865,11 +861,12 @@ class ClaudeCodeCLI(TokenEstimateMixin):
             user=user,
             forward_headers=forward_headers,
         )
+        # AskUserQuestion is intercepted via a can_use_tool callback (below),
+        # not a PreToolUse hook: the CLI only surfaces AskUserQuestion to the
+        # model as a callable tool when a permission callback is present.
+        options.can_use_tool = self._make_ask_user_can_use_tool(session)
+
         pre_tool_use = [
-            HookMatcher(
-                matcher="AskUserQuestion",
-                hooks=[self._make_ask_user_hook(session)],
-            ),
             # Force-approve the Skill tool. The gateway runs headless (no
             # interactive approver), so the CLI's per-skill permission "ask"
             # (surfaced to the client as an "Execute skill: <name>" error)

--- a/tests/test_ask_user_question_live.py
+++ b/tests/test_ask_user_question_live.py
@@ -1,17 +1,22 @@
-"""Live integration tests for AskUserQuestion via PreToolUse hooks.
+"""Live integration tests for AskUserQuestion via the can_use_tool callback.
 
 These tests use the real Claude Code CLI and SDK to verify that:
-1. PreToolUse hooks fire when AskUserQuestion is invoked
-2. The hook can await indefinitely for a client response
-3. bypassPermissions interacts correctly with hooks
+1. AskUserQuestion is surfaced to the model and reaches the can_use_tool callback
+2. The callback can await indefinitely for a client response, then resume
+3. This holds under permission_mode=bypassPermissions (the gateway's mode)
 
-NOTE: can_use_tool callbacks do NOT work — the CLI never sends
-control_request messages. PreToolUse hooks are the correct mechanism.
+NOTE (issue #131): the CLI surfaces AskUserQuestion to the model *only* when a
+``can_use_tool`` permission callback is registered. A PreToolUse hook alone does
+NOT expose the tool — the model reports it has no AskUserQuestion tool and the
+hook never fires. (An earlier revision claimed the opposite; it was true of an
+older CLI. Verified against claude-agent-sdk==0.2.108 + Claude CLI 2.1.x.)
 
 Requires: Claude Code CLI authenticated locally (claude auth status) and a
 reachable model endpoint, so these are marked ``e2e`` and excluded from the
 default suite (addopts -m 'not e2e'); run them with ``uv run pytest -m e2e``.
-Also skipped automatically if the CLI is not available.
+Also skipped automatically if the CLI is not available. Under a root user the
+CLI refuses --dangerously-skip-permissions (bypassPermissions); set
+``IS_SANDBOX=1`` to run these there.
 """
 
 import asyncio
@@ -19,7 +24,21 @@ import subprocess
 import pytest
 
 from claude_agent_sdk import ClaudeSDKClient, ClaudeAgentOptions
-from claude_agent_sdk.types import HookMatcher
+from claude_agent_sdk.types import (
+    HookMatcher,
+    PermissionResultAllow,
+    PermissionResultDeny,
+)
+
+# A well-formed request that naturally elicits AskUserQuestion. A heavy-handed
+# "you MUST call the tool now" prompt trips the model's prompt-injection defense
+# and it refuses, so keep this a genuine decision with real options.
+ASK_PROMPT = (
+    "I'm starting a new Python web service and need to pick a caching backend. "
+    "It's a real decision with genuine tradeoffs and I'd like your help. "
+    "Please ask me to choose between Redis, in-memory (lru_cache), and Memcached "
+    "using your AskUserQuestion tool so I can select one before we proceed."
+)
 
 
 def _cli_authenticated() -> bool:
@@ -45,86 +64,51 @@ pytestmark = [
 ]
 
 
-async def test_pretooluse_hook_fires_for_ask_user_question():
-    """Verify that a PreToolUse hook is invoked when Claude uses AskUserQuestion.
+async def test_can_use_tool_fires_for_ask_user_question():
+    """AskUserQuestion is surfaced and reaches the can_use_tool callback."""
+    seen = []
+    fired = asyncio.Event()
 
-    Sends a prompt designed to trigger AskUserQuestion, then checks
-    that the hook received the tool_name.
-
-    NOTE: This test depends on Claude actually calling AskUserQuestion,
-    which is LLM behavior and inherently non-deterministic.
-    """
-    callback_log = []
-    callback_event = asyncio.Event()
-
-    async def hook(input_data, tool_use_id, context):
-        tool_name = input_data.get("tool_name", "") if isinstance(input_data, dict) else ""
-        tool_input = input_data.get("tool_input", {}) if isinstance(input_data, dict) else {}
-        callback_log.append({"tool_name": tool_name, "input": tool_input})
+    async def can_use_tool(tool_name, input_data, context):
+        seen.append(tool_name)
         if tool_name == "AskUserQuestion":
-            callback_event.set()
-            return {
-                "hookSpecificOutput": {
-                    "hookEventName": "PreToolUse",
-                    "permissionDecision": "deny",
-                    "permissionDecisionReason": "User responded: yes",
-                }
-            }
-        return {
-            "hookSpecificOutput": {
-                "hookEventName": "PreToolUse",
-                "permissionDecision": "allow",
-            }
-        }
+            fired.set()
+            return PermissionResultDeny(message="User responded: Redis")
+        return PermissionResultAllow()
 
     options = ClaudeAgentOptions(
         max_turns=3,
         permission_mode="bypassPermissions",
-        hooks={
-            "PreToolUse": [
-                HookMatcher(
-                    matcher="AskUserQuestion",
-                    hooks=[hook],
-                )
-            ]
-        },
+        can_use_tool=can_use_tool,
+        system_prompt={"type": "preset", "preset": "claude_code"},
     )
 
     client = ClaudeSDKClient(options=options)
     try:
         await client.connect(prompt=None)
-        await client.query(
-            "Before doing ANYTHING, you MUST use AskUserQuestion to ask the user "
-            "'Should I proceed?' — do not use any other tool first. "
-            "This is critical: call AskUserQuestion immediately."
-        )
-
-        # Wait for either the callback or a timeout
+        await client.query(ASK_PROMPT)
         try:
-            async with asyncio.timeout(30):
+            async with asyncio.timeout(60):
                 async for _msg in client.receive_response():
-                    if callback_event.is_set():
+                    if fired.is_set():
                         break
         except TimeoutError:
             pass
-
     finally:
         await client.disconnect()
 
-    # Check if AskUserQuestion was seen in the hook
-    ask_calls = [c for c in callback_log if c["tool_name"] == "AskUserQuestion"]
-    if len(ask_calls) == 0:
+    if "AskUserQuestion" not in seen:
         pytest.skip(
             f"Claude did not call AskUserQuestion (LLM non-determinism). "
-            f"Tools seen: {[c['tool_name'] for c in callback_log]}"
+            f"Tools seen: {seen}"
         )
 
 
 async def test_pretooluse_hook_receives_tool_permissions():
-    """Verify that a PreToolUse hook receives permission requests for tools.
+    """PreToolUse hooks still fire for ordinary tools (used for Skill/sandbox).
 
-    Uses a broad matcher (None = all tools) to confirm the hook mechanism works
-    by checking that at least one tool goes through the hook.
+    Uses a broad matcher (None = all tools) to confirm the hook mechanism the
+    gateway relies on for the workspace sandbox and Skill auto-approve is active.
     """
     callback_log = []
 
@@ -169,92 +153,67 @@ async def test_pretooluse_hook_receives_tool_permissions():
     )
 
 
-async def test_hook_can_await_for_response():
-    """Verify that a PreToolUse hook can await indefinitely for external input.
+async def test_can_use_tool_can_await_for_response():
+    """The can_use_tool callback can block for external input, then resume.
 
-    This simulates the AskUserQuestion interception pattern where the hook
-    blocks until a client provides a response via asyncio.Event.
+    Mirrors the gateway's park/wait pattern: the callback blocks on an
+    asyncio.Event until the HTTP layer supplies the answer, then denies with
+    the answer as the message so Claude reads it as the user's reply.
     """
-    hook_started = asyncio.Event()
+    cb_started = asyncio.Event()
     external_event = asyncio.Event()
-    hook_completed = asyncio.Event()
+    cb_completed = asyncio.Event()
 
-    async def hook(input_data, tool_use_id, context):
-        tool_name = input_data.get("tool_name", "") if isinstance(input_data, dict) else ""
+    async def can_use_tool(tool_name, input_data, context):
         if tool_name == "AskUserQuestion":
-            hook_started.set()
-            # Simulate waiting for external input
-            await external_event.wait()
-            hook_completed.set()
-            return {
-                "hookSpecificOutput": {
-                    "hookEventName": "PreToolUse",
-                    "permissionDecision": "deny",
-                    "permissionDecisionReason": "User responded: proceed",
-                }
-            }
-        return {
-            "hookSpecificOutput": {
-                "hookEventName": "PreToolUse",
-                "permissionDecision": "allow",
-            }
-        }
+            cb_started.set()
+            await external_event.wait()  # simulate waiting for the client
+            cb_completed.set()
+            return PermissionResultDeny(message="User responded: Redis")
+        return PermissionResultAllow()
 
     options = ClaudeAgentOptions(
-        max_turns=1,
-        hooks={
-            "PreToolUse": [
-                HookMatcher(
-                    matcher="AskUserQuestion",
-                    hooks=[hook],
-                    timeout=60,  # Long timeout for the await
-                )
-            ]
-        },
+        max_turns=2,
+        permission_mode="bypassPermissions",
+        can_use_tool=can_use_tool,
+        system_prompt={"type": "preset", "preset": "claude_code"},
     )
 
     client = ClaudeSDKClient(options=options)
     try:
         await client.connect(prompt=None)
-        await client.query(
-            "Before doing ANYTHING, you MUST use AskUserQuestion to ask "
-            "'Should I proceed?' — call it immediately."
-        )
+        await client.query(ASK_PROMPT)
 
-        # Start receiving in a background task
         async def receive():
             async for _msg in client.receive_response():
                 pass
 
         recv_task = asyncio.create_task(receive())
 
-        # Wait for the hook to start (or timeout)
         try:
-            async with asyncio.timeout(30):
-                await hook_started.wait()
+            async with asyncio.timeout(60):
+                await cb_started.wait()
         except TimeoutError:
+            recv_task.cancel()
             pytest.skip("AskUserQuestion was not triggered within timeout")
             return
 
-        # The hook is now blocking — unblock it
+        # The callback is now blocking — unblock it.
         external_event.set()
 
-        # Wait for hook to complete
         try:
-            async with asyncio.timeout(10):
-                await hook_completed.wait()
+            async with asyncio.timeout(60):
+                await cb_completed.wait()
         except TimeoutError:
-            pytest.fail("Hook did not complete after external event was set")
+            pytest.fail("can_use_tool did not complete after external event was set")
 
-        # Clean up the receive task
-        recv_task.cancel()
         try:
-            await recv_task
-        except asyncio.CancelledError:
-            pass
-
+            async with asyncio.timeout(60):
+                await recv_task
+        except (TimeoutError, asyncio.CancelledError):
+            recv_task.cancel()
     finally:
         await client.disconnect()
 
-    assert hook_started.is_set(), "Hook should have started"
-    assert hook_completed.is_set(), "Hook should have completed after event was set"
+    assert cb_started.is_set(), "callback should have started"
+    assert cb_completed.is_set(), "callback should have completed after event was set"

--- a/tests/test_sdk_client_backend.py
+++ b/tests/test_sdk_client_backend.py
@@ -1,12 +1,15 @@
 """Tests for ClaudeSDKClient integration methods on ClaudeCodeCLI.
 
-Covers create_client(), run_completion_with_client(), and _make_ask_user_hook().
+Covers create_client(), run_completion_with_client(), and
+_make_ask_user_can_use_tool().
 All SDK interactions are mocked — no real subprocess or Anthropic credentials required.
 """
 
 import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
+
+from claude_agent_sdk.types import PermissionResultAllow, PermissionResultDeny
 
 from src.session_manager import Session
 
@@ -58,7 +61,12 @@ async def test_create_client_returns_connected_client():
 
 
 async def test_create_client_sets_hooks():
-    """create_client() sets PreToolUse hooks: AskUserQuestion intercept + Skill auto-approve."""
+    """create_client() sets a can_use_tool callback (AskUserQuestion intercept)
+    and a Skill auto-approve PreToolUse hook.
+
+    AskUserQuestion is handled via can_use_tool — not a PreToolUse hook — because
+    the CLI only surfaces it as a callable tool when a permission callback is
+    present (issue #131)."""
     cli = _make_cli()
     session = Session(session_id="sess-2")
 
@@ -75,14 +83,17 @@ async def test_create_client_sets_hooks():
         MockSDKClient.side_effect = capture_init
         await cli.create_client(session)
 
-    # The options object passed to ClaudeSDKClient must have hooks set
     options = captured_options.get("options")
     assert options is not None
+    # AskUserQuestion is intercepted via can_use_tool, no longer a hook.
+    assert callable(options.can_use_tool)
     assert options.hooks is not None
     assert "PreToolUse" in options.hooks
     matchers = options.hooks["PreToolUse"]
     by_matcher = {m.matcher: m for m in matchers}
-    assert set(by_matcher) == {"AskUserQuestion", "Skill"}
+    # AskUserQuestion must NOT be a PreToolUse hook anymore; Skill remains.
+    assert "AskUserQuestion" not in by_matcher
+    assert "Skill" in by_matcher
     for matcher in by_matcher.values():
         assert len(matcher.hooks) == 1
         assert callable(matcher.hooks[0])
@@ -262,106 +273,93 @@ async def test_run_completion_with_client_error_during_receive():
 
 
 # ---------------------------------------------------------------------------
-# _make_ask_user_hook (PreToolUse hook)
+# _make_ask_user_can_use_tool (can_use_tool permission callback)
 # ---------------------------------------------------------------------------
 
 
-async def test_hook_allows_other_tools():
-    """Non-AskUserQuestion tools get an empty dict (allow and proceed)."""
+def _ctx(tool_use_id):
+    """Minimal stand-in for the SDK's ToolPermissionContext."""
+    return SimpleNamespace(tool_use_id=tool_use_id)
+
+
+async def test_can_use_tool_allows_other_tools():
+    """Non-AskUserQuestion tools are approved (PermissionResultAllow)."""
     cli = _make_cli()
     session = Session(session_id="sess-other-tool")
 
-    hook = cli._make_ask_user_hook(session)
+    can_use_tool = cli._make_ask_user_can_use_tool(session)
 
-    # input_data is a plain dict (not a dataclass) per SDK contract
-    input_data = {
-        "tool_name": "BashTool",
-        "tool_input": {"command": "ls"},
-        "tool_use_id": "tu_123",
-    }
-    result = await hook(input_data, "tu_123", {})
+    # can_use_tool receives the tool input dict directly (not wrapped).
+    result = await can_use_tool("BashTool", {"command": "ls"}, _ctx("tu_123"))
 
-    assert result == {}
+    assert isinstance(result, PermissionResultAllow)
     # Session fields should NOT be modified
     assert session.pending_tool_call is None
     assert session.input_event is None
 
 
-async def test_hook_intercepts_ask_user_question():
-    """AskUserQuestion hook sets pending_tool_call, waits, then returns deny+reason."""
+async def test_can_use_tool_intercepts_ask_user_question():
+    """AskUserQuestion parks pending_tool_call, waits, then denies with the answer."""
     cli = _make_cli()
     session = Session(session_id="sess-ask")
 
-    hook = cli._make_ask_user_hook(session)
+    can_use_tool = cli._make_ask_user_can_use_tool(session)
 
-    # input_data is a plain dict per SDK contract
-    input_data = {
-        "tool_name": "AskUserQuestion",
-        "tool_input": {"question": "Continue?"},
-        "tool_use_id": "tu_ask_1",
-    }
+    input_data = {"question": "Continue?"}
 
-    # Run hook in a task — it will block on input_event.wait()
+    # Run the callback in a task — it will block on input_event.wait()
     result_holder = []
 
-    async def run_hook():
-        result = await hook(input_data, None, {})
+    async def run_cb():
+        result = await can_use_tool("AskUserQuestion", input_data, _ctx("tu_ask_1"))
         result_holder.append(result)
 
-    task = asyncio.create_task(run_hook())
+    task = asyncio.create_task(run_cb())
 
-    # Allow the hook to start and park
+    # Allow the callback to start and park
     await asyncio.sleep(0.05)
 
-    # Verify the session was updated with pending_tool_call
+    # Verify the session was updated with pending_tool_call. call_id comes from
+    # context.tool_use_id; arguments are the input_data dict verbatim.
     assert session.pending_tool_call is not None
     assert session.pending_tool_call["call_id"] == "tu_ask_1"
     assert session.pending_tool_call["name"] == "AskUserQuestion"
     assert session.pending_tool_call["arguments"] == {"question": "Continue?"}
 
-    # Verify input_event was created
     assert session.input_event is not None
 
     # Simulate the HTTP layer providing a response
     session.input_response = "Yes, continue"
     session.input_event.set()
 
-    # Wait for hook to complete
     await task
 
-    # Hook should have returned deny + reason (user's answer)
+    # Callback should have returned deny + the user's answer as the message
     assert len(result_holder) == 1
     result = result_holder[0]
-    assert "hookSpecificOutput" in result
-    assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
-    assert "Yes, continue" in result["hookSpecificOutput"]["permissionDecisionReason"]
+    assert isinstance(result, PermissionResultDeny)
+    assert "Yes, continue" in result.message
 
-    # After hook completes, input_response and input_event are reset
+    # After completion, input_response and input_event are reset
     assert session.input_response is None
     assert session.input_event is None
 
 
-async def test_hook_times_out_when_client_does_not_respond():
-    """Hook returns deny with timeout message when wait exceeds timeout."""
+async def test_can_use_tool_times_out_when_client_does_not_respond():
+    """Callback returns deny with a timeout message when the wait exceeds timeout."""
     cli = _make_cli()
     session = Session(session_id="sess-timeout")
 
-    hook = cli._make_ask_user_hook(session)
-
-    input_data = {
-        "tool_name": "AskUserQuestion",
-        "tool_input": {"question": "Respond?"},
-        "tool_use_id": "tu_timeout_1",
-    }
+    can_use_tool = cli._make_ask_user_can_use_tool(session)
 
     # Patch timeout to a very short value so the test completes quickly
     with patch("src.backends.claude.client.ASK_USER_TIMEOUT_SECONDS", 0.05):
-        result = await hook(input_data, None, {})
+        result = await can_use_tool(
+            "AskUserQuestion", {"question": "Respond?"}, _ctx("tu_timeout_1")
+        )
 
-    # Should have returned a deny with timeout message
-    assert "hookSpecificOutput" in result
-    assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
-    assert "timeout" in result["hookSpecificOutput"]["permissionDecisionReason"].lower()
+    assert isinstance(result, PermissionResultDeny)
+    assert "timeout" in result.message.lower()
 
     # Session state should be cleaned up
     assert session.pending_tool_call is None


### PR DESCRIPTION
Closes #131.

## Problem

Under the **Claude backend**, `AskUserQuestion` was never exposed to the model, so the interactive question-card flow (which works on codex/opencode) silently degraded to plain text. The model reports *"I don't have an AskUserQuestion tool"* even though the gateway registers a `PreToolUse` hook for it and forwards it in `allowed_tools`.

## Root cause

The current Claude CLI only surfaces `AskUserQuestion` to the model as a **callable tool when a `can_use_tool` permission callback is registered**. The gateway relied on a `PreToolUse` hook + `allowed_tools`, which:

- does **not** make the tool callable (allowed_tools is an auto-approve hint, especially under `bypassPermissions`; and the hook only fires when the model *calls* the tool), so
- the model never sees the tool → never calls it → the hook can never fire.

This is a CLI-behavior change, not a gateway regression. The CLI is not version-pinned (the SDK is pinned at `0.2.108`, but it spawns whatever `claude` is on PATH). An older CLI surfaced `AskUserQuestion` via the hook path and did **not** send permission `control_request` messages (hence the old "can_use_tool doesn't work" note). A newer CLI now sends `control_request` — so `can_use_tool` works — and gates `AskUserQuestion` visibility on the presence of a permission callback. The mechanism silently flipped from hook → can_use_tool.

## Fix

Replace the `AskUserQuestion` `PreToolUse` hook with an `options.can_use_tool` callback that reuses the **exact same park/wait machinery**:

- on `AskUserQuestion`: record `session.pending_tool_call` (`call_id` from `context.tool_use_id`), set `stream_break_event` so the route emits `function_call` + `requires_action`, wait on `input_event` for the client's answer, then return `PermissionResultDeny(message="User responded: …")` — which the CLI turns into a `tool_result` Claude reads as the reply (same contract the hook used).
- every other tool → `PermissionResultAllow()`. The `Skill` and workspace-sandbox `PreToolUse` hooks run **before** `can_use_tool` and are unchanged, so those gates aren't weakened.

The route-level `function_call` / `requires_action` / resume path needs **no change** — `can_use_tool` blocks inside `receive_response()` exactly as the hook did.

## Verification

Live, against `claude-agent-sdk==0.2.108` + Claude CLI 2.1.x:

- **Before (hook only):** model replies `NO_TOOL` — tool not surfaced.
- **After (can_use_tool):** the callback receives `AskUserQuestion` and the answer round-trips — including under `permission_mode=bypassPermissions` (the gateway's mode; `AskUserQuestion` falls through to the callback even though ordinary tools are auto-approved).
- Coordination test confirms the `break_event` race in `run_completion_with_client` breaks correctly and the session resumes after the answer is delivered.

Tests:
- `tests/test_sdk_client_backend.py` updated to the `can_use_tool` mechanism — 11 passed.
- `tests/test_ask_user_question_live.py` (e2e) rewritten to verify `can_use_tool` (and the stale "can_use_tool doesn't work" note corrected) — 3 passed live.
- Full smoke: 230 passed; the 8 failing `test_ask_user_question.py` cases fail identically on clean `main` (pre-existing/environment, unrelated to this change).

## Follow-up (not in this PR)

Consider **pinning the Claude CLI version** in the Dockerfile so a future CLI update can't silently flip the mechanism again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFsj3J7EAZNr1TKZXYqoqm

---
_Generated by [Claude Code](https://claude.ai/code/session_01LFsj3J7EAZNr1TKZXYqoqm)_