### PR TITLE
feat(mcp): admin credential overlays for plugin MCP servers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -443,7 +443,10 @@ DEFAULT_MODEL=sonnet
 #
 # Admin-managed credential overlays for *plugin-provided* MCP servers
 # (env/headers only; plugin command/url stay in the plugin). Hot-reloads into
-# NEW Claude sessions. Path override:
+# NEW Claude sessions. Overlay env is injected into the Claude session's
+# process environment, so it is visible to anything the session runs (e.g.
+# Bash tool subprocesses). Overlays whose plugin is no longer installed are
+# skipped entirely. Path override:
 # GATEWAY_MCP_PLUGIN_OVERLAY=/app/data/gateway-mcp-plugin-overlay.json
 
 # Metadata env var passthrough (comma-separated allowlist)

--- a/.env.example
+++ b/.env.example
@@ -440,6 +440,11 @@ DEFAULT_MODEL=sonnet
 # HOT-RELOAD into NEW sessions (Claude/Codex). OpenCode reads MCP only at
 # managed-server startup behind OPENCODE_USE_WRAPPER_MCP_CONFIG — restart needed.
 # GATEWAY_MCP_MANIFEST=/app/data/gateway-mcp.json
+#
+# Admin-managed credential overlays for *plugin-provided* MCP servers
+# (env/headers only; plugin command/url stay in the plugin). Hot-reloads into
+# NEW Claude sessions. Path override:
+# GATEWAY_MCP_PLUGIN_OVERLAY=/app/data/gateway-mcp-plugin-overlay.json
 
 # Metadata env var passthrough (comma-separated allowlist)
 # Only metadata keys listed here are forwarded as env vars to the Claude subprocess.

--- a/src/admin_html_mcp.py
+++ b/src/admin_html_mcp.py
@@ -14,7 +14,8 @@ def get_mcp_html() -> str:
         <p class="text-xs text-muted mb-md">
           Overlay on top of the MCP_CONFIG environment base (manifest wins). Applies to new sessions.
           Existing sessions keep the MCP set pinned at creation. OpenCode requires a restart.
-          Plugin-provided servers are shown read-only (Claude loads them via setting_sources).
+          Plugin-provided servers keep command/url from the plugin; use
+          <strong>Credentials</strong> to inject env/headers dynamically (new Claude sessions).
           Per-server env/headers stay on the MCP config only (not the gateway process).
           Use <code style="font-size:0.75em">{{env:VAR}}</code> to pull from the gateway environment at session create
           (Claude/Codex) or OpenCode managed startup.
@@ -61,7 +62,9 @@ def get_mcp_html() -> str:
                       <div x-show="s.source === 'plugin' && s.plugin" class="text-xs text-muted"
                         style="max-width:180px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap"
                         x-text="s.plugin" :title="s.plugin"></div>
-                      <div class="text-xs text-muted" x-text="s.editable ? 'editable' : 'read-only'"></div>
+                      <div class="text-xs text-muted"
+                        x-text="s.editable ? 'editable' : (s.source === 'plugin' ? 'def read-only' : 'read-only')"></div>
+                      <div x-show="s.has_overlay" class="text-xs" style="color:var(--green)">+ credentials</div>
                     </td>
                     <td>
                       <div class="flex-wrap-gap" style="gap:0.25rem">
@@ -73,12 +76,15 @@ def get_mcp_html() -> str:
                           style="padding:1px 6px; border:1px solid var(--border-bright); background:var(--bg-surface); color:var(--text-dim)"
                           :title="(s.header_keys || []).join(', ')"
                           x-text="'hdr:' + (s.header_key_count || 0)"></span>
+                        <span x-show="s.has_overlay" class="text-xs text-mono"
+                          style="padding:1px 6px; border:1px solid var(--green); color:var(--green)"
+                          title="Admin credential overlay active">overlay</span>
                         <template x-for="ref in (s.env_refs || [])" :key="s.name + ':ref:' + ref">
                           <span class="text-xs text-mono" style="padding:1px 6px; border:1px solid var(--cyan); color:var(--cyan)"
                             title="Resolved from gateway env at session create / OpenCode startup"
                             x-text="mcpEnvRefBadge(ref)"></span>
                         </template>
-                        <span x-show="!(s.env_key_count || s.header_key_count)" class="text-xs text-muted">-</span>
+                        <span x-show="!(s.env_key_count || s.header_key_count || s.has_overlay)" class="text-xs text-muted">-</span>
                       </div>
                     </td>
                     <td>
@@ -106,6 +112,10 @@ def get_mcp_html() -> str:
                         </button>
                         <button x-show="s.editable" class="btn btn-sm btn-ghost" @click="editMcpServer(s)"
                           aria-label="Edit MCP server">Edit</button>
+                        <button x-show="s.source === 'plugin'" class="btn btn-sm btn-ghost"
+                          @click="editPluginMcpOverlay(s)" aria-label="Edit plugin MCP credentials">
+                          Credentials
+                        </button>
                         <button x-show="s.editable" class="btn btn-sm btn-ghost" style="color:var(--red)"
                           @click="deleteMcpServer(s.name)" aria-label="Delete MCP server">Delete</button>
                       </div>
@@ -246,6 +256,62 @@ def get_mcp_html() -> str:
               <span x-text="mcpBusy ? 'Working...' : (mcpEditName ? 'Save' : 'Add server')"></span>
             </button>
             <button x-show="mcpEditName" class="btn btn-sm btn-ghost" @click="cancelMcpEdit()">Cancel</button>
