### PR TITLE
fix(mcp): scope plugin overlay credentials to the MCP server config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -443,9 +443,10 @@ DEFAULT_MODEL=sonnet
 #
 # Admin-managed credential overlays for *plugin-provided* MCP servers
 # (env/headers only; plugin command/url stay in the plugin). Hot-reloads into
-# NEW Claude sessions. Overlay env is injected into the Claude session's
-# process environment, so it is visible to anything the session runs (e.g.
-# Bash tool subprocesses). Overlays whose plugin is no longer installed are
+# NEW Claude sessions. The merged config replaces the plugin's own server
+# registration (verified on the pinned SDK's CLI), and overlay values stay
+# scoped to the MCP server process — they are NOT injected into the session
+# process environment. Overlays whose plugin is no longer installed are
 # skipped entirely. Path override:
 # GATEWAY_MCP_PLUGIN_OVERLAY=/app/data/gateway-mcp-plugin-overlay.json
 

--- a/src/admin_html_mcp.py
+++ b/src/admin_html_mcp.py
@@ -267,12 +267,11 @@ def get_mcp_html() -> str:
           </div>
           <p class="text-xs text-muted mb-md">
             Inject env/headers for this plugin MCP without editing the plugin files.
-            Command/url stay owned by the plugin. Applies to <strong>new Claude sessions</strong>
-            (materialized into gateway mcp_servers + process env). Use
+            Command/url stay owned by the plugin. Applies to <strong>new Claude sessions</strong>:
+            the merged config replaces the plugin's own registration, and values stay
+            scoped to the MCP server process (not the session environment). Use
             <code style="font-size:0.75em">{{env:VAR}}</code> to reference gateway env vars.
-            Note: resolved env values land in the session's process environment, so
-            they are visible to anything the session runs (e.g. Bash). Overlays for
-            uninstalled plugins are ignored.
+            Overlays for uninstalled plugins are ignored.
           </p>
           <div class="mb-md">
             <div class="flex-between mb-sm">

--- a/src/backends/claude/client.py
+++ b/src/backends/claude/client.py
@@ -377,45 +377,30 @@ class ClaudeCodeCLI(TokenEstimateMixin):
     def _merge_plugin_mcp_overlays(
         self,
         mcp_servers: Optional[Dict[str, Any]],
-        options: ClaudeAgentOptions,
     ) -> Optional[Dict[str, Any]]:
         """Materialize plugin MCP credential overlays into *mcp_servers*.
 
         Admin overlays (env/headers only) are stored separately from the plugin
         ``.mcp.json``. For each overlay we deep-copy the plugin base config,
         merge the overlay, and add it to the gateway ``mcp_servers`` map so it
-        rides the same path as MCP_CONFIG/manifest servers. Resolved overlay
-        env keys are also injected into ``options.env`` so stdio children that
-        inherit the Claude process environment still see credentials when the
-        plugin path also loads via ``setting_sources``. Both effects are scoped
-        to overlays that actually materialized: a stale overlay (plugin no
-        longer installed) contributes neither a server nor process env.
+        rides the same path as MCP_CONFIG/manifest servers. Overlay values stay
+        scoped to that server config; nothing is injected into the session
+        process environment. A stale overlay (plugin no longer installed)
+        contributes nothing.
+
+        Verified live (CLI 2.1.187, the SDK 0.2.108 bundle, 2026-07-16): when
+        ``--mcp-config`` names a server also declared by a plugin, the CLI
+        drops the plugin registration entirely — only the materialized copy is
+        registered and spawned, so merged env/headers are authoritative and no
+        duplicate server runs.
         """
         try:
             from src import mcp_plugin_overlay
-            from src.mcp_config import resolve_string_map_env_refs
 
             overlaid = mcp_plugin_overlay.materialize_overlaid_plugin_servers()
-            active_overlays = {
-                name: rec
-                for name, rec in mcp_plugin_overlay.get_overlays().items()
-                if name in overlaid
-            }
-            process_env = mcp_plugin_overlay.collect_overlay_env_for_process(
-                active_overlays
-            )
         except Exception:
             logger.warning("Plugin MCP overlay merge failed", exc_info=True)
             return mcp_servers
-
-        if process_env:
-            resolved_env = resolve_string_map_env_refs(process_env)
-            if resolved_env:
-                options.env.update(resolved_env)
-                logger.debug(
-                    "Injected %d plugin-MCP overlay env key(s) into Claude process env",
-                    len(resolved_env),
-                )
 
         if not overlaid:
             return mcp_servers
