### PR TITLE
perf(files): run workspace file I/O in the threadpool, off the event loop

### DIFF
--- a/src/routes/terminal_files.py
+++ b/src/routes/terminal_files.py
@@ -30,6 +30,13 @@ Config:
 - ``WORKSPACE_HIDE_DOTFILES`` — when true (default), dot-prefixed entries are
   neither listed nor accessible.
 
+Concurrency:
+- Filesystem work (directory scans, file reads/writes, deletes, zip builds) runs
+  in the threadpool via ``run_in_threadpool``. FileNav polls ``/files/list``
+  continuously for every connected user; done synchronously that I/O would
+  block the gateway event loop and stall everything else it serves
+  (``/v1/responses`` streams, terminal websockets).
+
 Security:
 - ``API_KEY`` MUST be configured; otherwise ``verify_api_key`` is a no-op and
   these endpoints would expose every user's files unauthenticated, so we fail
@@ -51,6 +58,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, File, HTTPException, Request, Response, UploadFile
+from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import FileResponse, StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials
 from pydantic import BaseModel
@@ -248,25 +256,34 @@ async def list_files(
         raise HTTPException(status_code=404, detail="directory not found")
 
     hide_dot = _hide_dotfiles()
-    entries = []
-    with os.scandir(target) as it:
-        for entry in it:
-            if hide_dot and entry.name.startswith("."):
-                continue
-            try:
-                st = entry.stat()  # follow symlinks; broken links are skipped
-            except OSError:
-                continue
-            entries.append(
-                {
-                    "name": entry.name,
-                    "type": "directory" if stat_module.S_ISDIR(st.st_mode) else "file",
-                    "size": st.st_size,
-                    "modified": int(st.st_mtime),
-                }
-            )
-    entries.sort(key=lambda e: (e["type"] != "directory", e["name"].lower()))
-    return {"entries": entries}
+
+    # Run the directory scan off the event loop: FileNav polls this endpoint
+    # continuously across all users, and a synchronous scandir would stall
+    # every other request (chat streams, terminal websockets) on the loop.
+    def _scan() -> list:
+        entries = []
+        with os.scandir(target) as it:
+            for entry in it:
+                if hide_dot and entry.name.startswith("."):
+                    continue
+                try:
+                    st = entry.stat()  # follow symlinks; broken links are skipped
+                except OSError:
+                    continue
+                entries.append(
+                    {
+                        "name": entry.name,
+                        "type": (
+                            "directory" if stat_module.S_ISDIR(st.st_mode) else "file"
+                        ),
+                        "size": st.st_size,
+                        "modified": int(st.st_mtime),
+                    }
+                )
+        entries.sort(key=lambda e: (e["type"] != "directory", e["name"].lower()))
+        return entries
+
+    return {"entries": await run_in_threadpool(_scan)}
 
 
 @router.get("/files/read")
@@ -288,7 +305,7 @@ async def read_file(
             detail=f"file too large to preview (> {_MAX_READ_BYTES} bytes); use download",
         )
 
-    data = target.read_bytes()
+    data = await run_in_threadpool(target.read_bytes)
     try:
         text = data.decode("utf-8")
     except UnicodeDecodeError:
@@ -358,7 +375,7 @@ async def upload_file(
     target = _resolve_or_403(root, f"{directory}/{name}")
 
     data = await file.read()
-    target.write_bytes(data)
+    await run_in_threadpool(target.write_bytes, data)
     return {"path": str(target), "size": len(data)}
 
 
@@ -393,10 +410,11 @@ async def delete_entry(
     if not target.exists():
         raise HTTPException(status_code=404, detail="not found")
     is_dir = target.is_dir() and not target.is_symlink()
+    # rmtree over a large workspace subtree can take seconds — keep it off the loop.
     if is_dir:
-        shutil.rmtree(target)
+        await run_in_threadpool(shutil.rmtree, target)
     else:
-        target.unlink()
+        await run_in_threadpool(target.unlink)
     return {"path": path, "type": "directory" if is_dir else "file"}
 
 
@@ -417,7 +435,7 @@ async def move_entry(
         raise HTTPException(status_code=404, detail="source not found")
     if not dst.parent.is_dir():
         raise HTTPException(status_code=404, detail="destination directory not found")
-    shutil.move(str(src), str(dst))
+    await run_in_threadpool(shutil.move, str(src), str(dst))
     return {"source": body.source, "destination": body.destination}
 
 
@@ -449,22 +467,27 @@ async def archive_entries(
             part.startswith(".") for part in p.relative_to(root_resolved).parts
         )
 
-    buf = io.BytesIO()
-    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
-        for t in targets:
-            if t.is_dir():
-                for sub in t.rglob("*"):
-                    if (
-                        sub.is_file()
-                        and not sub.is_symlink()
-                        and not _is_hidden(sub)
-                    ):
-                        zf.write(sub, arcname=str(sub.relative_to(root_resolved)))
-            elif t.is_file() and not t.is_symlink():
-                zf.write(t, arcname=str(t.relative_to(root_resolved)))
-    buf.seek(0)
+    # Walking the tree and deflating can take seconds on big workspaces — keep
+    # the whole zip build off the event loop.
+    def _build_zip() -> bytes:
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            for t in targets:
+                if t.is_dir():
+                    for sub in t.rglob("*"):
+                        if (
+                            sub.is_file()
+                            and not sub.is_symlink()
+                            and not _is_hidden(sub)
+                        ):
+                            zf.write(sub, arcname=str(sub.relative_to(root_resolved)))
+                elif t.is_file() and not t.is_symlink():
+                    zf.write(t, arcname=str(t.relative_to(root_resolved)))
+        return buf.getvalue()
+
+    payload = await run_in_threadpool(_build_zip)
     return StreamingResponse(
-        iter([buf.getvalue()]),
+        iter([payload]),
         media_type="application/zip",
         headers={"Content-Disposition": 'attachment; filename="archive.zip"'},
     )


### PR DESCRIPTION
## 배경

open-webui 쪽 인시던트(Kyutinium/open-webui#47 코멘트 참고): FileNav 주기 폴링이 몰리면 `/health`가 밀려 외부 헬스체크가 false-positive로 컨테이너를 재시작하는 루프가 발생했습니다. 조사 결과 실제 블로킹 지점은 이 gateway의 `src/routes/terminal_files.py` — `async def` 핸들러 안에서 동기 파일시스템 I/O를 실행해 **gateway 이벤트 루프 전체**(`/v1/responses` 스트리밍, 터미널 웹소켓 포함)가 파일 I/O에 직렬화되는 구조였습니다.

## 변경

블로킹 파일시스템 작업을 `run_in_threadpool`로 이벤트 루프 밖으로 오프로드:

- `/files/list` — `os.scandir` 스캔 (폴링으로 가장 자주 호출됨)
- `/files/read` — 프리뷰 파일 읽기
- `/files/upload` — 쓰기
- `/files/delete` — `shutil.rmtree` (큰 서브트리에서 수 초 소요 가능)
- `/files/move` — `shutil.move` (cross-device면 복사)
- `/files/archive` — zip 빌드 전체 (walk + deflate)

단일 stat 수준의 가벼운 검사(`resolve`/`is_dir`/`is_file`)는 인라인 유지. `/files/view`는 `FileResponse`가 자체적으로 스레드풀에서 읽으므로 변경 없음.

## 동작 변화

없음 — 순수 동시성 개선입니다. HTTPException 등 에러 경로도 동일하게 전파됩니다.

## 테스트

- `uv run pytest tests/test_terminal_files.py -q` → 35 passed
- 전체 스위트: 이 변경과 무관한 기존 실패(opencode 커버리지 테스트 순서 이슈, sqlite usage 테스트)만 존재 — 클린 main에서도 동일하게 재현됨을 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFsj3J7EAZNr1TKZXYqoqm

---
_Generated by [Claude Code](https://claude.ai/code/session_01LFsj3J7EAZNr1TKZXYqoqm)_