+          </div>
+        </div>
+
+        <!-- Plugin MCP credentials overlay form -->
+        <div class="card" style="margin-top:1rem" x-show="mcpOverlayName">
+          <div class="flex-between mb-md">
+            <h3 style="margin:0" x-text="'Plugin credentials: ' + mcpOverlayName"></h3>
+            <span class="badge text-xs" style="border-color:var(--magenta); color:var(--magenta)">PLUGIN OVERLAY</span>
+          </div>
+          <p class="text-xs text-muted mb-md">
+            Inject env/headers for this plugin MCP without editing the plugin files.
+            Command/url stay owned by the plugin. Applies to <strong>new Claude sessions</strong>
+            (materialized into gateway mcp_servers + process env). Use
+            <code style="font-size:0.75em">{{env:VAR}}</code> to reference gateway env vars.
+          </p>
+          <div class="mb-md">
+            <div class="flex-between mb-sm">
+              <label class="text-xs text-muted" style="margin:0">ENVIRONMENT VARIABLES</label>
+              <button type="button" class="btn btn-sm btn-ghost" @click="mcpOverlayForm.envPairs.push({key:'',value:''})">+ Add</button>
+            </div>
+            <template x-for="(pair, idx) in mcpOverlayForm.envPairs" :key="'oenv-'+idx">
+              <div class="flex-gap-sm mb-sm" style="align-items:center">
+                <input type="text" x-model="pair.key" placeholder="KEY" aria-label="Overlay env key"
+                  style="flex:1; font-family:var(--font-mono); font-size:0.78rem">
+                <input type="text" x-model="pair.value" placeholder="value or env ref" aria-label="Overlay env value"
+                  style="flex:2; font-family:var(--font-mono); font-size:0.78rem">
+                <button type="button" class="btn btn-sm btn-ghost" style="color:var(--red)"
+                  @click="mcpOverlayForm.envPairs.splice(idx,1)">×</button>
+              </div>
+            </template>
+            <div x-show="!mcpOverlayForm.envPairs.length" class="text-xs text-muted">No env vars</div>
+          </div>
+          <div class="mb-md">
+            <div class="flex-between mb-sm">
+              <label class="text-xs text-muted" style="margin:0">HEADERS (remote MCP)</label>
+              <button type="button" class="btn btn-sm btn-ghost" @click="mcpOverlayForm.headerPairs.push({key:'',value:''})">+ Add</button>
+            </div>
+            <template x-for="(pair, idx) in mcpOverlayForm.headerPairs" :key="'ohdr-'+idx">
+              <div class="flex-gap-sm mb-sm" style="align-items:center">
+                <input type="text" x-model="pair.key" placeholder="Header-Name" aria-label="Overlay header name"
+                  style="flex:1; font-family:var(--font-mono); font-size:0.78rem">
+                <input type="text" x-model="pair.value" placeholder="value or env ref" aria-label="Overlay header value"
+                  style="flex:2; font-family:var(--font-mono); font-size:0.78rem">
+                <button type="button" class="btn btn-sm btn-ghost" style="color:var(--red)"
+                  @click="mcpOverlayForm.headerPairs.splice(idx,1)">×</button>
+              </div>
+            </template>
+            <div x-show="!mcpOverlayForm.headerPairs.length" class="text-xs text-muted">No headers</div>
+          </div>
+          <div class="flex-gap-sm">
+            <button class="btn btn-sm btn-primary" @click="savePluginMcpOverlay()" :disabled="mcpOverlayBusy">
+              <span x-text="mcpOverlayBusy ? 'Saving...' : 'Save credentials'"></span>
+            </button>
+            <button class="btn btn-sm btn-ghost" style="color:var(--red)" @click="clearPluginMcpOverlay()"
+              :disabled="mcpOverlayBusy" x-show="mcpOverlayHadExisting">Clear overlay</button>
+            <button class="btn btn-sm btn-ghost" @click="cancelPluginMcpOverlay()">Cancel</button>
           </div>
         </div>
       </div>"""

--- a/src/admin_html_mcp.py
+++ b/src/admin_html_mcp.py
@@ -270,6 +270,9 @@ def get_mcp_html() -> str:
             Command/url stay owned by the plugin. Applies to <strong>new Claude sessions</strong>
             (materialized into gateway mcp_servers + process env). Use
             <code style="font-size:0.75em">{{env:VAR}}</code> to reference gateway env vars.
+            Note: resolved env values land in the session's process environment, so
+            they are visible to anything the session runs (e.g. Bash). Overlays for
+            uninstalled plugins are ignored.
           </p>
           <div class="mb-md">
             <div class="flex-between mb-sm">

--- a/src/admin_js.py
+++ b/src/admin_js.py
@@ -58,6 +58,11 @@ def get_admin_js() -> str:
     mcpSyncLock: false,
     mcpTestBusy: {},
     mcpTestResult: {},
+    mcpOverlayName: null,
+    mcpOverlayPluginId: null,
+    mcpOverlayHadExisting: false,
+    mcpOverlayBusy: false,
+    mcpOverlayForm: { envPairs: [], headerPairs: [] },
     toolsRegistry: {},
     sandboxConfig: {},
     systemPrompt: { mode: 'preset', prompt: null, resolved_prompt: null, preset_text: null, char_count: 0, active_name: null },
@@ -1193,6 +1198,85 @@ def get_admin_js() -> str:
         else { this.mcpTestResult[name] = {ok:false, message: (d.detail || d.error || 'unreachable') + agent}; this.showToast('MCP FAIL: '+name, 'err'); }
       } catch(e) { this.mcpTestResult[name] = {ok:false, message:'connection error'}; this.showToast('Connection error', 'err'); }
       finally { delete this.mcpTestBusy[name]; }
+    },
+
+    // --- Plugin MCP credential overlay ---
+    editPluginMcpOverlay(s) {
+      this.mcpOverlayName = s.name;
+      this.mcpOverlayPluginId = s.plugin || null;
+      this.mcpOverlayHadExisting = !!s.has_overlay;
+      const ov = s.overlay || {};
+      this.mcpOverlayForm = {
+        envPairs: this._mcpPairsFromMap(ov.env),
+        headerPairs: this._mcpPairsFromMap(ov.headers),
+      };
+      if (!this.mcpOverlayForm.envPairs.length && !this.mcpOverlayForm.headerPairs.length) {
+        this.mcpOverlayForm.envPairs = [{ key: '', value: '' }];
+      }
+      // Scroll overlay card into view after Alpine paints.
+      this.$nextTick && this.$nextTick(() => {
+        const el = document.querySelector('[x-show="mcpOverlayName"]');
+        if (el) el.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      });
+    },
+    cancelPluginMcpOverlay() {
+      this.mcpOverlayName = null;
+      this.mcpOverlayPluginId = null;
+      this.mcpOverlayHadExisting = false;
+      this.mcpOverlayForm = { envPairs: [], headerPairs: [] };
+    },
+    async savePluginMcpOverlay() {
+      if (!this.mcpOverlayName) return;
+      const env = this._mcpMapFromPairs(this.mcpOverlayForm.envPairs);
+      const headers = this._mcpMapFromPairs(this.mcpOverlayForm.headerPairs);
+      if (!Object.keys(env).length && !Object.keys(headers).length) {
+        this.showToast('Add at least one env or header entry', 'err');
+        return;
+      }
+      this.mcpOverlayBusy = true;
+      try {
+        const body = { env, headers };
+        if (this.mcpOverlayPluginId) body.plugin_id = this.mcpOverlayPluginId;
+        const r = await this.api(
+          '/admin/api/mcp-servers/' + encodeURIComponent(this.mcpOverlayName) + '/plugin-overlay',
+          { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }
+        );
+        if (r.ok) {
+          this.showToast('PLUGIN CREDENTIALS SAVED: ' + this.mcpOverlayName, 'ok');
+          this.cancelPluginMcpOverlay();
+          await this.refreshMcp();
+        } else {
+          const d = await r.json().catch(() => ({}));
+          this.showToast(d.error || 'Save failed', 'err');
+        }
+      } catch (e) {
+        this.showToast('Connection error', 'err');
+      } finally {
+        this.mcpOverlayBusy = false;
+      }
+    },
+    async clearPluginMcpOverlay() {
+      if (!this.mcpOverlayName) return;
+      if (!confirm('Clear credential overlay for "' + this.mcpOverlayName + '"?')) return;
+      this.mcpOverlayBusy = true;
+      try {
+        const r = await this.api(
+          '/admin/api/mcp-servers/' + encodeURIComponent(this.mcpOverlayName) + '/plugin-overlay',
+          { method: 'DELETE' }
+        );
+        if (r.ok) {
+          this.showToast('PLUGIN CREDENTIALS CLEARED', 'ok');
+          this.cancelPluginMcpOverlay();
+          await this.refreshMcp();
+        } else {
+          const d = await r.json().catch(() => ({}));
+          this.showToast(d.error || 'Clear failed', 'err');
+        }
+      } catch (e) {
+        this.showToast('Connection error', 'err');
+      } finally {
+        this.mcpOverlayBusy = false;
+      }
     },
 
     async toggleSessionHistory(sessionId) {

--- a/src/admin_service.py
+++ b/src/admin_service.py
@@ -534,6 +534,35 @@ def get_plugin_mcp_servers_detail() -> List[Dict[str, Any]]:
 
             ok, reason = validate_server(name, config)
             meta = mcp_secret_maps_meta(config)
+            # Admin credential overlay (env/headers only) for this plugin server.
+            overlay_meta: Dict[str, Any] = {
+                "has_overlay": False,
+                "overlay_env_key_count": 0,
+                "overlay_header_key_count": 0,
+                "overlay_env_refs": [],
+                "overlay": {},
+            }
+            try:
+                from src import mcp_plugin_overlay
+
+                overlay = mcp_plugin_overlay.get_overlay(name)
+                if overlay:
+                    ometa = mcp_secret_maps_meta(overlay)
+                    overlay_meta = {
+                        "has_overlay": True,
+                        "overlay_env_key_count": ometa["env_key_count"],
+                        "overlay_header_key_count": ometa["header_key_count"],
+                        "overlay_env_refs": ometa["env_refs"],
+                        "overlay": _redact_mcp_config(overlay),
+                    }
+                    # Effective env/headers for display = base merged with overlay.
+                    from src.mcp_plugin_overlay import merge_overlay_into_config
+
+                    effective_cfg = merge_overlay_into_config(config, overlay)
+                    meta = mcp_secret_maps_meta(effective_cfg)
+            except Exception:
+                logger.debug("Failed to read plugin MCP overlay for %s", name, exc_info=True)
+
             result.append(
                 {
                     "name": name,
@@ -543,6 +572,9 @@ def get_plugin_mcp_servers_detail() -> List[Dict[str, Any]]:
                     "pattern": f"{safe_prefix}*",
                     "source": "plugin",
                     "editable": False,
+                    # Overlay credentials are editable even though the plugin
+                    # definition (command/url) is not.
+                    "overlay_editable": True,
                     "plugin": entry.get("plugin_id"),
                     "plugin_name": entry.get("plugin_name"),
                     "scope": entry.get("scope"),
@@ -552,6 +584,7 @@ def get_plugin_mcp_servers_detail() -> List[Dict[str, Any]]:
                     "invalid_reason": None if ok else reason,
                     "shadowed": name in effective,
                     **meta,
+                    **overlay_meta,
                 }
             )
         return result

--- a/src/backends/claude/client.py
+++ b/src/backends/claude/client.py
@@ -374,6 +374,54 @@ class ClaudeCodeCLI(TokenEstimateMixin):
         else:
             options.system_prompt = {"type": "preset", "preset": "claude_code"}
 
+    def _merge_plugin_mcp_overlays(
+        self,
+        mcp_servers: Optional[Dict[str, Any]],
+        options: ClaudeAgentOptions,
+    ) -> Optional[Dict[str, Any]]:
+        """Materialize plugin MCP credential overlays into *mcp_servers*.
+
+        Admin overlays (env/headers only) are stored separately from the plugin
+        ``.mcp.json``. For each overlay we deep-copy the plugin base config,
+        merge the overlay, and add it to the gateway ``mcp_servers`` map so it
+        rides the same path as MCP_CONFIG/manifest servers. Resolved overlay
+        env keys are also injected into ``options.env`` so stdio children that
+        inherit the Claude process environment still see credentials when the
+        plugin path also loads via ``setting_sources``.
+        """
+        try:
+            from src import mcp_plugin_overlay
+            from src.mcp_config import resolve_string_map_env_refs
+
+            overlaid = mcp_plugin_overlay.materialize_overlaid_plugin_servers()
+            process_env = mcp_plugin_overlay.collect_overlay_env_for_process()
+        except Exception:
+            logger.warning("Plugin MCP overlay merge failed", exc_info=True)
+            return mcp_servers
+
+        if process_env:
+            resolved_env = resolve_string_map_env_refs(process_env)
+            if resolved_env:
+                options.env.update(resolved_env)
+                logger.debug(
+                    "Injected %d plugin-MCP overlay env key(s) into Claude process env",
+                    len(resolved_env),
+                )
+
+        if not overlaid:
+            return mcp_servers
+
+        merged: Dict[str, Any] = dict(mcp_servers or {})
+        # Overlay materialization wins on name collision with gateway MCP so
+        # admin credentials attach to the plugin-defined command/url.
+        merged.update(overlaid)
+        logger.debug(
+            "Materialized %d plugin MCP server(s) with admin overlays: %s",
+            len(overlaid),
+            list(overlaid.keys()),
+        )
+        return merged
+
     def _configure_mcp_servers(
         self,
         options: ClaudeAgentOptions,
@@ -381,6 +429,9 @@ class ClaudeCodeCLI(TokenEstimateMixin):
         allowed_tools: Optional[List[str]],
         forward_headers: Optional[Dict[str, str]] = None,
     ) -> None:
+        # Merge plugin credential overlays even when gateway MCP_CONFIG is empty.
+        mcp_servers = self._merge_plugin_mcp_overlays(mcp_servers, options)
+
         if not mcp_servers:
             return
 

--- a/src/backends/claude/client.py
+++ b/src/backends/claude/client.py
@@ -424,11 +424,32 @@ class ClaudeCodeCLI(TokenEstimateMixin):
         # Overlay materialization wins on name collision with gateway MCP so
         # admin credentials attach to the plugin-defined command/url.
         merged.update(overlaid)
-        logger.debug(
-            "Materialized %d plugin MCP server(s) with admin overlays: %s",
+        # The plugin's own .mcp.json copy still loads via setting_sources, so
+        # the CLI sees two configs per materialized name and its precedence is
+        # unverified. Env credentials survive either way via the process-env
+        # injection above; header overlays on remote servers only apply if the
+        # materialized copy wins.
+        logger.warning(
+            "Materialized %d plugin MCP server(s) with admin overlays: %s; "
+            "each also loads from its plugin .mcp.json via setting_sources "
+            "(duplicate registration, CLI precedence unverified)",
             len(overlaid),
-            list(overlaid.keys()),
+            sorted(overlaid),
         )
+        header_risk = sorted(
+            name
+            for name, cfg in overlaid.items()
+            if isinstance(cfg, dict)
+            and cfg.get("type", "stdio") != "stdio"
+            and (active_overlays.get(name) or {}).get("headers")
+        )
+        if header_risk:
+            logger.warning(
+                "Header overlay(s) on remote plugin MCP server(s) %s may not "
+                "take effect if the CLI prefers the plugin's own config; "
+                "verify tool connectivity in a new session",
+                header_risk,
+            )
         return merged
 
     def _configure_mcp_servers(

--- a/src/backends/claude/client.py
+++ b/src/backends/claude/client.py
@@ -387,14 +387,23 @@ class ClaudeCodeCLI(TokenEstimateMixin):
         rides the same path as MCP_CONFIG/manifest servers. Resolved overlay
         env keys are also injected into ``options.env`` so stdio children that
         inherit the Claude process environment still see credentials when the
-        plugin path also loads via ``setting_sources``.
+        plugin path also loads via ``setting_sources``. Both effects are scoped
+        to overlays that actually materialized: a stale overlay (plugin no
+        longer installed) contributes neither a server nor process env.
         """
         try:
             from src import mcp_plugin_overlay
             from src.mcp_config import resolve_string_map_env_refs
 
             overlaid = mcp_plugin_overlay.materialize_overlaid_plugin_servers()