@@ -424,32 +409,12 @@ class ClaudeCodeCLI(TokenEstimateMixin):
         # Overlay materialization wins on name collision with gateway MCP so
         # admin credentials attach to the plugin-defined command/url.
         merged.update(overlaid)
-        # The plugin's own .mcp.json copy still loads via setting_sources, so
-        # the CLI sees two configs per materialized name and its precedence is
-        # unverified. Env credentials survive either way via the process-env
-        # injection above; header overlays on remote servers only apply if the
-        # materialized copy wins.
-        logger.warning(
-            "Materialized %d plugin MCP server(s) with admin overlays: %s; "
-            "each also loads from its plugin .mcp.json via setting_sources "
-            "(duplicate registration, CLI precedence unverified)",
+        logger.info(
+            "Materialized %d plugin MCP server(s) with admin overlays: %s "
+            "(replaces the plugin's own setting_sources registration)",
             len(overlaid),
             sorted(overlaid),
         )
-        header_risk = sorted(
-            name
-            for name, cfg in overlaid.items()
-            if isinstance(cfg, dict)
-            and cfg.get("type", "stdio") != "stdio"
-            and (active_overlays.get(name) or {}).get("headers")
-        )
-        if header_risk:
-            logger.warning(
-                "Header overlay(s) on remote plugin MCP server(s) %s may not "
-                "take effect if the CLI prefers the plugin's own config; "
-                "verify tool connectivity in a new session",
-                header_risk,
-            )
         return merged
 
     def _configure_mcp_servers(
@@ -460,7 +425,7 @@ class ClaudeCodeCLI(TokenEstimateMixin):
         forward_headers: Optional[Dict[str, str]] = None,
     ) -> None:
         # Merge plugin credential overlays even when gateway MCP_CONFIG is empty.
-        mcp_servers = self._merge_plugin_mcp_overlays(mcp_servers, options)
+        mcp_servers = self._merge_plugin_mcp_overlays(mcp_servers)
 
         if not mcp_servers:
             return

--- a/src/mcp_plugin_overlay.py
+++ b/src/mcp_plugin_overlay.py
@@ -14,11 +14,13 @@ by MCP server name. On new Claude sessions the gateway:
    defines that variable while loading plugin-scoped config, so the materialized
    copy must be self-contained
 4. Materializes the result into ``options.mcp_servers`` (same path as gateway MCP)
-5. Also injects resolved overlay ``env`` into ``ClaudeAgentOptions.env`` so
-   stdio children that inherit the CLI process environment still see the values
 
-Overlays whose plugin is no longer installed are stale: they neither materialize
-nor contribute process env.
+The CLI then drops the plugin's own registration for that server name — only
+the materialized copy is registered and spawned (verified live 2026-07-16 on
+CLI 2.1.187, the SDK 0.2.108 bundle) — so overlay values stay scoped to that
+server config and are never injected into the session process environment.
+
+Overlays whose plugin is no longer installed are stale: they do not materialize.
 
 Hot-reload: overlay mutations rebind the in-memory map; already-running sessions
 keep the MCP set pinned at create time (same model as the main MCP manifest).
@@ -331,29 +333,6 @@ def materialize_plugin_server(server_name: str) -> Optional[Dict[str, Any]]:
             cfg, _overlays.get(server_name) or {}, entry.get("install_path")
         )
     return None
-
-
-def collect_overlay_env_for_process(
-    overlays: Optional[Mapping[str, Mapping[str, Any]]] = None,
-) -> Dict[str, str]:
-    """Flatten all overlay ``env`` maps for ClaudeAgentOptions.env injection.
-
-    Later servers overwrite earlier keys on collision (deterministic sorted names).
-    Values are **not** resolved here — call :func:`resolve_string_map_env_refs`.
-    """
-    src = overlays if overlays is not None else _overlays
-    flat: Dict[str, str] = {}
-    for name in sorted(src.keys()):
-        rec = src[name]
-        if not isinstance(rec, Mapping):
-            continue
-        env = rec.get("env")
-        if not isinstance(env, dict):
-            continue
-        for k, v in env.items():
-            if isinstance(k, str) and isinstance(v, str):
-                flat[k] = v
-    return flat
 
 
 # Load at import so get_overlays() works without an explicit reload.

