### PR TITLE
feat(responses): send Claude images as native inline content blocks (#140 Fix A)

### DIFF
--- a/src/backends/base.py
+++ b/src/backends/base.py
@@ -125,10 +125,11 @@ class BackendClient(Protocol):
         """Execute a turn against an existing backend client.
 
         ``prompt`` may be either a plain string or a list of backend-native
-        input items. Backends that don't carry multimodal payloads natively
-        (Claude, OpenCode) should ignore the list shape; only Codex emits a
-        list, and only when the request body carried Codex-supported
-        multimodal parts.
+        input items, emitted only when the request body carried natively
+        supported multimodal parts: Codex receives Codex turn-input items,
+        Claude receives Anthropic content blocks (inline images, issue #140).
+        Backends that don't carry multimodal payloads natively (OpenCode)
+        never see the list shape.
         """
         ...
 

--- a/src/backends/claude/client.py
+++ b/src/backends/claude/client.py
@@ -10,7 +10,7 @@ import tempfile
 import atexit
 import shutil
 import contextlib
-from typing import AsyncGenerator, Dict, Any, Literal, Optional, List, cast
+from typing import AsyncGenerator, Dict, Any, Literal, Optional, List, Union, cast
 from pathlib import Path
 import logging
 
@@ -986,16 +986,34 @@ class ClaudeCodeCLI(TokenEstimateMixin):
 
         return client
 
+    @staticmethod
+    async def _stream_user_content_blocks(
+        content_blocks: List[Dict[str, Any]],
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        """Wrap Anthropic content blocks as a single SDK streaming-input message.
+
+        Mirrors the message shape ``ClaudeSDKClient.query()`` builds for plain
+        strings, but with block-list content so inline image blocks reach the
+        model directly (issue #140). ``query()`` fills in ``session_id``.
+        """
+        yield {
+            "type": "user",
+            "message": {"role": "user", "content": content_blocks},
+            "parent_tool_use_id": None,
+        }
+
     async def run_completion_with_client(
         self,
         client: ClaudeSDKClient,
-        prompt: str,
+        prompt: Union[str, List[Dict[str, Any]]],
         session,
     ) -> AsyncGenerator[Dict[str, Any], None]:
         """Run a completion turn on an existing *client*.
 
         Sends *prompt* via ``client.query()`` then yields converted
-        message dicts from ``client.receive_response()``.  On error the
+        message dicts from ``client.receive_response()``.  A list prompt is
+        a list of native Anthropic content blocks (multimodal turn) and is
+        sent as SDK streaming input.  On error the
         session's client reference is cleared so the caller can detect
         the broken connection and create a fresh client.
 
@@ -1016,7 +1034,10 @@ class ClaudeCodeCLI(TokenEstimateMixin):
         get_next = None
         wait_break = None
         try:
-            await client.query(prompt)
+            if isinstance(prompt, str):
+                await client.query(prompt)
+            else:
+                await client.query(self._stream_user_content_blocks(prompt))
             response_iter = client.receive_response().__aiter__()
             while True:
                 # Race: next message vs hook-fired break signal

--- a/src/image_handler.py
+++ b/src/image_handler.py
@@ -105,6 +105,42 @@ class ImageHandler:
         return self.save_base64_image(b64data, media_type)
 
     # ------------------------------------------------------------------
+    # Native content-block conversion (no disk round-trip)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def data_url_to_image_block(image_url: str) -> dict:
+        """Convert a ``data:`` URL into a native Anthropic image content block.
+
+        Runs the same validation as the save path (supported media type,
+        well-formed base64, size limit) but never touches disk — the block is
+        sent inline to the SDK so the model receives pixels directly instead
+        of depending on a Read-tool round-trip (issue #140).
+        """
+        media_type, b64data = ImageHandler.parse_data_url(image_url)
+
+        if media_type not in SUPPORTED_MEDIA_TYPES:
+            raise ValueError(
+                f"Unsupported image type: {media_type}. "
+                f"Supported: {', '.join(sorted(SUPPORTED_MEDIA_TYPES))}"
+            )
+
+        try:
+            image_bytes = base64.b64decode(b64data, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise ValueError("Malformed image base64 payload") from exc
+
+        if len(image_bytes) > MAX_IMAGE_SIZE:
+            raise ValueError(
+                f"Image size {len(image_bytes)} bytes exceeds {MAX_IMAGE_SIZE} byte limit"
+            )
+
+        return {
+            "type": "image",
+            "source": {"type": "base64", "media_type": media_type, "data": b64data},
+        }
+
+    # ------------------------------------------------------------------
     # Cleanup
     # ------------------------------------------------------------------
 

--- a/src/message_adapter.py
+++ b/src/message_adapter.py
@@ -214,6 +214,70 @@ class MessageAdapter:
         return "\n\n".join(parts)
 
     @staticmethod
+    def response_input_to_claude_blocks(input_data) -> list:
+        """Convert Responses API input to native Anthropic content blocks.
+
+        Used for multimodal Claude turns: ``input_image`` parts become inline
+        ``{"type": "image", "source": {...}}`` blocks (no disk round-trip, no
+        ``<attached_image>`` placeholder — issue #140), text parts become
+        ``{"type": "text", ...}`` blocks with the same ``filter_content``
+        treatment as the collapsed-string path. Part order within and across
+        messages is preserved; no separator text is injected — content blocks
+        are already structurally delimited for the model.
+
+        Raises ``ValueError`` for invalid image payloads (non-``data:`` URL,
+        unsupported media type, malformed base64, oversize).
+        """
+        from src.image_handler import ImageHandler
+
+        if isinstance(input_data, str):
+            filtered = MessageAdapter.filter_content(input_data)
+            return [{"type": "text", "text": filtered}] if filtered else []
+
+        blocks: list = []
+        for item in input_data:
+            content = item.content
+
+            if isinstance(content, str):
+                parts: list = [{"type": "text", "text": content}] if content else []
+            elif isinstance(content, list):
+                parts = []
+                for part in content:
+                    ptype = (
+                        part.get("type") if isinstance(part, dict) else getattr(part, "type", None)
+                    )
+                    text_part = (
+                        part.get("text") if isinstance(part, dict) else getattr(part, "text", "")
+                    )
+
+                    if text_part:
+                        parts.append({"type": "text", "text": text_part})
+                    elif ptype == "input_image":
+                        image_url = (
+                            part.get("image_url", "")
+                            if isinstance(part, dict)
+                            else getattr(part, "image_url", "")
+                        )
+                        if image_url:
+                            parts.append(ImageHandler.data_url_to_image_block(image_url))
+            else:
+                continue
+
+            blocks.extend(parts)
+
+        # Apply the same content filtering the string path gets, per text block.
+        filtered_blocks: list = []
+        for block in blocks:
+            if block.get("type") == "text":
+                text = MessageAdapter.filter_content(block["text"])
+                if not text:
+                    continue
+                filtered_blocks.append({"type": "text", "text": text})
+            else:
+                filtered_blocks.append(block)
+        return filtered_blocks
+
+    @staticmethod
     def estimate_tokens(text: str) -> int:
         """
         Rough estimation of token count.

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -763,12 +763,12 @@ def _response_prompt_and_system(
     return MessageAdapter.filter_content(prompt), system_prompt
 
 
-_CODEX_SUPPORTED_INPUT_PART_TYPES = frozenset({"input_image"})
+_NATIVE_IMAGE_INPUT_PART_TYPES = frozenset({"input_image"})
 
 
 def _has_multimodal_input(body: ResponseCreateRequest) -> bool:
-    """True when the request carries an input part Codex can carry natively
-    (currently only ``input_image``).
+    """True when the request carries an input part a backend can carry
+    natively (currently only ``input_image``; Claude and Codex).
 
     Narrow on purpose: an unknown type alone would otherwise route us into
     the multimodal branch and then drop out as an empty items list.
@@ -781,9 +781,27 @@ def _has_multimodal_input(body: ResponseCreateRequest) -> bool:
             continue
         for part in content:
             ptype = part.get("type") if isinstance(part, dict) else getattr(part, "type", None)
-            if ptype in _CODEX_SUPPORTED_INPUT_PART_TYPES:
+            if ptype in _NATIVE_IMAGE_INPUT_PART_TYPES:
                 return True
     return False
+
+
+def _response_prompt_blocks_and_system(
+    body: ResponseCreateRequest,
+) -> tuple[list, Optional[str]]:
+    """Build native Anthropic content blocks from a multimodal Responses request.
+
+    Claude counterpart of ``_response_input_to_codex_items``: ``input_image``
+    parts become inline ``{"type": "image", ...}`` blocks passed to the SDK as
+    streaming input, so the model receives pixels directly instead of a
+    ``<attached_image>`` path placeholder + Read-tool round-trip (issue #140).
+    """
+    system_prompt, input_for_prompt = _split_response_input(body)
+    try:
+        blocks = MessageAdapter.response_input_to_claude_blocks(input_for_prompt)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    return blocks, system_prompt
 
 
 def _response_input_to_codex_items(
@@ -1824,6 +1842,17 @@ async def create_response(
                 detail="Codex multimodal input produced no usable items",
             )
         prompt: Any = codex_items
+    elif resolved.backend == "claude" and _has_multimodal_input(body):
+        # Claude carries images as native inline content blocks (issue #140) —
+        # no disk round-trip, no <attached_image> placeholder, no Read-tool
+        # dependency for the model to see the pixels.
+        prompt, system_prompt = _response_prompt_blocks_and_system(body)
+        if not prompt:
+            # Defensive — same rationale as the Codex branch above.
+            raise HTTPException(
+                status_code=400,
+                detail="Multimodal input produced no usable content blocks",
+            )
     else:
         prompt, system_prompt = _response_prompt_and_system(body, workspace)
 
@@ -1832,6 +1861,17 @@ async def create_response(
     # backend; other backends pass through unchanged.
     if isinstance(prompt, str):
         await _validate_backend_prompt(resolved, prompt, workspace_str)
+    elif resolved.backend == "claude":
+        # Block-mode prompts get the same slash validation on their text.
+        await _validate_backend_prompt(
+            resolved,
+            "\n".join(
+                b.get("text", "")
+                for b in prompt
+                if isinstance(b, dict) and b.get("type") == "text"
+            ),
+            workspace_str,
+        )
 
     if body.background:
         return await _create_background_response(

--- a/tests/test_claude_native_images.py
+++ b/tests/test_claude_native_images.py
@@ -1,0 +1,293 @@
+"""Tests for native inline image blocks on the Claude backend (issue #140).
+
+Covers the full Fix A path: data-URL → Anthropic image block conversion
+(no disk round-trip), Responses input → content blocks, the route branch
+helper, and the SDK streaming-input wrapping in the Claude client.
+"""
+
+import base64
+from typing import Optional
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from src.constants import DEFAULT_MODEL
+from src.image_handler import MAX_IMAGE_SIZE, ImageHandler
+from src.message_adapter import MessageAdapter
+
+# 1x1 transparent PNG
+PNG_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk"
+    "YPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+)
+PNG_DATA_URL = f"data:image/png;base64,{PNG_B64}"
+
+
+def _make_cli(cwd: Optional[str] = None):
+    """Create a ClaudeCodeCLI instance with auth mocked out."""
+    with patch("src.auth.validate_claude_code_auth") as mock_validate:
+        with patch("src.auth.auth_manager") as mock_auth:
+            mock_validate.return_value = (True, {"method": "anthropic"})
+            mock_auth.get_claude_code_env_vars.return_value = {
+                "ANTHROPIC_AUTH_TOKEN": "test-key",
+            }
+            from src.backends.claude.client import ClaudeCodeCLI
+
+            return ClaudeCodeCLI(cwd=cwd or "/tmp")
+
+
+# ---------------------------------------------------------------------------
+# ImageHandler.data_url_to_image_block
+# ---------------------------------------------------------------------------
+
+
+class TestDataUrlToImageBlock:
+    def test_valid_png_block(self):
+        block = ImageHandler.data_url_to_image_block(PNG_DATA_URL)
+        assert block == {
+            "type": "image",
+            "source": {"type": "base64", "media_type": "image/png", "data": PNG_B64},
+        }
+
+    def test_unsupported_media_type_raises(self):
+        with pytest.raises(ValueError, match="Unsupported image type"):
+            ImageHandler.data_url_to_image_block(f"data:image/tiff;base64,{PNG_B64}")
+
+    def test_malformed_base64_raises(self):
+        with pytest.raises(ValueError, match="Malformed image base64"):
+            ImageHandler.data_url_to_image_block("data:image/png;base64,@@not-base64@@")
+
+    def test_non_data_url_raises(self):
+        with pytest.raises(ValueError, match="Only data: URLs"):
+            ImageHandler.data_url_to_image_block("https://example.com/img.png")
+
+    def test_oversize_image_raises(self):
+        big = base64.b64encode(b"\x00" * (MAX_IMAGE_SIZE + 1)).decode()
+        with pytest.raises(ValueError, match="exceeds"):
+            ImageHandler.data_url_to_image_block(f"data:image/png;base64,{big}")
+
+    def test_no_disk_write(self, tmp_path):
+        """Block conversion never touches the workspace image dir."""
+        handler = ImageHandler(tmp_path)
+        ImageHandler.data_url_to_image_block(PNG_DATA_URL)
+        assert list(handler.image_dir.iterdir()) == []
+
+
+# ---------------------------------------------------------------------------
+# MessageAdapter.response_input_to_claude_blocks
+# ---------------------------------------------------------------------------
+
+
+class TestResponseInputToClaudeBlocks:
+    def test_string_input(self):
+        blocks = MessageAdapter.response_input_to_claude_blocks("hello")
+        assert blocks == [{"type": "text", "text": "hello"}]
+
+    def test_empty_string_input(self):
+        assert MessageAdapter.response_input_to_claude_blocks("   ") == []
+
+    def test_text_and_image_order_preserved(self):
+        from src.response_models import ResponseInputItem
+
+        items = [
+            ResponseInputItem(
+                role="user",
+                content=[
+                    {"type": "input_text", "text": "what is in this image?"},
+                    {"type": "input_image", "image_url": PNG_DATA_URL},
+                ],
+            )
+        ]
+        blocks = MessageAdapter.response_input_to_claude_blocks(items)
+        assert [b["type"] for b in blocks] == ["text", "image"]
+        assert blocks[0]["text"] == "what is in this image?"
+        assert blocks[1]["source"]["data"] == PNG_B64
+
+    def test_image_before_text(self):
+        from src.response_models import ResponseInputItem
+
+        items = [
+            ResponseInputItem(
+                role="user",
+                content=[
+                    {"type": "input_image", "image_url": PNG_DATA_URL},
+                    {"type": "input_text", "text": "describe it"},
+                ],
+            )
+        ]
+        blocks = MessageAdapter.response_input_to_claude_blocks(items)
+        assert [b["type"] for b in blocks] == ["image", "text"]
+
+    def test_multiple_items_concatenate(self):
+        from src.response_models import ResponseInputItem
+
+        items = [
+            ResponseInputItem(role="user", content="first"),
+            ResponseInputItem(
+                role="user",
+                content=[{"type": "input_image", "image_url": PNG_DATA_URL}],
+            ),
+        ]
+        blocks = MessageAdapter.response_input_to_claude_blocks(items)
+        assert [b["type"] for b in blocks] == ["text", "image"]
+        assert blocks[0]["text"] == "first"
+
+    def test_empty_image_url_skipped(self):
+        from src.response_models import ResponseInputItem
+
+        items = [
+            ResponseInputItem(
+                role="user",
+                content=[
+                    {"type": "input_text", "text": "no image attached"},
+                    {"type": "input_image", "image_url": ""},
+                ],
+            )
+        ]
+        blocks = MessageAdapter.response_input_to_claude_blocks(items)
+        assert blocks == [{"type": "text", "text": "no image attached"}]
+
+    def test_invalid_image_raises_value_error(self):
+        from src.response_models import ResponseInputItem
+
+        items = [
+            ResponseInputItem(
+                role="user",
+                content=[{"type": "input_image", "image_url": "https://x/y.png"}],
+            )
+        ]
+        with pytest.raises(ValueError):
+            MessageAdapter.response_input_to_claude_blocks(items)
+
+    def test_text_blocks_are_content_filtered(self):
+        """Raw base64 data URIs in *text* are stripped, same as the string path."""
+        from src.response_models import ResponseInputItem
+
+        items = [
+            ResponseInputItem(
+                role="user",
+                content=[
+                    {
+                        "type": "input_text",
+                        "text": f"look: {PNG_DATA_URL}",
+                    }
+                ],
+            )
+        ]
+        blocks = MessageAdapter.response_input_to_claude_blocks(items)
+        assert len(blocks) == 1
+        assert PNG_B64 not in blocks[0]["text"]
+        assert "[base64 image data removed]" in blocks[0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# Route helper: _response_prompt_blocks_and_system
+# ---------------------------------------------------------------------------
+
+
+class TestResponsePromptBlocksAndSystem:
+    def test_blocks_and_system_split(self):
+        from src.response_models import ResponseCreateRequest, ResponseInputItem
+        from src.routes.responses import _response_prompt_blocks_and_system
+
+        body = ResponseCreateRequest(
+            model=DEFAULT_MODEL,
+            input=[
+                ResponseInputItem(role="system", content="be terse"),
+                ResponseInputItem(
+                    role="user",
+                    content=[
+                        {"type": "input_text", "text": "what color?"},
+                        {"type": "input_image", "image_url": PNG_DATA_URL},
+                    ],
+                ),
+            ],
+        )
+        blocks, system_prompt = _response_prompt_blocks_and_system(body)
+        assert system_prompt == "be terse"
+        assert [b["type"] for b in blocks] == ["text", "image"]
+
+    def test_invalid_image_becomes_400(self):
+        from src.response_models import ResponseCreateRequest, ResponseInputItem
+        from src.routes.responses import _response_prompt_blocks_and_system
+
+        body = ResponseCreateRequest(
+            model=DEFAULT_MODEL,
+            input=[
+                ResponseInputItem(
+                    role="user",
+                    content=[{"type": "input_image", "image_url": "http://remote/x.png"}],
+                )
+            ],
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            _response_prompt_blocks_and_system(body)
+        assert exc_info.value.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Claude client: block-list prompt sent as SDK streaming input
+# ---------------------------------------------------------------------------
+
+
+class TestRunCompletionWithBlockPrompt:
+    async def test_block_prompt_wrapped_as_streaming_input(self):
+        from src.session_manager import Session
+
+        cli = _make_cli()
+        session = Session(session_id="sess-img")
+
+        captured = {}
+
+        async def capture_query(prompt):
+            if isinstance(prompt, str):
+                captured["messages"] = prompt
+            else:
+                captured["messages"] = [msg async for msg in prompt]
+
+        mock_client = AsyncMock()
+        mock_client.query.side_effect = capture_query
+
+        async def empty_receive():
+            return
+            yield
+
+        mock_client.receive_response = empty_receive
+
+        blocks = [
+            {"type": "text", "text": "what color?"},
+            {
+                "type": "image",
+                "source": {"type": "base64", "media_type": "image/png", "data": PNG_B64},
+            },
+        ]
+        async for _ in cli.run_completion_with_client(mock_client, blocks, session):
+            pass
+
+        assert captured["messages"] == [
+            {
+                "type": "user",
+                "message": {"role": "user", "content": blocks},
+                "parent_tool_use_id": None,
+            }
+        ]
+
+    async def test_string_prompt_still_passed_verbatim(self):
+        from src.session_manager import Session
+
+        cli = _make_cli()
+        session = Session(session_id="sess-str")
+
+        mock_client = AsyncMock()
+
+        async def empty_receive():
+            return
+            yield
+
+        mock_client.receive_response = empty_receive
+
+        async for _ in cli.run_completion_with_client(mock_client, "plain text", session):
+            pass
+
+        mock_client.query.assert_awaited_once_with("plain text")


### PR DESCRIPTION
issue #140의 Fix A입니다.

## 문제

Claude 백엔드의 `/v1/responses`가 `input_image`를 디스크에 디코딩하고 텍스트 프롬프트에 `<attached_image path=...>` 플레이스홀더를 삽입해, 모델이 자기 Read 툴로 픽셀을 보게 만들었습니다. 이 라운드트립은 OpenAI 포맷 프록시(LiteLLM/vLLM) 뒤에서 깨집니다 — Read 결과 이미지가 `tool_result`에 실리는데, OpenAI `role:"tool"` 메시지는 이미지 파트를 못 실어서 평탄화되거나 드롭됩니다 (#140에서 실측으로 확정한 원인).

## 변경

Claude 백엔드의 멀티모달 `/v1/responses` 턴이 `input_image`를 **네이티브 Anthropic `{"type": "image"}` 블록으로 변환해 SDK 스트리밍 입력으로 직접 전달**합니다. 이미지가 첫 user 턴에 인라인으로 실리므로 디스크 저장·플레이스홀더·Read 의존이 모두 사라지고, OpenAI 포맷 변환기가 정식 지원하는 경로(`image_url` 파트)만 탑니다.

| 위치 | 변경 |
|---|---|
| `src/image_handler.py` | `data_url_to_image_block()` — data URL → image 블록. 저장 경로와 동일한 검증(media type, base64, 5MB 캡), 디스크 무접촉 |
| `src/message_adapter.py` | `response_input_to_claude_blocks()` — Responses input → 순서 보존 text/image 블록, 기존 `filter_content` 동일 적용 |
| `src/routes/responses.py` | 기존 코덱스 멀티모달 브랜치와 대칭인 claude 브랜치 (`_response_prompt_blocks_and_system`); 블록 모드 프롬프트도 텍스트 파트에 동일한 slash-command 검증 |
| `src/backends/claude/client.py` | `run_completion_with_client`가 블록 리스트 프롬프트를 받으면 SDK `query()`의 문자열 경로와 동일한 message dict로 스트리밍 입력 래핑 |
| `src/backends/base.py` | 프로토콜 독스트링 갱신 (리스트 프롬프트: Codex items / Claude content blocks) |

## 설계 노트

- **코덱스 선례 재사용**: `prompt: Any = codex_items`로 리스트 프롬프트가 라우트를 흐르는 인프라(세션 저장 `Message.normalize_content`, 토큰 추정 폴백)가 이미 존재 — 동일 패턴으로 최소 침습.
- **텍스트 전용 요청 무변경**: 문자열 프롬프트 경로 그대로 유지.
- `/v1/agents/messages`는 계약대로 텍스트 전용 유지 (변경 없음).
- 역할 분담: **Fix A = 첨부 이미지** (이 PR), **tool_result 이미지 재배치 = sanitizer** (`claude/sanitizer-tool-images` / litellm_serving PR #16) — 모델이 자발적으로 이미지 파일을 Read하는 케이스 담당. 보완적이며 충돌 없음.

## 테스트

- 신규 18개 (`tests/test_claude_native_images.py`): 블록 변환(순서/검증/필터), 라우트 헬퍼(400 처리), 클라이언트 스트리밍 입력 래핑(정확한 message dict 형태), 문자열 경로 무변경 가드.
- 전체 스위트 통과 (2,490 passed / 133 deselected). `test_usage_queries_sqlite` 2건 실패는 베이스 커밋에서도 동일한 기존 KST 환경 이슈로 무관 확인.
- SDK 0.2.108 `query()`의 AsyncIterable 스트리밍 입력 계약 소스 확인 완료 — #140 코멘트의 실측과 일치.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NgA7pMJR9Earn7DSHPuh4E)_