-            process_env = mcp_plugin_overlay.collect_overlay_env_for_process()
+            active_overlays = {
+                name: rec
+                for name, rec in mcp_plugin_overlay.get_overlays().items()
+                if name in overlaid
+            }
+            process_env = mcp_plugin_overlay.collect_overlay_env_for_process(
+                active_overlays
+            )
         except Exception:
             logger.warning("Plugin MCP overlay merge failed", exc_info=True)
             return mcp_servers

--- a/src/mcp_admin_service.py
+++ b/src/mcp_admin_service.py
@@ -206,6 +206,19 @@ async def test_connection(name: str) -> Dict[str, Any]:
 
         config = plugin_service.get_plugin_mcp_server_config(name)
         source = "plugin"
+        # Apply admin credential overlay for plugin servers so Test matches
+        # new Claude session materialization.
+        if config is not None:
+            try:
+                from src import mcp_plugin_overlay
+
+                overlay = mcp_plugin_overlay.get_overlay(name)
+                if overlay:
+                    config = mcp_plugin_overlay.merge_overlay_into_config(
+                        config, overlay
+                    )
+            except Exception:
+                pass
     if config is None:
         return {"ok": False, "detail": f"server '{name}' not found"}
     result = await mcp_connection_test.test_mcp_server(name, config)

--- a/src/mcp_admin_service.py
+++ b/src/mcp_admin_service.py
@@ -14,6 +14,7 @@ CRUD.
 
 from __future__ import annotations
 
+import logging
 import re
 from typing import Any, Dict, List, Optional
 