--- a/src/mcp_plugin_overlay_service.py
+++ b/src/mcp_plugin_overlay_service.py
@@ -126,8 +126,8 @@ def upsert_overlay(
         "patterns": [f"mcp__{mcp_safe_name(name)}__*"],
         "note": (
             "Applies to new Claude sessions: materializes this plugin server into "
-            "gateway mcp_servers with merged env/headers, and injects env into the "
-            "Claude process environment. Existing sessions keep their pinned set."
+            "gateway mcp_servers with merged env/headers, scoped to the MCP server "
+            "process. Existing sessions keep their pinned set."
         ),
     }
 

--- a/tests/test_mcp_plugin_overlay.py
+++ b/tests/test_mcp_plugin_overlay.py
@@ -47,15 +47,6 @@ def _plugin_entry(name="ctx", plugin_id="p@mp", config=None, install_path=None):
     }
 
 
-class _FakeOptions:
-    """Minimal stand-in for ClaudeAgentOptions in merge tests."""
-
-    def __init__(self):
-        self.env = {}
-        self.mcp_servers = None
-        self.allowed_tools = None
-
-
 class TestOverlayStore:
     def test_upsert_and_get(self, overlay_file):
         mcp_plugin_overlay.upsert_overlay("ctx", env={"TOKEN": "secret"}, headers={})
@@ -214,8 +205,7 @@ class TestOverlayService:
 
 
 class TestClaudeMerge:
-    def test_merge_plugin_overlays_into_mcp_servers(self, overlay_file, monkeypatch):
-        monkeypatch.setenv("TOK", "from-env")
+    def test_merge_plugin_overlays_into_mcp_servers(self, overlay_file):
         mcp_plugin_overlay.upsert_overlay(
             "ctx", env={"TOKEN": "{{env:TOK}}", "PLAIN": "x"}
         )
@@ -227,36 +217,32 @@ class TestClaudeMerge:
 
             # Minimal instance without full init
             cli = object.__new__(ClaudeCodeCLI)
-            options = _FakeOptions()
             merged = cli._merge_plugin_mcp_overlays(
-                {"gw": {"type": "stdio", "command": "gw"}}, options
+                {"gw": {"type": "stdio", "command": "gw"}}
             )
             assert "gw" in merged
             assert "ctx" in merged
+            # Env refs stay templated here; _configure_mcp_servers resolves
+            # the merged map at session create.
             assert merged["ctx"]["env"]["TOKEN"] == "{{env:TOK}}"
-            # Process env injection resolves templates.
-            assert options.env["TOKEN"] == "from-env"
-            assert options.env["PLAIN"] == "x"
+            assert merged["ctx"]["env"]["PLAIN"] == "x"
 
-    def test_stale_overlay_injects_nothing(self, overlay_file):
-        """An overlay without an installed plugin neither materializes a
-        server nor leaks env into the session process."""
+    def test_stale_overlay_materializes_nothing(self, overlay_file):
+        """An overlay without an installed plugin does not materialize."""
         mcp_plugin_overlay.upsert_overlay("gone", env={"LEAK": "v"})
         with patch("src.plugin_service.list_plugin_mcp_servers", return_value=[]):
             from src.backends.claude.client import ClaudeCodeCLI
 
             cli = object.__new__(ClaudeCodeCLI)
-            options = _FakeOptions()
             merged = cli._merge_plugin_mcp_overlays(
-                {"gw": {"type": "stdio", "command": "gw"}}, options
+                {"gw": {"type": "stdio", "command": "gw"}}
             )
         assert merged == {"gw": {"type": "stdio", "command": "gw"}}
-        assert options.env == {}
 
