### PR TITLE
fix(workspace): exclude hidden entries from directory archives

### DIFF
--- a/src/routes/terminal_files.py
+++ b/src/routes/terminal_files.py
@@ -439,12 +439,26 @@ async def archive_entries(
             raise HTTPException(status_code=404, detail=f"not found: {p}")
         targets.append(t)
 
+    hide_dot = _hide_dotfiles()
+
+    def _is_hidden(p: Path) -> bool:
+        # Same rule as listing/_resolve_or_403: any dot-prefixed component
+        # relative to the workspace root is hidden. Keeps downloads consistent
+        # with the browser view — e.g. ``.claude`` never ends up in the zip.
+        return hide_dot and any(
+            part.startswith(".") for part in p.relative_to(root_resolved).parts
+        )
+
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
         for t in targets:
             if t.is_dir():
                 for sub in t.rglob("*"):
-                    if sub.is_file() and not sub.is_symlink():
+                    if (
+                        sub.is_file()
+                        and not sub.is_symlink()
+                        and not _is_hidden(sub)
+                    ):
                         zf.write(sub, arcname=str(sub.relative_to(root_resolved)))
             elif t.is_file() and not t.is_symlink():
                 zf.write(t, arcname=str(t.relative_to(root_resolved)))

--- a/tests/test_terminal_files.py
+++ b/tests/test_terminal_files.py
@@ -341,6 +341,39 @@ def test_archive_zips_selection(client):
     assert "notes.txt" in names and "sub/inner.md" in names
 
 
+def test_archive_excludes_hidden_entries(client):
+    """Directory downloads must not sweep in dotfiles (e.g. .claude) that the
+    browser hides — the zip mirrors the visible listing."""
+    r = client.post(
+        "/files/archive",
+        headers={**_AUTH, **_USER},
+        json={"paths": ["/"]},
+    )
+    assert r.status_code == 200
+    import io as _io
+    import zipfile as _zip
+
+    names = _zip.ZipFile(_io.BytesIO(r.content)).namelist()
+    assert "notes.txt" in names and "sub/inner.md" in names
+    assert ".env" not in names
+    assert not any(n.startswith(".secret_dir/") for n in names)
+
+
+def test_archive_includes_hidden_when_disabled(client, monkeypatch):
+    monkeypatch.setenv("WORKSPACE_HIDE_DOTFILES", "false")
+    r = client.post(
+        "/files/archive",
+        headers={**_AUTH, **_USER},
+        json={"paths": ["/"]},
+    )
+    assert r.status_code == 200
+    import io as _io
+    import zipfile as _zip
+
+    names = _zip.ZipFile(_io.BytesIO(r.content)).namelist()
+    assert ".env" in names and ".secret_dir/k.txt" in names
+
+
 def test_writes_fail_closed_without_api_key(workspace, monkeypatch):
     _patch_api_key(monkeypatch, "")
     monkeypatch.setattr(tf.workspace_manager, "resolve", lambda user, backend=None: workspace)


### PR DESCRIPTION
## Problem

Listing/read/view hide dot-prefixed entries when `WORKSPACE_HIDE_DOTFILES` is on (the default), but the `/files/archive` walk zipped everything under a directory — so a workspace download from the file browser swept in `.claude` and other dotfiles the browser never shows.

## Fix

Apply the same hidden rule the listing and `_resolve_or_403` use — any dot-prefixed component relative to the workspace root — to the archive's `rglob` walk. The zip now mirrors exactly what the browser displays.

- Explicitly-targeted hidden paths were already 404ed by `_resolve_or_403`; this closes the remaining leak via recursive directory walks.
- With `WORKSPACE_HIDE_DOTFILES=false`, archives still include dotfiles (covered by a test).

## Tests

Two new tests in `tests/test_terminal_files.py`:
- workspace-root archive excludes `.env` / `.secret_dir/*` while including regular files
- with hiding disabled, dotfiles are included

Full file-server suite: **35 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFsj3J7EAZNr1TKZXYqoqm

---
_Generated by [Claude Code](https://claude.ai/code/session_01LFsj3J7EAZNr1TKZXYqoqm)_