@@ -24,6 +25,8 @@ from src.mcp_config import (
     mcp_safe_name,
     validate_server,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class McpAdminError(ValueError):
@@ -206,19 +209,22 @@ async def test_connection(name: str) -> Dict[str, Any]:
 
         config = plugin_service.get_plugin_mcp_server_config(name)
         source = "plugin"
-        # Apply admin credential overlay for plugin servers so Test matches
-        # new Claude session materialization.
+        # Probe the session-equivalent config: admin credential overlay merged
+        # and ${CLAUDE_PLUGIN_ROOT} expanded, matching what a new Claude
+        # session materializes.
         if config is not None:
             try:
                 from src import mcp_plugin_overlay
 
-                overlay = mcp_plugin_overlay.get_overlay(name)
-                if overlay:
-                    config = mcp_plugin_overlay.merge_overlay_into_config(
-                        config, overlay
-                    )
+                materialized = mcp_plugin_overlay.materialize_plugin_server(name)
+                if materialized is not None:
+                    config = materialized
             except Exception:
-                pass
+                logger.debug(
+                    "Plugin MCP overlay materialization failed for %s",
+                    name,
+                    exc_info=True,
+                )
     if config is None:
         return {"ok": False, "detail": f"server '{name}' not found"}
     result = await mcp_connection_test.test_mcp_server(name, config)

--- a/src/mcp_plugin_overlay.py
+++ b/src/mcp_plugin_overlay.py
@@ -1,0 +1,295 @@
+"""Admin-managed env/headers overlays for plugin-provided MCP servers.
+
+Plugin MCP definitions live in each plugin's ``.mcp.json`` and are loaded by
+the Claude CLI via ``setting_sources``. They are not part of the gateway
+``MCP_CONFIG``/manifest effective set, so the main Admin MCP CRUD cannot edit
+them.
+
+This module stores a **credentials-only overlay** (``env`` + ``headers``) keyed
+by MCP server name. On new Claude sessions the gateway:
+
+1. Reads the plugin's base server config
+2. Merges the overlay (overlay wins on key collision)
+3. Materializes the result into ``options.mcp_servers`` (same path as gateway MCP)
+4. Also injects resolved overlay ``env`` into ``ClaudeAgentOptions.env`` so
+   stdio children that inherit the CLI process environment still see the values
+
+Hot-reload: overlay mutations rebind the in-memory map; already-running sessions
+keep the MCP set pinned at create time (same model as the main MCP manifest).
+
+File: ``GATEWAY_MCP_PLUGIN_OVERLAY`` or ``data/gateway-mcp-plugin-overlay.json``.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+from threading import RLock
+from typing import Any, Dict, List, Mapping, Optional
+
+logger = logging.getLogger(__name__)
+
+_lock = RLock()
+
+_DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+_DEFAULT_PATH = _DATA_DIR / "gateway-mcp-plugin-overlay.json"
+
+# In-memory singleton (rebound on save, never mutated in place).
+_overlays: Dict[str, Dict[str, Any]] = {}
+
+
+def overlay_path() -> Path:
+    override = os.getenv("GATEWAY_MCP_PLUGIN_OVERLAY")
+    if override:
+        return Path(override)
+    return _DEFAULT_PATH
+
+
+def _defaults() -> dict:
+    return {"version": 1, "overlays": {}}
+
+
+def _normalize_string_map(value: Any) -> Dict[str, str]:
+    if not isinstance(value, dict):
+        return {}
+    out: Dict[str, str] = {}
+    for k, v in value.items():
+        if not isinstance(k, str) or not k.strip():
+            continue
+        if not isinstance(v, str):
+            continue
+        out[k] = v
+    return out
+
+
+def _normalize_overlay_entry(raw: Any) -> Optional[Dict[str, Any]]:
+    if not isinstance(raw, dict):
+        return None
+    entry: Dict[str, Any] = {}
+    env = _normalize_string_map(raw.get("env"))
+    headers = _normalize_string_map(raw.get("headers"))
+    if env:
+        entry["env"] = env
+    if headers:
+        entry["headers"] = headers
+    plugin_id = raw.get("plugin_id")
+    if isinstance(plugin_id, str) and plugin_id.strip():
+        entry["plugin_id"] = plugin_id.strip()
+    # Empty overlay (no env, no headers) is useless — treat as absent.
+    if "env" not in entry and "headers" not in entry:
+        return None
+    return entry
+
+
+def load() -> dict:
+    """Return a well-formed overlay file; corrupt/missing -> defaults, never raises."""
+    path = overlay_path()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return _defaults()
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning("Failed to load plugin MCP overlay, using defaults: %s", e)
+        return _defaults()
+    if not isinstance(data, dict):
+        return _defaults()
+    raw_overlays = data.get("overlays")
+    if not isinstance(raw_overlays, dict):
+        raw_overlays = {}
+    overlays: Dict[str, Dict[str, Any]] = {}
+    for name, rec in raw_overlays.items():
+        if not isinstance(name, str) or not name.strip():
+            continue
+        entry = _normalize_overlay_entry(rec)
+        if entry is not None:
+            overlays[name] = entry
+    version = data.get("version")
+    if not isinstance(version, int):
+        version = 1
+    return {"version": version, "overlays": overlays}
+
+
+def save(data: dict) -> None:
+    """Atomically persist the overlay file."""
+    path = overlay_path()
+    with _lock:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(
+            dir=str(path.parent), prefix=path.name + ".", suffix=".tmp"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(data, f, ensure_ascii=False, indent=2)
+            os.replace(tmp, path)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+
+
+def reload_overlays() -> Dict[str, Dict[str, Any]]:
+    """Re-read disk and rebind the singleton. Returns the new map."""
+    global _overlays
+    data = load()
+    _overlays = dict(data.get("overlays") or {})
+    return _overlays
+
+
+def get_overlays() -> Dict[str, Dict[str, Any]]:
+    """Return the in-memory overlay map (do not mutate)."""
+    return _overlays
+
+
+def get_overlay(server_name: str) -> Dict[str, Any]:
+    """Return a copy of the overlay for *server_name*, or ``{}``."""
+    rec = _overlays.get(server_name)
+    return copy.deepcopy(rec) if isinstance(rec, dict) else {}
+
+
+def list_overlay_names() -> List[str]:
+    return sorted(_overlays.keys())
+
+
+def upsert_overlay(
+    server_name: str,
+    *,
+    env: Optional[Mapping[str, Any]] = None,
+    headers: Optional[Mapping[str, Any]] = None,
+    plugin_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Create or replace an overlay entry, then hot-reload.
+
+    Passing empty env and empty headers deletes the overlay (same as delete).
+    """
+    name = (server_name or "").strip()
+    if not name:
+        raise ValueError("server name is required")
+
+    entry_raw: Dict[str, Any] = {
+        "env": dict(env or {}),
+        "headers": dict(headers or {}),
+    }
+    if plugin_id:
+        entry_raw["plugin_id"] = plugin_id
+    entry = _normalize_overlay_entry(entry_raw)
+
+    with _lock:
+        data = load()
+        if entry is None:
+            data["overlays"].pop(name, None)
+        else:
+            data["overlays"][name] = entry
+        save(data)
+    reload_overlays()
+    return get_overlay(name)
+
+
+def delete_overlay(server_name: str) -> bool:
+    """Remove an overlay. Returns whether it existed."""
+    name = (server_name or "").strip()
+    with _lock:
+        data = load()
+        existed = name in data.get("overlays", {})
+        data.get("overlays", {}).pop(name, None)
+        save(data)
+    reload_overlays()
+    return existed
+
+
+def merge_overlay_into_config(
+    base: Mapping[str, Any],
+    overlay: Mapping[str, Any],
+) -> Dict[str, Any]:
+    """Deep-copy *base* and merge overlay env/headers (overlay keys win)."""
+    merged = copy.deepcopy(dict(base)) if isinstance(base, Mapping) else {}
+    if not isinstance(overlay, Mapping):
+        return merged
+
+    for field in ("env", "headers"):
+        base_map = merged.get(field) if isinstance(merged.get(field), dict) else {}
+        over_map = overlay.get(field) if isinstance(overlay.get(field), dict) else {}
+        if not base_map and not over_map:
+            continue
+        combined = dict(base_map)
+        # Overlay wins; only string values from overlay (already normalized on save).
+        for k, v in over_map.items():
+            if isinstance(k, str) and isinstance(v, str):
+                combined[k] = v
+        if combined:
+            merged[field] = combined
+        elif field in merged:
+            del merged[field]
+    return merged
+
+
+def materialize_overlaid_plugin_servers() -> Dict[str, Dict[str, Any]]:
+    """Build ``{server_name: config}`` for plugin MCP servers that have overlays.
+
+    Base config comes from installed plugins; overlay env/headers are merged in.
+    Servers without a matching installed plugin are skipped (stale overlay).
+    Never raises.
+    """
+    if not _overlays:
+        return {}
+    try:
+        from src import plugin_service
+
+        entries = plugin_service.list_plugin_mcp_servers()
+    except Exception:
+        logger.warning("Failed to list plugin MCP servers for overlay", exc_info=True)
+        return {}
+
+    # First installed plugin that declares the name wins (same as get_plugin_mcp_server_config).
+    by_name: Dict[str, Dict[str, Any]] = {}
+    for entry in entries:
+        name = entry.get("server_name")
+        cfg = entry.get("config")
+        if not isinstance(name, str) or not isinstance(cfg, dict):
+            continue
+        if name not in by_name:
+            by_name[name] = cfg
+
+    out: Dict[str, Dict[str, Any]] = {}
+    for name, overlay in _overlays.items():
+        base = by_name.get(name)
+        if base is None:
+            logger.warning(
+                "Plugin MCP overlay for %r has no matching installed plugin server; skipping",
+                name,
+            )
+            continue
+        out[name] = merge_overlay_into_config(base, overlay)
+    return out
+
+
+def collect_overlay_env_for_process(
+    overlays: Optional[Mapping[str, Mapping[str, Any]]] = None,
+) -> Dict[str, str]:
+    """Flatten all overlay ``env`` maps for ClaudeAgentOptions.env injection.
+
+    Later servers overwrite earlier keys on collision (deterministic sorted names).
+    Values are **not** resolved here — call :func:`resolve_string_map_env_refs`.
+    """
+    src = overlays if overlays is not None else _overlays
+    flat: Dict[str, str] = {}
+    for name in sorted(src.keys()):
+        rec = src[name]
+        if not isinstance(rec, Mapping):
+            continue
+        env = rec.get("env")
+        if not isinstance(env, dict):
+            continue
+        for k, v in env.items():
+            if isinstance(k, str) and isinstance(v, str):
+                flat[k] = v
+    return flat
+
+
+# Load at import so get_overlays() works without an explicit reload.
+reload_overlays()

--- a/src/mcp_plugin_overlay.py
+++ b/src/mcp_plugin_overlay.py
@@ -10,9 +10,15 @@ by MCP server name. On new Claude sessions the gateway:
 
 1. Reads the plugin's base server config
 2. Merges the overlay (overlay wins on key collision)
-3. Materializes the result into ``options.mcp_servers`` (same path as gateway MCP)
-4. Also injects resolved overlay ``env`` into ``ClaudeAgentOptions.env`` so
+3. Expands ``${CLAUDE_PLUGIN_ROOT}`` to the plugin's install path — the CLI only
+   defines that variable while loading plugin-scoped config, so the materialized
+   copy must be self-contained
+4. Materializes the result into ``options.mcp_servers`` (same path as gateway MCP)
+5. Also injects resolved overlay ``env`` into ``ClaudeAgentOptions.env`` so
    stdio children that inherit the CLI process environment still see the values
+
+Overlays whose plugin is no longer installed are stale: they neither materialize
+nor contribute process env.
 
 Hot-reload: overlay mutations rebind the in-memory map; already-running sessions
 keep the MCP set pinned at create time (same model as the main MCP manifest).
@@ -228,10 +234,39 @@ def merge_overlay_into_config(
     return merged
 
 
+_PLUGIN_ROOT_TOKEN = "${CLAUDE_PLUGIN_ROOT}"
+
+
+def _expand_plugin_root(value: Any, root: str) -> Any:
+    """Replace ``${CLAUDE_PLUGIN_ROOT}`` in every string leaf of *value*.
+
+    The CLI only defines that variable while loading a plugin's own config, so
+    a config materialized into gateway ``mcp_servers`` must carry the resolved
+    install path itself or its command/args would not resolve.
+    """
+    if isinstance(value, str):
+        return value.replace(_PLUGIN_ROOT_TOKEN, root)
+    if isinstance(value, dict):
+        return {k: _expand_plugin_root(v, root) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_expand_plugin_root(v, root) for v in value]
+    return value
+
+
+def _merged_expanded(
+    base: Dict[str, Any], overlay: Mapping[str, Any], install_path: Any
+) -> Dict[str, Any]:
+    merged = merge_overlay_into_config(base, overlay)
+    if isinstance(install_path, str) and install_path:
+        merged = _expand_plugin_root(merged, install_path)
+    return merged
+
+
 def materialize_overlaid_plugin_servers() -> Dict[str, Dict[str, Any]]:
     """Build ``{server_name: config}`` for plugin MCP servers that have overlays.
 
-    Base config comes from installed plugins; overlay env/headers are merged in.
+    Base config comes from installed plugins; overlay env/headers are merged in
+    and ``${CLAUDE_PLUGIN_ROOT}`` is expanded to the plugin's install path.
     Servers without a matching installed plugin are skipped (stale overlay).
     Never raises.
     """
@@ -253,19 +288,49 @@ def materialize_overlaid_plugin_servers() -> Dict[str, Dict[str, Any]]:
         if not isinstance(name, str) or not isinstance(cfg, dict):
             continue
         if name not in by_name:
-            by_name[name] = cfg
+            by_name[name] = entry
 
     out: Dict[str, Dict[str, Any]] = {}
     for name, overlay in _overlays.items():
-        base = by_name.get(name)
-        if base is None:
+        entry = by_name.get(name)
+        if entry is None:
             logger.warning(
                 "Plugin MCP overlay for %r has no matching installed plugin server; skipping",
                 name,
             )
             continue
-        out[name] = merge_overlay_into_config(base, overlay)
+        out[name] = _merged_expanded(
+            entry["config"], overlay, entry.get("install_path")
+        )
     return out
+
+
+def materialize_plugin_server(server_name: str) -> Optional[Dict[str, Any]]:
+    """Session-equivalent config for one plugin MCP server, or ``None``.
+
+    Same materialization as :func:`materialize_overlaid_plugin_servers` — admin
+    overlay (if any) merged in, ``${CLAUDE_PLUGIN_ROOT}`` expanded — but also
+    for servers without an overlay, so the admin connection test probes exactly
+    what a new Claude session would run. ``None`` when no installed plugin
+    declares *server_name*. Never raises.
+    """
+    try:
+        from src import plugin_service
+
+        entries = plugin_service.list_plugin_mcp_servers()
+    except Exception:
+        logger.warning("Failed to list plugin MCP servers for overlay", exc_info=True)
+        return None
+    for entry in entries:
+        if entry.get("server_name") != server_name:
+            continue
+        cfg = entry.get("config")
+        if not isinstance(cfg, dict):
+            continue
+        return _merged_expanded(
+            cfg, _overlays.get(server_name) or {}, entry.get("install_path")
+        )
+    return None
 
 
 def collect_overlay_env_for_process(

--- a/src/mcp_plugin_overlay_service.py
+++ b/src/mcp_plugin_overlay_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any, Dict, List, Optional
 
 from src import mcp_plugin_overlay
@@ -17,14 +18,19 @@ class McpPluginOverlayError(ValueError):
     """Invalid plugin MCP overlay input."""
 
 
+class McpPluginOverlayNotFound(McpPluginOverlayError):
+    """Overlay target missing: not a plugin server, or no stored overlay."""
+
+
+# Same character class as mcp_admin_service server names.
+_NAME_RE = re.compile(r"^[A-Za-z0-9._@-]+$")
+
+
 def _validate_name(name: str) -> str:
     name = (name or "").strip()
     if not name:
         raise McpPluginOverlayError("server name is required")
-    # Same character class as mcp_admin_service server names.
-    import re
-
-    if not re.match(r"^[A-Za-z0-9._@-]+$", name) or name.startswith("-"):
+    if not _NAME_RE.match(name) or name.startswith("-"):
         raise McpPluginOverlayError(
             f"invalid server name {name!r}: only letters, digits and ._@- are allowed"
         )
@@ -82,10 +88,18 @@ def upsert_overlay(
         ok, reason = validate_string_map(mapping, field)
         if not ok:
             raise McpPluginOverlayError(reason or f"invalid {field}")
+        # A leftover placeholder means the key has no stored secret to restore
+        # (new or renamed key) — storing the literal mask would break the server.
+        for k, v in mapping.items():
+            if v == _REDACTED:
+                raise McpPluginOverlayError(
+                    f"{field} key {k!r} still holds the redaction placeholder; "
+                    "enter the actual value (a renamed key cannot reuse a stored secret)"
+                )
 
     plugins = _plugin_server_names()
     if name not in plugins:
-        raise McpPluginOverlayError(
+        raise McpPluginOverlayNotFound(
             f"server '{name}' is not a plugin-provided MCP server "
             "(overlay is only for source=plugin rows)"
         )
@@ -122,7 +136,7 @@ def delete_overlay(name: str) -> Dict[str, Any]:
     name = _validate_name(name)
     existed = mcp_plugin_overlay.delete_overlay(name)
     if not existed:
-        raise McpPluginOverlayError(f"no overlay for server '{name}'")
+        raise McpPluginOverlayNotFound(f"no overlay for server '{name}'")
     return {"status": "deleted", "server": name}
 
 

--- a/src/mcp_plugin_overlay_service.py
+++ b/src/mcp_plugin_overlay_service.py
@@ -1,0 +1,152 @@
+"""Admin API logic for plugin MCP env/headers overlays."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from src import mcp_plugin_overlay
+from src.mcp_config import (
+    list_env_refs,
+    mcp_safe_name,
+    mcp_secret_maps_meta,
+    validate_string_map,
+)
+
+
+class McpPluginOverlayError(ValueError):
+    """Invalid plugin MCP overlay input."""
+
+
+def _validate_name(name: str) -> str:
+    name = (name or "").strip()
+    if not name:
+        raise McpPluginOverlayError("server name is required")
+    # Same character class as mcp_admin_service server names.
+    import re
+
+    if not re.match(r"^[A-Za-z0-9._@-]+$", name) or name.startswith("-"):
+        raise McpPluginOverlayError(
+            f"invalid server name {name!r}: only letters, digits and ._@- are allowed"
+        )
+    return name
+
+
+def _plugin_server_names() -> Dict[str, Dict[str, Any]]:
+    """Map server_name -> first matching plugin entry metadata."""
+    from src import plugin_service
+
+    out: Dict[str, Dict[str, Any]] = {}
+    for entry in plugin_service.list_plugin_mcp_servers():
+        name = entry.get("server_name")
+        if isinstance(name, str) and name not in out:
+            out[name] = entry
+    return out
+
+
+_REDACTED = "***REDACTED***"
+
+
+def _restore_redacted_map(
+    new: Dict[str, Any], existing: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Keep stored secrets when the admin form round-trips ``***REDACTED***``."""
+    out: Dict[str, Any] = {}
+    for k, v in new.items():
+        if v == _REDACTED and k in existing:
+            out[k] = existing[k]
+        else:
+            out[k] = v
+    return out
+
+
+def upsert_overlay(
+    name: str,
+    *,
+    env: Optional[Dict[str, Any]] = None,
+    headers: Optional[Dict[str, Any]] = None,
+    plugin_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Validate and persist an overlay for a plugin MCP server."""
+    name = _validate_name(name)
+    env = env if isinstance(env, dict) else {}
+    headers = headers if isinstance(headers, dict) else {}
+
+    existing = mcp_plugin_overlay.get_overlay(name)
+    if existing:
+        env = _restore_redacted_map(env, existing.get("env") or {})
+        headers = _restore_redacted_map(headers, existing.get("headers") or {})
+
+    for field, mapping in (("env", env), ("headers", headers)):
+        if not mapping:
+            continue
+        ok, reason = validate_string_map(mapping, field)
+        if not ok:
+            raise McpPluginOverlayError(reason or f"invalid {field}")
+
+    plugins = _plugin_server_names()
+    if name not in plugins:
+        raise McpPluginOverlayError(
+            f"server '{name}' is not a plugin-provided MCP server "
+            "(overlay is only for source=plugin rows)"
+        )
+
+    # Reject empty body after string-map filter.
+    if not env and not headers:
+        raise McpPluginOverlayError(
+            "overlay must include at least one env or headers entry"
+        )
+
+    entry = plugins[name]
+    resolved_plugin_id = plugin_id or entry.get("plugin_id")
+    stored = mcp_plugin_overlay.upsert_overlay(
+        name,
+        env=env,
+        headers=headers,
+        plugin_id=resolved_plugin_id if isinstance(resolved_plugin_id, str) else None,
+    )
+    return {
+        "status": "saved",
+        "server": name,
+        "plugin_id": stored.get("plugin_id") or resolved_plugin_id,
+        "overlay": _public_overlay(stored),
+        "patterns": [f"mcp__{mcp_safe_name(name)}__*"],
+        "note": (
+            "Applies to new Claude sessions: materializes this plugin server into "
+            "gateway mcp_servers with merged env/headers, and injects env into the "
+            "Claude process environment. Existing sessions keep their pinned set."
+        ),
+    }
+
+
+def delete_overlay(name: str) -> Dict[str, Any]:
+    name = _validate_name(name)
+    existed = mcp_plugin_overlay.delete_overlay(name)
+    if not existed:
+        raise McpPluginOverlayError(f"no overlay for server '{name}'")
+    return {"status": "deleted", "server": name}
+
+
+def get_overlay_detail(name: str) -> Dict[str, Any]:
+    name = _validate_name(name)
+    from src.admin_service import _redact_mcp_config
+
+    stored = mcp_plugin_overlay.get_overlay(name)
+    plugins = _plugin_server_names()
+    meta = plugins.get(name)
+    return {
+        "server": name,
+        "exists": bool(stored),
+        "plugin": meta.get("plugin_id") if meta else None,
+        "overlay": _public_overlay(stored),
+        "config_redacted": _redact_mcp_config(stored) if stored else {},
+        **mcp_secret_maps_meta(stored or {}),
+        "env_refs": list_env_refs(stored or {}),
+    }
+
+
+def _public_overlay(stored: Dict[str, Any]) -> Dict[str, Any]:
+    from src.admin_service import _redact_mcp_config
+
+    if not stored:
+        return {}
+    return _redact_mcp_config(stored)

--- a/src/plugin_service.py
+++ b/src/plugin_service.py
@@ -547,7 +547,7 @@ def list_plugin_mcp_servers() -> List[Dict[str, Any]]:
     """Return MCP servers contributed by installed plugins.
 
     Each item is ``{plugin_id, plugin_name, marketplace, scope, origin,
-    server_name, config}``. These servers are loaded by the Claude SDK via
+    server_name, config, install_path}``. These servers are loaded by the Claude SDK via
     ``setting_sources`` (reading the plugin's ``.mcp.json``) and never pass
     through the gateway's ``MCP_CONFIG``/manifest effective config — so they
     are otherwise invisible to the MCP admin view. Read-only; never raises.
@@ -583,6 +583,7 @@ def list_plugin_mcp_servers() -> List[Dict[str, Any]]:
                         ),
                         "server_name": server_name,
                         "config": config,
+                        "install_path": str(resolved["install_path"]),
                     }
                 )
     return results

--- a/src/routes/admin.py
+++ b/src/routes/admin.py
@@ -413,10 +413,10 @@ async def put_mcp_plugin_overlay_endpoint(
             headers=body.headers,
             plugin_id=body.plugin_id,
         )
+    except mcp_plugin_overlay_service.McpPluginOverlayNotFound as e:
+        return JSONResponse(status_code=404, content={"error": str(e)})
     except mcp_plugin_overlay_service.McpPluginOverlayError as e:
-        msg = str(e)
-        code = 404 if "not a plugin-provided" in msg else 400
-        return JSONResponse(status_code=code, content={"error": msg})
+        return JSONResponse(status_code=400, content={"error": str(e)})
 
 
 @router.delete("/api/mcp-servers/{name}/plugin-overlay")
@@ -427,13 +427,11 @@ async def delete_mcp_plugin_overlay_endpoint(name: str, _=Depends(require_admin)
     from src import mcp_plugin_overlay_service
 
     try:
-        return await run_in_threadpool(
-            mcp_plugin_overlay_service.delete_overlay, name
-        )
+        return await run_in_threadpool(mcp_plugin_overlay_service.delete_overlay, name)
+    except mcp_plugin_overlay_service.McpPluginOverlayNotFound as e:
+        return JSONResponse(status_code=404, content={"error": str(e)})
     except mcp_plugin_overlay_service.McpPluginOverlayError as e:
-        msg = str(e)
-        code = 404 if "no overlay" in msg else 400
-        return JSONResponse(status_code=code, content={"error": msg})
+        return JSONResponse(status_code=400, content={"error": str(e)})
 
 
 # ---------------------------------------------------------------------------

--- a/src/routes/admin.py
+++ b/src/routes/admin.py
@@ -25,6 +25,7 @@ MCP servers:    GET  /admin/api/mcp-servers
                 DELETE /admin/api/mcp-servers/{name}
 MCP validate:   POST /admin/api/mcp-servers/validate
 MCP test:       POST /admin/api/mcp-servers/{name}/test
+MCP plugin overlay: GET/PUT/DELETE /admin/api/mcp-servers/{name}/plugin-overlay
 Plugins:        GET  /admin/api/plugins
 Plugin detail:  GET  /admin/api/plugins/{id}
 Plugin skills:  GET  /admin/api/plugins/{id}/skills/{name}
@@ -131,6 +132,14 @@ class McpServerUpsert(BaseModel):
 class McpServerValidate(BaseModel):
     name: str = ""
     config: dict[str, Any] = {}
+
+
+class McpPluginOverlayUpsert(BaseModel):
+    """Credentials-only overlay for a plugin-provided MCP server."""
+
+    env: dict[str, str] = {}
+    headers: dict[str, str] = {}
+    plugin_id: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------
@@ -365,6 +374,66 @@ async def test_mcp_server_endpoint(name: str, _=Depends(require_admin)):
     from src import mcp_admin_service
 
     return await mcp_admin_service.test_connection(name)
+
+
+# --- Plugin MCP credential overlays ---------------------------------------
+# Env/headers only; plugin command/url stay owned by the plugin. Hot-reloads
+# into NEW Claude sessions (materialize + process env inject).
+
+
+@router.get("/api/mcp-servers/{name}/plugin-overlay")
+async def get_mcp_plugin_overlay_endpoint(name: str, _=Depends(require_admin)):
+    """Return the admin credential overlay for a plugin MCP server (redacted)."""
+    from fastapi.concurrency import run_in_threadpool
+
+    from src import mcp_plugin_overlay_service
+
+    try:
+        return await run_in_threadpool(
+            mcp_plugin_overlay_service.get_overlay_detail, name
+        )
+    except mcp_plugin_overlay_service.McpPluginOverlayError as e:
+        return JSONResponse(status_code=400, content={"error": str(e)})
+
+
+@router.put("/api/mcp-servers/{name}/plugin-overlay")
+async def put_mcp_plugin_overlay_endpoint(
+    name: str, body: McpPluginOverlayUpsert, _=Depends(require_admin)
+):
+    """Create or replace env/headers overlay for a plugin MCP server."""
+    from fastapi.concurrency import run_in_threadpool
+
+    from src import mcp_plugin_overlay_service
+
+    try:
+        return await run_in_threadpool(
+            mcp_plugin_overlay_service.upsert_overlay,
+            name,
+            env=body.env,
+            headers=body.headers,
+            plugin_id=body.plugin_id,
+        )
+    except mcp_plugin_overlay_service.McpPluginOverlayError as e:
+        msg = str(e)
+        code = 404 if "not a plugin-provided" in msg else 400
+        return JSONResponse(status_code=code, content={"error": msg})
+
+
+@router.delete("/api/mcp-servers/{name}/plugin-overlay")
+async def delete_mcp_plugin_overlay_endpoint(name: str, _=Depends(require_admin)):
+    """Remove the admin credential overlay for a plugin MCP server."""
+    from fastapi.concurrency import run_in_threadpool
+
+    from src import mcp_plugin_overlay_service
+
+    try:
+        return await run_in_threadpool(
+            mcp_plugin_overlay_service.delete_overlay, name
+        )
+    except mcp_plugin_overlay_service.McpPluginOverlayError as e:
+        msg = str(e)
+        code = 404 if "no overlay" in msg else 400
+        return JSONResponse(status_code=code, content={"error": msg})
 
 
 # ---------------------------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,26 @@ def register_all_descriptors():
     BackendRegistry.register_descriptor(CODEX_DESCRIPTOR)
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _isolate_plugin_mcp_overlay(tmp_path_factory):
+    """Point the plugin MCP overlay store at a per-run temp file.
+
+    ``src.mcp_plugin_overlay`` loads ``data/gateway-mcp-plugin-overlay.json``
+    at import time; without this, a developer's real overlay file (live
+    credentials) would leak into every test that materializes plugin MCP
+    servers or builds Claude session options.
+    """
+    path = tmp_path_factory.mktemp("mcp-plugin-overlay") / "overlay.json"
+    mp = pytest.MonkeyPatch()
+    mp.setenv("GATEWAY_MCP_PLUGIN_OVERLAY", str(path))
+
+    from src import mcp_plugin_overlay
+
+    mcp_plugin_overlay.reload_overlays()
+    yield
+    mp.undo()
+
+
 @pytest.fixture(autouse=True)
 def reset_main_state():
     """Restore mutable module state and clean shared session state between tests."""

--- a/tests/test_mcp_plugin_overlay.py
+++ b/tests/test_mcp_plugin_overlay.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from unittest.mock import patch
 
@@ -251,6 +252,41 @@ class TestClaudeMerge:
             )
         assert merged == {"gw": {"type": "stdio", "command": "gw"}}
         assert options.env == {}
+
+    def test_materialization_warns_duplicate_registration(self, overlay_file, caplog):
+        """Materializing an overlay dual-registers the server (gateway map +
+        setting_sources); stdio/env-only overlays get the generic warning but
+        not the remote-headers one."""
+        mcp_plugin_overlay.upsert_overlay("ctx", env={"TOKEN": "t"})
+        with patch(
+            "src.plugin_service.list_plugin_mcp_servers",
+            return_value=[_plugin_entry()],
+        ):
+            from src.backends.claude.client import ClaudeCodeCLI
+
+            cli = object.__new__(ClaudeCodeCLI)
+            with caplog.at_level(logging.WARNING):
+                cli._merge_plugin_mcp_overlays(None, _FakeOptions())
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("duplicate registration" in m and "'ctx'" in m for m in messages)
+        assert not any("may not take effect" in m for m in messages)
+
+    def test_materialization_warns_remote_header_overlay(self, overlay_file, caplog):
+        """Header overlays on remote plugin servers get the extra silent-no-op
+        warning (headers cannot ride the process env if the plugin copy wins)."""
+        mcp_plugin_overlay.upsert_overlay(
+            "ctx", headers={"Authorization": "Bearer x"}
+        )
+        entry = _plugin_entry(config={"type": "http", "url": "https://mcp.example"})
+        with patch("src.plugin_service.list_plugin_mcp_servers", return_value=[entry]):
+            from src.backends.claude.client import ClaudeCodeCLI
+
+            cli = object.__new__(ClaudeCodeCLI)
+            with caplog.at_level(logging.WARNING):
+                merged = cli._merge_plugin_mcp_overlays(None, _FakeOptions())
+        assert merged["ctx"]["headers"]["Authorization"] == "Bearer x"
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("may not take effect" in m for m in messages)
 
 
 class TestOverlayRoutes:

--- a/tests/test_mcp_plugin_overlay.py
+++ b/tests/test_mcp_plugin_overlay.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import os
 from unittest.mock import patch
 
 import pytest
 
 from src import mcp_plugin_overlay, mcp_plugin_overlay_service
-from src.mcp_plugin_overlay_service import McpPluginOverlayError
+from src.mcp_plugin_overlay_service import (
+    McpPluginOverlayError,
+    McpPluginOverlayNotFound,
+)
 
 
 @pytest.fixture
@@ -16,10 +20,14 @@ def overlay_file(tmp_path, monkeypatch):
     monkeypatch.setenv("GATEWAY_MCP_PLUGIN_OVERLAY", str(path))
     mcp_plugin_overlay.reload_overlays()
     yield path
+    # This teardown runs BEFORE monkeypatch undo, so re-point the store at a
+    # path that never exists and reload — otherwise overlays this test saved
+    # would stay in the module singleton and leak into later tests.
+    monkeypatch.setenv("GATEWAY_MCP_PLUGIN_OVERLAY", str(tmp_path / "absent.json"))
     mcp_plugin_overlay.reload_overlays()
 
 
-def _plugin_entry(name="ctx", plugin_id="p@mp", config=None):
+def _plugin_entry(name="ctx", plugin_id="p@mp", config=None, install_path=None):
     return {
         "plugin_id": plugin_id,
         "plugin_name": "p",
@@ -28,15 +36,28 @@ def _plugin_entry(name="ctx", plugin_id="p@mp", config=None):
         "origin": "managed",
         "server_name": name,
         "config": config
-        or {"type": "stdio", "command": "npx", "args": ["-y", "svc"], "env": {"BASE": "1"}},
+        or {
+            "type": "stdio",
+            "command": "npx",
+            "args": ["-y", "svc"],
+            "env": {"BASE": "1"},
+        },
+        "install_path": install_path,
     }
+
+
+class _FakeOptions:
+    """Minimal stand-in for ClaudeAgentOptions in merge tests."""
+
+    def __init__(self):
+        self.env = {}
+        self.mcp_servers = None
+        self.allowed_tools = None
 
 
 class TestOverlayStore:
     def test_upsert_and_get(self, overlay_file):
-        mcp_plugin_overlay.upsert_overlay(
-            "ctx", env={"TOKEN": "secret"}, headers={}
-        )
+        mcp_plugin_overlay.upsert_overlay("ctx", env={"TOKEN": "secret"}, headers={})
         assert mcp_plugin_overlay.get_overlay("ctx")["env"]["TOKEN"] == "secret"
         assert "ctx" in mcp_plugin_overlay.list_overlay_names()
 
@@ -60,9 +81,7 @@ class TestOverlayStore:
 
     def test_materialize_skips_stale(self, overlay_file):
         mcp_plugin_overlay.upsert_overlay("gone", env={"T": "1"})
-        with patch(
-            "src.plugin_service.list_plugin_mcp_servers", return_value=[]
-        ):
+        with patch("src.plugin_service.list_plugin_mcp_servers", return_value=[]):
             assert mcp_plugin_overlay.materialize_overlaid_plugin_servers() == {}
 
     def test_materialize_merges(self, overlay_file):
@@ -76,16 +95,46 @@ class TestOverlayStore:
         assert out["ctx"]["env"]["BASE"] == "1"
         assert out["ctx"]["env"]["TOKEN"] == "{{env:TOK}}"
 
+    def test_materialize_expands_plugin_root(self, overlay_file):
+        mcp_plugin_overlay.upsert_overlay("ctx", env={"TOKEN": "t"})
+        entry = _plugin_entry(
+            config={
+                "type": "stdio",
+                "command": "${CLAUDE_PLUGIN_ROOT}/bin/serve",
+                "args": ["--root", "${CLAUDE_PLUGIN_ROOT}/data"],
+                "env": {"BASE": "${CLAUDE_PLUGIN_ROOT}/cfg"},
+            },
+            install_path="/opt/plugins/p",
+        )
+        with patch("src.plugin_service.list_plugin_mcp_servers", return_value=[entry]):
+            out = mcp_plugin_overlay.materialize_overlaid_plugin_servers()
+        assert out["ctx"]["command"] == "/opt/plugins/p/bin/serve"
+        assert out["ctx"]["args"] == ["--root", "/opt/plugins/p/data"]
+        assert out["ctx"]["env"]["BASE"] == "/opt/plugins/p/cfg"
+        assert out["ctx"]["env"]["TOKEN"] == "t"
+
+    def test_materialize_plugin_server_single(self, overlay_file):
+        """Single-server materialization works with and without an overlay."""
+        entry = _plugin_entry(
+            config={"type": "stdio", "command": "${CLAUDE_PLUGIN_ROOT}/run"},
+            install_path="/opt/plugins/p",
+        )
+        with patch("src.plugin_service.list_plugin_mcp_servers", return_value=[entry]):
+            cfg = mcp_plugin_overlay.materialize_plugin_server("ctx")
+            assert cfg == {"type": "stdio", "command": "/opt/plugins/p/run"}
+            assert mcp_plugin_overlay.materialize_plugin_server("nope") is None
+
+            mcp_plugin_overlay.upsert_overlay("ctx", env={"TOKEN": "t"})
+            cfg = mcp_plugin_overlay.materialize_plugin_server("ctx")
+            assert cfg["env"]["TOKEN"] == "t"
+            assert cfg["command"] == "/opt/plugins/p/run"
+
 
 class TestOverlayService:
     def test_reject_non_plugin(self, overlay_file):
-        with patch(
-            "src.plugin_service.list_plugin_mcp_servers", return_value=[]
-        ):
+        with patch("src.plugin_service.list_plugin_mcp_servers", return_value=[]):
             with pytest.raises(McpPluginOverlayError, match="not a plugin"):
-                mcp_plugin_overlay_service.upsert_overlay(
-                    "x", env={"A": "1"}
-                )
+                mcp_plugin_overlay_service.upsert_overlay("x", env={"A": "1"})
 
     def test_reject_non_string_env(self, overlay_file):
         with patch(
@@ -139,6 +188,29 @@ class TestOverlayService:
         with pytest.raises(McpPluginOverlayError, match="no overlay"):
             mcp_plugin_overlay_service.delete_overlay("ctx")
 
+    def test_not_found_error_types(self, overlay_file):
+        """Missing targets raise the NotFound subtype (routes map it to 404)."""
+        with patch("src.plugin_service.list_plugin_mcp_servers", return_value=[]):
+            with pytest.raises(McpPluginOverlayNotFound):
+                mcp_plugin_overlay_service.upsert_overlay("x", env={"A": "1"})
+        with pytest.raises(McpPluginOverlayNotFound):
+            mcp_plugin_overlay_service.delete_overlay("nope")
+
+    def test_reject_placeholder_for_unknown_key(self, overlay_file):
+        """A ***REDACTED*** value with no stored secret behind it is an error,
+        not something to persist literally (e.g. a renamed key)."""
+        with patch(
+            "src.plugin_service.list_plugin_mcp_servers",
+            return_value=[_plugin_entry()],
+        ):
+            mcp_plugin_overlay_service.upsert_overlay("ctx", env={"TOKEN": "real"})
+            with pytest.raises(McpPluginOverlayError, match="placeholder"):
+                mcp_plugin_overlay_service.upsert_overlay(
+                    "ctx", env={"RENAMED": "***REDACTED***"}
+                )
+        # Stored overlay unchanged.
+        assert mcp_plugin_overlay.get_overlay("ctx")["env"] == {"TOKEN": "real"}
+
 
 class TestClaudeMerge:
     def test_merge_plugin_overlays_into_mcp_servers(self, overlay_file, monkeypatch):
@@ -154,13 +226,7 @@ class TestClaudeMerge:
 
             # Minimal instance without full init
             cli = object.__new__(ClaudeCodeCLI)
-            class _Opts:
-                def __init__(self):
-                    self.env = {}
-                    self.mcp_servers = None
-                    self.allowed_tools = None
-
-            options = _Opts()
+            options = _FakeOptions()
             merged = cli._merge_plugin_mcp_overlays(
                 {"gw": {"type": "stdio", "command": "gw"}}, options
             )
@@ -170,3 +236,85 @@ class TestClaudeMerge:
             # Process env injection resolves templates.
             assert options.env["TOKEN"] == "from-env"
             assert options.env["PLAIN"] == "x"
+
+    def test_stale_overlay_injects_nothing(self, overlay_file):
+        """An overlay without an installed plugin neither materializes a
+        server nor leaks env into the session process."""
+        mcp_plugin_overlay.upsert_overlay("gone", env={"LEAK": "v"})
+        with patch("src.plugin_service.list_plugin_mcp_servers", return_value=[]):
+            from src.backends.claude.client import ClaudeCodeCLI
+
+            cli = object.__new__(ClaudeCodeCLI)
+            options = _FakeOptions()
+            merged = cli._merge_plugin_mcp_overlays(
+                {"gw": {"type": "stdio", "command": "gw"}}, options
+            )
+        assert merged == {"gw": {"type": "stdio", "command": "gw"}}
+        assert options.env == {}
+
+
+class TestOverlayRoutes:
+    @pytest.fixture
+    def admin_client(self):
+        """FastAPI TestClient with admin auth bypassed (same shape as
+        the fixture in test_admin_features)."""
+        from fastapi.testclient import TestClient
+
+        with patch.dict(os.environ, {"ADMIN_API_KEY": "test-key"}):
+            from src.admin_auth import require_admin
+            from src.main import app
+
+            app.dependency_overrides[require_admin] = lambda: True
+            client = TestClient(app)
+            yield client
+            app.dependency_overrides.pop(require_admin, None)
+
+    def test_requires_admin(self, overlay_file):
+        from fastapi.testclient import TestClient
+
+        from src.main import app
+
+        client = TestClient(app)
+        r = client.get("/admin/api/mcp-servers/ctx/plugin-overlay")
+        assert r.status_code == 401
+
+    def test_put_get_delete_roundtrip(self, overlay_file, admin_client):
+        with patch(
+            "src.plugin_service.list_plugin_mcp_servers",
+            return_value=[_plugin_entry()],
+        ):
+            r = admin_client.put(
+                "/admin/api/mcp-servers/ctx/plugin-overlay",
+                json={"env": {"TOKEN": "s3cret"}},
+            )
+            assert r.status_code == 200
+            body = r.json()
+            assert body["status"] == "saved"
+            # Secrets never echo back.
+            assert body["overlay"]["env"]["TOKEN"] == "***REDACTED***"
+
+            r = admin_client.get("/admin/api/mcp-servers/ctx/plugin-overlay")
+            assert r.status_code == 200
+            detail = r.json()
+            assert detail["exists"] is True
+            assert detail["overlay"]["env"]["TOKEN"] == "***REDACTED***"
+
+        r = admin_client.delete("/admin/api/mcp-servers/ctx/plugin-overlay")
+        assert r.status_code == 200
+        r = admin_client.delete("/admin/api/mcp-servers/ctx/plugin-overlay")
+        assert r.status_code == 404
+
+    def test_put_non_plugin_is_404(self, overlay_file, admin_client):
+        with patch("src.plugin_service.list_plugin_mcp_servers", return_value=[]):
+            r = admin_client.put(
+                "/admin/api/mcp-servers/ghost/plugin-overlay",
+                json={"env": {"A": "1"}},
+            )
+        assert r.status_code == 404
+
+    def test_put_invalid_name_is_400(self, overlay_file, admin_client):
+        r = admin_client.put(
+            "/admin/api/mcp-servers/bad%20name/plugin-overlay",
+            json={"env": {"A": "1"}},
+        )
+        assert r.status_code == 400

--- a/tests/test_mcp_plugin_overlay.py
+++ b/tests/test_mcp_plugin_overlay.py
@@ -1,0 +1,172 @@
+"""Tests for plugin MCP credential overlays."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from src import mcp_plugin_overlay, mcp_plugin_overlay_service
+from src.mcp_plugin_overlay_service import McpPluginOverlayError
+
+
+@pytest.fixture
+def overlay_file(tmp_path, monkeypatch):
+    path = tmp_path / "plugin-overlay.json"
+    monkeypatch.setenv("GATEWAY_MCP_PLUGIN_OVERLAY", str(path))
+    mcp_plugin_overlay.reload_overlays()
+    yield path
+    mcp_plugin_overlay.reload_overlays()
+
+
+def _plugin_entry(name="ctx", plugin_id="p@mp", config=None):
+    return {
+        "plugin_id": plugin_id,
+        "plugin_name": "p",
+        "marketplace": "mp",
+        "scope": "user",
+        "origin": "managed",
+        "server_name": name,
+        "config": config
+        or {"type": "stdio", "command": "npx", "args": ["-y", "svc"], "env": {"BASE": "1"}},
+    }
+
+
+class TestOverlayStore:
+    def test_upsert_and_get(self, overlay_file):
+        mcp_plugin_overlay.upsert_overlay(
+            "ctx", env={"TOKEN": "secret"}, headers={}
+        )
+        assert mcp_plugin_overlay.get_overlay("ctx")["env"]["TOKEN"] == "secret"
+        assert "ctx" in mcp_plugin_overlay.list_overlay_names()
+
+    def test_empty_overlay_deletes(self, overlay_file):
+        mcp_plugin_overlay.upsert_overlay("ctx", env={"A": "1"})
+        mcp_plugin_overlay.upsert_overlay("ctx", env={}, headers={})
+        assert mcp_plugin_overlay.get_overlay("ctx") == {}
+
+    def test_merge_overlay_into_config(self):
+        base = {
+            "type": "stdio",
+            "command": "echo",
+            "env": {"BASE": "1", "SHARED": "old"},
+        }
+        overlay = {"env": {"SHARED": "new", "EXTRA": "x"}}
+        merged = mcp_plugin_overlay.merge_overlay_into_config(base, overlay)
+        assert merged["env"]["BASE"] == "1"
+        assert merged["env"]["SHARED"] == "new"
+        assert merged["env"]["EXTRA"] == "x"
+        assert base["env"]["SHARED"] == "old"  # no mutate
+
+    def test_materialize_skips_stale(self, overlay_file):
+        mcp_plugin_overlay.upsert_overlay("gone", env={"T": "1"})
+        with patch(
+            "src.plugin_service.list_plugin_mcp_servers", return_value=[]
+        ):
+            assert mcp_plugin_overlay.materialize_overlaid_plugin_servers() == {}
+
+    def test_materialize_merges(self, overlay_file):
+        mcp_plugin_overlay.upsert_overlay("ctx", env={"TOKEN": "{{env:TOK}}"})
+        with patch(
+            "src.plugin_service.list_plugin_mcp_servers",
+            return_value=[_plugin_entry()],
+        ):
+            out = mcp_plugin_overlay.materialize_overlaid_plugin_servers()
+        assert out["ctx"]["command"] == "npx"
+        assert out["ctx"]["env"]["BASE"] == "1"
+        assert out["ctx"]["env"]["TOKEN"] == "{{env:TOK}}"
+
+
+class TestOverlayService:
+    def test_reject_non_plugin(self, overlay_file):
+        with patch(
+            "src.plugin_service.list_plugin_mcp_servers", return_value=[]
+        ):
+            with pytest.raises(McpPluginOverlayError, match="not a plugin"):
+                mcp_plugin_overlay_service.upsert_overlay(
+                    "x", env={"A": "1"}
+                )
+
+    def test_reject_non_string_env(self, overlay_file):
+        with patch(
+            "src.plugin_service.list_plugin_mcp_servers",
+            return_value=[_plugin_entry()],
+        ):
+            with pytest.raises(McpPluginOverlayError, match="env"):
+                mcp_plugin_overlay_service.upsert_overlay(
+                    "ctx", env={"A": 1}  # type: ignore[dict-item]
+                )
+
+    def test_happy_path(self, overlay_file):
+        with patch(
+            "src.plugin_service.list_plugin_mcp_servers",
+            return_value=[_plugin_entry()],
+        ):
+            result = mcp_plugin_overlay_service.upsert_overlay(
+                "ctx", env={"TOKEN": "s3cret"}
+            )
+        assert result["status"] == "saved"
+        assert result["server"] == "ctx"
+        # Redacted in public response (TOKEN key is secret-looking).
+        assert result["overlay"]["env"]["TOKEN"] == "***REDACTED***"
+        # Stored raw.
+        assert mcp_plugin_overlay.get_overlay("ctx")["env"]["TOKEN"] == "s3cret"
+
+    def test_redacted_roundtrip_preserves_secret(self, overlay_file):
+        with patch(
+            "src.plugin_service.list_plugin_mcp_servers",
+            return_value=[_plugin_entry()],
+        ):
+            mcp_plugin_overlay_service.upsert_overlay(
+                "ctx", env={"TOKEN": "real", "REGION": "us"}
+            )
+            mcp_plugin_overlay_service.upsert_overlay(
+                "ctx",
+                env={"TOKEN": "***REDACTED***", "REGION": "eu"},
+            )
+        stored = mcp_plugin_overlay.get_overlay("ctx")
+        assert stored["env"]["TOKEN"] == "real"
+        assert stored["env"]["REGION"] == "eu"
+
+    def test_delete(self, overlay_file):
+        with patch(
+            "src.plugin_service.list_plugin_mcp_servers",
+            return_value=[_plugin_entry()],
+        ):
+            mcp_plugin_overlay_service.upsert_overlay("ctx", env={"A": "1"})
+            mcp_plugin_overlay_service.delete_overlay("ctx")
+        assert mcp_plugin_overlay.get_overlay("ctx") == {}
+        with pytest.raises(McpPluginOverlayError, match="no overlay"):
+            mcp_plugin_overlay_service.delete_overlay("ctx")
+
+
+class TestClaudeMerge:
+    def test_merge_plugin_overlays_into_mcp_servers(self, overlay_file, monkeypatch):
+        monkeypatch.setenv("TOK", "from-env")
+        mcp_plugin_overlay.upsert_overlay(
+            "ctx", env={"TOKEN": "{{env:TOK}}", "PLAIN": "x"}
+        )
+        with patch(
+            "src.plugin_service.list_plugin_mcp_servers",
+            return_value=[_plugin_entry()],
+        ):
+            from src.backends.claude.client import ClaudeCodeCLI
+
+            # Minimal instance without full init
+            cli = object.__new__(ClaudeCodeCLI)
+            class _Opts:
+                def __init__(self):
+                    self.env = {}
+                    self.mcp_servers = None
+                    self.allowed_tools = None
+
+            options = _Opts()
+            merged = cli._merge_plugin_mcp_overlays(
+                {"gw": {"type": "stdio", "command": "gw"}}, options
+            )
+            assert "gw" in merged
+            assert "ctx" in merged
+            assert merged["ctx"]["env"]["TOKEN"] == "{{env:TOK}}"
+            # Process env injection resolves templates.
+            assert options.env["TOKEN"] == "from-env"
+            assert options.env["PLAIN"] == "x"


### PR DESCRIPTION
## Summary

- Add Admin-managed **plugin MCP credential overlays** (env/headers only) so operators can inject secrets dynamically without `MCP_CONFIG` redeploy or editing plugin `.mcp.json`.
- Persist overlays at `data/gateway-mcp-plugin-overlay.json` (`GATEWAY_MCP_PLUGIN_OVERLAY` override), hot-reload for **new Claude sessions**.
- On session create: materialize plugin base config + overlay into `options.mcp_servers`, resolve `{{env:VAR}}`, and inject overlay env into the Claude process environment.
- Admin MCP tab: **Credentials** button on PLUGIN rows, save/clear overlay UI; Test uses the same merged config.

## API

- `GET/PUT/DELETE /admin/api/mcp-servers/{name}/plugin-overlay`

## Notes

- Plugin command/url remain owned by the plugin (definition read-only).
- Applies to Claude new sessions; existing sessions keep their pinned MCP set.
- Codex/OpenCode do not load Claude plugins; this path is Claude-focused.

## Test plan

- [x] `uv run pytest tests/test_mcp_plugin_overlay.py tests/test_mcp_config.py tests/test_mcp_admin_service.py tests/test_claude_client_more_coverage.py tests/test_admin_features.py -q`
- [ ] Admin UI: open MCP tab → plugin row → Credentials → set env with `{{env:…}}` → Save → new `/v1/responses` Claude session sees tools
- [ ] Clear overlay → new session no longer has injected credentials
- [ ] Test button on plugin row with overlay probes merged config