-    def test_materialization_warns_duplicate_registration(self, overlay_file, caplog):
-        """Materializing an overlay dual-registers the server (gateway map +
-        setting_sources); stdio/env-only overlays get the generic warning but
-        not the remote-headers one."""
+    def test_materialization_logs_replacement(self, overlay_file, caplog):
+        """Materialization notes that the CLI runs the materialized copy in
+        place of the plugin's own setting_sources registration (verified live
+        on CLI 2.1.187, the pinned SDK bundle)."""
         mcp_plugin_overlay.upsert_overlay("ctx", env={"TOKEN": "t"})
         with patch(
             "src.plugin_service.list_plugin_mcp_servers",
@@ -265,15 +251,17 @@ class TestClaudeMerge:
             from src.backends.claude.client import ClaudeCodeCLI
 
             cli = object.__new__(ClaudeCodeCLI)
-            with caplog.at_level(logging.WARNING):
-                cli._merge_plugin_mcp_overlays(None, _FakeOptions())
-        messages = [r.getMessage() for r in caplog.records]
-        assert any("duplicate registration" in m and "'ctx'" in m for m in messages)
-        assert not any("may not take effect" in m for m in messages)
+            with caplog.at_level(logging.INFO):
+                cli._merge_plugin_mcp_overlays(None)
+        assert any(
+            "replaces the plugin's own setting_sources registration"
+            in r.getMessage()
+            for r in caplog.records
+        )
 
-    def test_materialization_warns_remote_header_overlay(self, overlay_file, caplog):
-        """Header overlays on remote plugin servers get the extra silent-no-op
-        warning (headers cannot ride the process env if the plugin copy wins)."""
+    def test_remote_header_overlay_lands_in_config(self, overlay_file):
+        """Header overlays ride the materialized config — the copy the CLI
+        actually registers and runs — so they apply to remote plugin servers."""
         mcp_plugin_overlay.upsert_overlay(
             "ctx", headers={"Authorization": "Bearer x"}
         )
@@ -282,11 +270,29 @@ class TestClaudeMerge:
             from src.backends.claude.client import ClaudeCodeCLI
 
             cli = object.__new__(ClaudeCodeCLI)
-            with caplog.at_level(logging.WARNING):
-                merged = cli._merge_plugin_mcp_overlays(None, _FakeOptions())
+            merged = cli._merge_plugin_mcp_overlays(None)
         assert merged["ctx"]["headers"]["Authorization"] == "Bearer x"
-        messages = [r.getMessage() for r in caplog.records]
-        assert any("may not take effect" in m for m in messages)
+
+    def test_overlay_env_never_reaches_session_process_env(self, overlay_file):
+        """Regression for the scoped-env fix: overlay credentials must land in
+        the materialized server config only. If session-process env injection
+        is ever reintroduced, the agent's Bash would see the secret via `env`
+        — this asserts options.env stays clean through the real MCP configure
+        path."""
+        mcp_plugin_overlay.upsert_overlay("ctx", env={"TOKEN": "s3cret"})
+        with patch(
+            "src.plugin_service.list_plugin_mcp_servers",
+            return_value=[_plugin_entry()],
+        ):
+            from claude_agent_sdk import ClaudeAgentOptions
+
+            from src.backends.claude.client import ClaudeCodeCLI
+
+            cli = object.__new__(ClaudeCodeCLI)
+            options = ClaudeAgentOptions()
+            cli._configure_mcp_servers(options, None, ["mcp__ctx__*"])
+        assert options.mcp_servers["ctx"]["env"]["TOKEN"] == "s3cret"
+        assert "TOKEN" not in options.env
 
 
 class TestOverlayRoutes:


### PR DESCRIPTION
## Summary

Follow-up to #138. Live verification resolved the dual-registration unknown, so the process-env hedge is removed: **plugin overlay credentials now stay scoped to the materialized MCP server config and never enter the session process environment** (agent Bash can no longer read them via `env`).

## Verification (live CLI probe, 2026-07-16)

Isolated-HOME probe plugin + real SDK session on CLI 2.1.187 (the `claude-agent-sdk==0.2.108` bundle — exactly what production runs):

- Control (no overlay): plugin `.mcp.json` copy registers as `plugin:<plugin>:<server>` and spawns; stdio MCP children inherit the full CLI process env.
- Dual (overlay materialized): the CLI **drops the plugin registration entirely** — only the `--mcp-config` copy registers/connects/spawns (no duplicate in a 20s window); merged env/headers are authoritative; tools expose as `mcp__<server>__*`.
- Patched dual: server still receives credentials via config; `options.env` stays clean.

Consequences: remote-server header overlays definitively work; the `options.env` injection was unnecessary exposure.

## Changes

- `client.py`: `_merge_plugin_mcp_overlays` no longer injects into `options.env`; unverified-precedence warnings replaced with one info log documenting the verified behavior
- `mcp_plugin_overlay.py`: remove now-unused `collect_overlay_env_for_process`; docstring records the verified precedence
- `.env.example` / admin UI copy / API note: scoped-to-server wording
- Tests: `TestClaudeMerge` rewritten; new regression test asserts `options.env` stays clean through the real `_configure_mcp_servers` path

## Test plan

- [x] `uv run pytest tests/test_mcp_plugin_overlay.py tests/test_mcp_config.py tests/test_mcp_admin_service.py tests/test_admin_features.py tests/test_claude_client_more_coverage.py -q` — 219 passed, 1 skipped
- [x] Live probe rerun on patched code (credentials via config only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)