### PR TITLE
feat(workspace): inline file serving endpoint for HTML preview (/files/serve)

### DIFF
--- a/src/routes/terminal_files.py
+++ b/src/routes/terminal_files.py
@@ -13,6 +13,7 @@ Contract (what FileNav calls):
 - ``GET  /files/search?query=<q>``    -> ``{"results": [{path,name,type,size,modified}], "truncated"}``
 - ``GET  /files/read?path=<p>``       -> text ``{path,total_lines,content}`` | raw bytes (binary)
 - ``GET  /files/view?path=<p>``       -> raw bytes (download)
+- ``GET  /files/serve/<path>``        -> raw bytes, inline (HTML iframe preview; relative assets)
 - ``POST /files/upload?directory=<p>``-> ``{path,size}`` (also how "new file" is created)
 - ``POST /files/mkdir``  {path}       -> ``{path}``
 - ``DELETE /files/delete?path=<p>``   -> ``{path,type}``
@@ -415,6 +416,33 @@ async def view_file(
 
     media = mimetypes.guess_type(target.name)[0] or "application/octet-stream"
     return FileResponse(target, media_type=media, filename=target.name)
+
+
+@router.get("/files/serve/{path:path}")
+async def serve_file(
+    request: Request,
+    path: str,
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+):
+    """Serve a file inline for in-browser preview.
+
+    FileNav previews HTML documents via ``<iframe src=".../files/serve/<path>">``
+    (path-based, unlike the query-based ``/files/view`` download endpoint) so
+    that relative references inside the document — ``./style.css``, images,
+    scripts — resolve to sibling files through this same route. The leading
+    slash of the absolute workspace path is consumed by the URL, so re-anchor
+    before resolving; confinement and dotfile hiding are the same as every
+    other endpoint.
+    """
+    await verify_api_key(request, credentials)
+    _ensure_api_key()
+    root = _workspace_root(_require_user(request))
+    target = _resolve_or_403(root, path if path.startswith("/") else f"/{path}")
+    if not target.is_file():
+        raise HTTPException(status_code=404, detail="file not found")
+
+    media = mimetypes.guess_type(target.name)[0] or "application/octet-stream"
+    return FileResponse(target, media_type=media, content_disposition_type="inline")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_terminal_files.py
+++ b/tests/test_terminal_files.py
@@ -430,3 +430,44 @@ def test_writes_fail_closed_without_api_key(workspace, monkeypatch):
     c = TestClient(app)
     r = c.post("/files/mkdir", json={"path": "/x"})
     assert r.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# /files/serve — inline serving for the HTML iframe preview
+# ---------------------------------------------------------------------------
+
+
+def test_serve_html_inline_with_content_type(client, workspace):
+    (workspace / "page.html").write_text("<h1>hi</h1>")
+    d = str(workspace.resolve())
+    r = client.get(f"/files/serve{d}/page.html", headers={**_AUTH, **_USER})
+    assert r.status_code == 200
+    assert r.text == "<h1>hi</h1>"
+    assert r.headers["content-type"].startswith("text/html")
+    assert "attachment" not in r.headers.get("content-disposition", "")
+
+
+def test_serve_resolves_sibling_asset(client, workspace):
+    # Relative references inside a served HTML document resolve through the
+    # same route — e.g. ./app.css next to the page.
+    (workspace / "site").mkdir()
+    (workspace / "site" / "index.html").write_text('<link href="./app.css">')
+    (workspace / "site" / "app.css").write_text("body{}")
+    d = str(workspace.resolve())
+    r = client.get(f"/files/serve{d}/site/app.css", headers={**_AUTH, **_USER})
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("text/css")
+    assert r.text == "body{}"
+
+
+def test_serve_outside_root_never_leaks(client, workspace):
+    outside = str(workspace.parent.parent / "secret.txt")
+    r = client.get(f"/files/serve{outside}", headers={**_AUTH, **_USER})
+    assert r.status_code in (403, 404)
+    assert "SECRET" not in r.text
+
+
+def test_serve_hidden_file_is_404(client, workspace):
+    d = str(workspace.resolve())
+    r = client.get(f"/files/serve{d}/.env", headers={**_AUTH, **_USER})
+    assert r.status_code == 404


### PR DESCRIPTION
## 배경

open-webui FileNav에서 마크다운은 미리보기가 되는데 HTML은 빈 화면이 나오는 문제. 프론트는 시스템 터미널일 때 HTML을 `<iframe src=".../files/serve/<경로>">`로 렌더링하도록 이미 구현되어 있지만, 이 서버에 `/files/serve` 라우트가 없어서 iframe이 404를 받고 있었습니다. (마크다운은 `/files/read`로 받은 텍스트를 클라이언트에서 렌더링하므로 무관.)

## 변경

`GET /files/serve/{path:path}` 추가:

- 파일을 **inline**으로 서빙 (`/files/view`는 다운로드용 attachment) — 확장자 기반 content-type.
- 경로 기반 라우트라 HTML 문서 안의 상대 참조(`./style.css`, 이미지, 스크립트)가 같은 라우트의 형제 경로로 해석되어 함께 로드됩니다.
- 보안 경계는 기존 엔드포인트와 동일: `_resolve_or_403` 워크스페이스 confinement, dotfile 숨김(404), API_KEY 미설정 시 503 fail-closed. `FileResponse`라 파일 읽기는 이벤트 루프 밖에서 수행됩니다.

## 테스트

`uv run pytest tests/test_terminal_files.py -q` → **45 passed** (기존 41 + 신규 4: inline HTML/content-type, 형제 asset 해석, traversal 차단, 숨김 파일 404).

## 배포

open-webui 쪽 변경 없음 — 이 PR 머지 후 gateway rebuild만 하면 FileNav에서 HTML 클릭 시 바로 렌더링됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFsj3J7EAZNr1TKZXYqoqm

---
_Generated by [Claude Code](https://claude.ai/code/session_01LFsj3J7EAZNr1TKZXYqoqm)_