### PR TITLE
AskUserQuestion 파킹 레이스 수정 + 자동 압축 창 런타임 설정 + 워크스페이스 dotfile 기본값

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -332,6 +332,13 @@ DEFAULT_MODEL=sonnet
 # STREAM_HOOK_EVENTS=true
 # STREAM_COMPACTION_EVENTS=true
 
+# 자동 압축이 **언제** 일어나는가 — CLI가 읽는 컨텍스트 창(토큰).
+# 낮출수록 일찍 압축되어 긴 에이전틱 턴이 작은 업스트림 창 안에 머무는 대신
+# 오래된 세부를 잃는다. 미설정이면 CLI가 모델에서 스스로 정한다.
+# 어드민 패널("Auto-compact window")에서 재시작 없이 바꿀 수 있고, 그 오버라이드가
+# 이 값을 이긴다. **새 세션에만** 적용된다(이미 열린 세션은 원래 창을 유지).
+# CLAUDE_CODE_AUTO_COMPACT_WINDOW=120000
+
 # Bash 샌드박스 (Bash 도구 실행의 OS 수준 프로세스 격리)
 # 3상태: 미설정 = 프로젝트 수준 설정 존중, true = 강제 켜기, false = 강제 끄기
 # Bash 명령에만 영향을 준다. Read/Edit/Write 접근은 SDK 권한 규칙이 제어한다.

--- a/src/admin_html_config.py
+++ b/src/admin_html_config.py
@@ -38,10 +38,11 @@ def get_config_html() -> str:
                         </select>
                       </template>
                       <template x-if="meta.type === 'int'">
-                        <input type="number" :value="meta.value" min="1"
+                        <input type="number" :value="meta.value" :min="meta.min || 1"
+                          :step="(meta.min || 1) >= 1000 ? 10000 : 1"
                           :aria-label="'Set ' + meta.label"
                           @change="updateRuntimeConfig(key, parseInt($event.target.value))"
-                          style="padding:4px 8px; font-size:0.75rem; width:100px">
+                          style="padding:4px 8px; font-size:0.75rem; width:120px">
                       </template>
                       <template x-if="meta.type === 'string' && Array.isArray(meta.options)">
                         <select :value="meta.value"

--- a/src/backends/claude/client.py
+++ b/src/backends/claude/client.py
@@ -767,6 +767,14 @@ class ClaudeCodeCLI(TokenEstimateMixin):
                 "1" if runtime_config.get("agent_teams_enabled") else ""
             )
 
+        # Auto-compact window: same shape as agent teams — only an explicit
+        # admin override touches the child env, so with no override the process
+        # env (or the CLI's own default) passes through untouched. The CLI reads
+        # this env var ahead of its `autoCompactWindow` setting.
+        if runtime_config.is_overridden("auto_compact_window"):
+            window = runtime_config.get("auto_compact_window")
+            sdk_env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = str(window) if window else ""
+
         if sdk_env:
             options.env.update(sdk_env)
 

--- a/src/routes/responses.py
+++ b/src/routes/responses.py
@@ -2121,6 +2121,10 @@ async def create_response(
                         "previous_response_id": body.previous_response_id,
                         "turn": next_turn,
                         "use_sdk_client": True,
+                        # 파킹(AskUserQuestion) 여부를 종료 직전에 물어보기 위해
+                        # 세션 자체를 넘긴다 — 아래에서 pending_tool_call을 보고
+                        # requires_action을 쏘는 것과 **같은 근거**여야 한다.
+                        "session": session,
                     },
                 )
                 async for line in streaming_utils.bridge_sse_stream(sse_source, chunk_source):

--- a/src/routes/terminal_files.py
+++ b/src/routes/terminal_files.py
@@ -29,8 +29,10 @@ name so the two agree (no code coupling to the caller's product).
 
 Config:
 - ``WORKSPACE_USER_HEADER`` — inbound identity header name (default ``X-User-Email``).
-- ``WORKSPACE_HIDE_DOTFILES`` — when true (default), dot-prefixed entries are
-  neither listed nor accessible.
+- ``WORKSPACE_HIDE_DOTFILES`` — when true, dot-prefixed entries are neither
+  listed nor accessible. Default **false**: hiding is a presentation choice that
+  belongs to the client rendering the tree, and hiding them here also blocks
+  writes to the workspace's agent-resource directories.
 
 Concurrency:
 - Filesystem work (directory scans, file reads/writes, deletes, zip builds) runs
@@ -100,8 +102,19 @@ def _user_header() -> str:
 
 
 def _hide_dotfiles() -> bool:
-    """When true (default), dot-prefixed entries are neither listed nor accessible."""
-    return os.getenv("WORKSPACE_HIDE_DOTFILES", "true").strip().lower() == "true"
+    """When true, dot-prefixed entries are neither listed nor accessible.
+
+    Defaults to **false**: hiding dotfiles protects nothing here — the agent
+    itself reads and writes them freely through Bash/Read within the same
+    workspace, and the real guards are ``API_KEY`` plus root confinement. What it
+    *did* do was make the workspace's agent-resource directories unreachable over
+    ``/files/*`` (a 404 on any dot-prefixed component, including writes), which
+    silently breaks clients that install skills/subagents through this API. Hiding
+    is presentation, so it belongs to the client that renders the tree — see the
+    Finder-style "show hidden items" toggle in ChatDRAGON's files panel. Set this
+    to ``true`` to restore server-side hiding for a deployment that wants it.
+    """
+    return os.getenv("WORKSPACE_HIDE_DOTFILES", "false").strip().lower() == "true"
 
 
 def _ensure_api_key() -> None:

--- a/src/runtime_config.py
+++ b/src/runtime_config.py
@@ -20,6 +20,14 @@ from typing import Any, Dict
 
 logger = logging.getLogger(__name__)
 
+
+def _int_env(name: str) -> int:
+    """Read an int env var, treating unset/junk as 0 ("not configured")."""
+    try:
+        return int(os.environ.get(name, "") or 0)
+    except ValueError:
+        return 0
+
 # ---------------------------------------------------------------------------
 # Editable key definitions
 # ---------------------------------------------------------------------------
@@ -59,6 +67,18 @@ EDITABLE_KEYS: Dict[str, Dict[str, Any]] = {
         "label": "Sanitizer (/v1/messages)",
         "type": "bool",
         "description": "Anthropic SSE sanitizer; effective only when ANTHROPIC_BASE_URL is set",
+    },
+    "auto_compact_window": {
+        "label": "Auto-compact window (tokens)",
+        "type": "int",
+        "min": 20000,
+        "description": (
+            "Context size at which the CLI auto-compacts a session "
+            "(CLAUDE_CODE_AUTO_COMPACT_WINDOW). Lower = compacts sooner, so long "
+            "agentic turns stay under a small upstream window at the cost of "
+            "losing older detail. 0 = leave the CLI default alone. Applies to NEW "
+            "sessions; an override wins over the gateway process env."
+        ),
     },
     "agent_teams_enabled": {
         "label": "Agent Teams",
@@ -172,6 +192,10 @@ class RuntimeConfig:
             "agent_teams_enabled": bool(
                 os.environ.get("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS")
             ),
+            # 0 = not set — the CLI picks its own window from the model.
+            # A junk value reads as 0 rather than crashing the config read;
+            # the CLI ignores junk the same way.
+            "auto_compact_window": _int_env("CLAUDE_CODE_AUTO_COMPACT_WINDOW"),
         }
         return _map.get(key)
 
@@ -182,8 +206,11 @@ class RuntimeConfig:
         expected = meta["type"]
         if expected == "int":
             v = int(value)
-            if v < 1:
-                raise ValueError(f"{key} must be >= 1, got {v}")
+            # A per-key floor where 1 is meaningless — a 1-token compaction
+            # window would compact on every turn and lose the conversation.
+            low = meta.get("min", 1)
+            if v < low:
+                raise ValueError(f"{key} must be >= {low}, got {v}")
             return v
         if expected == "bool":
             if isinstance(value, bool):

--- a/src/streaming_utils.py
+++ b/src/streaming_utils.py
@@ -1461,6 +1461,38 @@ async def stream_response_chunks(
 
     # --- Finalization ---
 
+    # **파킹된 턴은 완료된 턴이 아니다.**
+    #
+    # AskUserQuestion은 `can_use_tool` 콜백이 세션을 세워 두고 사용자의 답을
+    # 기다린다. 그 사이 SDK 메시지 반복자는 끝나 버릴 수 있고(실측: 모델이
+    # thinking만 내고 질문한 턴), 그러면 위쪽 `stream_break_event` 레이스에서
+    # `get_next`가 먼저 이겨 루프가 "정상 종료"로 빠져나온다. 그대로 두면 여기서
+    # `status="completed"`를 먼저 쏘고, 라우트가 뒤이어 `requires_action`을
+    # **한 번 더** 쏜다 — 클라이언트는 첫 완료를 보고 턴을 닫으므로 질문 카드가
+    # 영영 안 뜨고, 게이트웨이는 300초 뒤 타임아웃으로 끝난다 (issue #13).
+    #
+    # 아래 "내용이 없으면 라우트에 맡긴다" 가드가 이 경우를 잡아 주기를 기대했지만
+    # 그건 **내용의 유무**를 물을 뿐이다. 물어야 할 것은 파킹 여부다.
+    _paused_session = (
+        (request_context or {}).get("session") if isinstance(request_context, dict) else None
+    )
+    if getattr(_paused_session, "pending_tool_call", None) is not None:
+        logger.info("Responses stream paused on a pending tool call — deferring completion")
+        # 열려 있는 항목은 닫아 준다. 완료 이벤트는 라우트가 requires_action으로
+        # 쏘므로 여기서 쏘지 않는다.
+        _close_thinking_capture()
+        if reasoning_open:
+            for line in _close_reasoning():
+                yield line
+        if message_item_opened:
+            for line in _close_message_item():
+                yield line
+        stream_result["success"] = False
+        stream_result["paused"] = True
+        stream_result["assistant_text"] = "".join(all_visible_text)
+        stream_result["thinking_texts"] = thinking_texts
+        return
+
     # No content received AND no reasoning emitted.  Don't yield a failed event
     # here: the caller may still need to emit function_call + requires_action
     # (AskUserQuestion hook path).  Signal "empty" via stream_result and let

--- a/tests/test_auq_pause_completion.py
+++ b/tests/test_auq_pause_completion.py
@@ -1,0 +1,135 @@
+"""파킹된 AskUserQuestion 턴은 `completed`를 쏘지 않는다 (issue #13).
+
+증상은 UI 쪽에서 났다: 질문 카드가 뜨지 않고 "결과 (중단됨 — 결과 미수신)"만
+남았다가 300초 뒤 게이트웨이가 `AskUserQuestion timed out`으로 끝났다.
+
+원인은 여기다. `can_use_tool`이 세션을 세워 두고 답을 기다리는 동안 SDK 메시지
+반복자가 먼저 끝날 수 있고(모델이 thinking만 내고 질문한 턴), 그러면
+`stream_break_event` 레이스에서 `get_next`가 이겨 스트림 루프가 "정상 종료"로
+빠져나온다. 그 결과 종료 시퀀스가 `status="completed"`를 먼저 쏘고, 라우트가
+뒤이어 `requires_action`을 **한 번 더** 쏜다. 클라이언트는 첫 완료를 보고 턴을
+닫으므로 두 번째는 도착해도 소용이 없다.
+
+기존 가드(`not content_sent and not thinking_seen`)는 **내용의 유무**를 물었다.
+물어야 할 것은 파킹 여부다 — thinking이 하나라도 있으면 그 가드는 통과한다.
+"""
+
+import json
+
+import pytest
+
+from src.streaming_utils import stream_response_chunks
+
+
+class _Session:
+    """세션 대역 — 여기서 중요한 건 `pending_tool_call` 하나뿐이다."""
+
+    def __init__(self, pending=None):
+        self.pending_tool_call = pending
+
+
+def _thinking_then_end():
+    """모델이 thinking만 내고 질문한 턴 — 실측된 그 모양."""
+
+    async def gen():
+        yield {
+            "type": "assistant",
+            "content": [{"type": "thinking", "thinking": "어느 환경인지 물어봐야겠다"}],
+        }
+
+    return gen()
+
+
+async def _collect(source, session):
+    result: dict = {}
+    lines: list[str] = []
+    async for line in stream_response_chunks(
+        source,
+        model="test-model",
+        response_id="resp_1",
+        output_item_id="msg_1",
+        chunks_buffer=[],
+        logger=__import__("logging").getLogger(__name__),
+        stream_result=result,
+        request_context={"session": session, "use_sdk_client": True},
+    ):
+        lines.append(line)
+    return lines, result
+
+
+def _completions(lines: list[str]) -> list[dict]:
+    out = []
+    for line in lines:
+        for part in line.split("\n"):
+            if not part.startswith("data:"):
+                continue
+            try:
+                ev = json.loads(part[5:].strip())
+            except ValueError:
+                continue
+            if ev.get("type") == "response.completed":
+                out.append(ev)
+    return out
+
+
+@pytest.mark.asyncio
+async def test_parked_turn_emits_no_completed_event():
+    """파킹 중이면 완료 이벤트는 라우트(requires_action)에게 맡긴다."""
+    session = _Session(pending={"call_id": "toolu_1", "name": "AskUserQuestion", "arguments": {}})
+    lines, result = await _collect(_thinking_then_end(), session)
+
+    assert _completions(lines) == [], "파킹된 턴이 completed를 쐈다 — 카드가 안 뜬다"
+    assert result.get("paused") is True
+    assert result.get("success") is False
+
+
+@pytest.mark.asyncio
+async def test_thinking_only_turn_completes_normally_when_not_parked():
+    """파킹이 아니면 예전 그대로 — thinking만 있는 턴도 정상 종료한다."""
+    session = _Session(pending=None)
+    lines, result = await _collect(_thinking_then_end(), session)
+
+    done = _completions(lines)
+    assert len(done) == 1
+    assert done[0]["response"]["status"] == "completed"
+    assert result.get("success") is True
+    assert not result.get("paused")
+
+
+@pytest.mark.asyncio
+async def test_parked_turn_still_closes_open_items():
+    """완료를 미룬다고 열어 둔 reasoning 항목까지 흘리지는 않는다."""
+    session = _Session(pending={"call_id": "toolu_1", "name": "AskUserQuestion", "arguments": {}})
+    lines, _ = await _collect(_thinking_then_end(), session)
+
+    kinds = []
+    for line in lines:
+        for part in line.split("\n"):
+            if part.startswith("data:"):
+                try:
+                    kinds.append(json.loads(part[5:].strip()).get("type"))
+                except ValueError:
+                    pass
+    opened = kinds.count("response.output_item.added")
+    closed = kinds.count("response.output_item.done")
+    assert opened == closed, f"열린 항목 {opened}개, 닫힌 항목 {closed}개"
+
+
+@pytest.mark.asyncio
+async def test_no_session_in_context_behaves_as_before():
+    """세션을 안 넘기는 경로(다른 백엔드 등)는 영향을 받지 않는다."""
+    result: dict = {}
+    lines: list[str] = []
+    async for line in stream_response_chunks(
+        _thinking_then_end(),
+        model="test-model",
+        response_id="resp_1",
+        output_item_id="msg_1",
+        chunks_buffer=[],
+        logger=__import__("logging").getLogger(__name__),
+        stream_result=result,
+        request_context={"use_sdk_client": True},
+    ):
+        lines.append(line)
+    assert len(_completions(lines)) == 1
+    assert result.get("success") is True

--- a/tests/test_claude_cli_unit.py
+++ b/tests/test_claude_cli_unit.py
@@ -602,6 +602,38 @@ class TestBuildSdkOptions:
             opts = cli_instance._build_sdk_options(effort="none")
         assert opts.thinking == {"type": "disabled"}
 
+    def test_auto_compact_window_not_injected_without_override(
+        self, cli_instance, monkeypatch
+    ):
+        """No admin override → the operator's env (or the CLI default) stands."""
+        from src.runtime_config import runtime_config
+
+        monkeypatch.setenv("CLAUDE_CODE_AUTO_COMPACT_WINDOW", "150000")
+        runtime_config.reset("auto_compact_window")
+        opts = cli_instance._build_sdk_options()
+        assert "CLAUDE_CODE_AUTO_COMPACT_WINDOW" not in (opts.env or {})
+
+    def test_auto_compact_window_override_reaches_the_cli(self, cli_instance):
+        """The admin value lands on the env var the CLI actually reads."""
+        from src.runtime_config import runtime_config
+
+        runtime_config.set("auto_compact_window", 120000)
+        try:
+            opts = cli_instance._build_sdk_options()
+            assert opts.env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "120000"
+        finally:
+            runtime_config.reset("auto_compact_window")
+
+    def test_auto_compact_window_rejects_a_useless_floor(self):
+        """A 1-token window would compact every turn — the floor refuses it."""
+        import pytest as _pytest
+
+        from src.runtime_config import runtime_config
+
+        with _pytest.raises(ValueError):
+            runtime_config.set("auto_compact_window", 500)
+        assert not runtime_config.is_overridden("auto_compact_window")
+
     def test_agent_teams_not_injected_without_override(self, cli_instance, monkeypatch):
         """No admin override → the CLI gate env passes through untouched."""
         from src.runtime_config import runtime_config

--- a/tests/test_terminal_files.py
+++ b/tests/test_terminal_files.py
@@ -100,7 +100,9 @@ def test_list_root_sorts_dirs_first(client):
     assert r.status_code == 200
     entries = r.json()["entries"]
     names = [e["name"] for e in entries]
-    assert names == ["sub", "blob.bin", "notes.txt"]  # dir first, then files a-z
+    # dirs first, then files, each a-z — dot-prefixed entries sort with the rest
+    # now that the server no longer hides them.
+    assert names == [".secret_dir", "sub", ".env", "blob.bin", "notes.txt"]
     sub = next(e for e in entries if e["name"] == "sub")
     assert sub["type"] == "directory"
     notes = next(e for e in entries if e["name"] == "notes.txt")
@@ -202,16 +204,56 @@ def test_missing_file_is_404(client):
 
 
 # --- dotfile hiding -----------------------------------------------------------
+#
+# Off by default (2026-08). Server-side hiding blocked WRITES to dot-prefixed
+# paths too, so clients installing agent resources into the workspace got a 404
+# from a flag that was only ever meant to tidy a listing. Hiding is presentation
+# and now belongs to the client rendering the tree; the flag stays for
+# deployments that want the old behavior.
 
 
-def test_dotfiles_hidden_by_default(client):
+def test_dotfiles_visible_by_default(client):
     r = client.get("/files/list?directory=/", headers={**_AUTH, **_USER})
     names = [e["name"] for e in r.json()["entries"]]
-    assert ".env" not in names and ".secret_dir" not in names
+    assert ".env" in names and ".secret_dir" in names
+
+
+def test_hidden_path_accessible_by_default(client):
+    # Reading and listing inside a dot-prefixed path is allowed...
+    rr = client.get("/files/read?path=/.env", headers={**_AUTH, **_USER})
+    assert rr.status_code == 200 and rr.json()["content"] == "TOKEN=abc"
+    assert (
+        client.get("/files/list?directory=/.secret_dir", headers={**_AUTH, **_USER}).status_code
+        == 200
+    )
+
+
+def test_dot_prefixed_write_path_is_allowed_by_default(client, workspace):
+    """The regression this default exists for: installing into a dot-prefixed
+    directory must not 404. mkdir + upload is how a client writes agent
+    resources (skills, subagents) into the workspace."""
+    r = client.post(
+        "/files/mkdir", headers={**_AUTH, **_USER}, json={"path": "/.agent/skills/demo"}
+    )
+    assert r.status_code == 200
+    up = client.post(
+        "/files/upload?directory=/.agent/skills/demo",
+        headers={**_AUTH, **_USER},
+        files={"file": ("SKILL.md", b"# demo", "text/markdown")},
+    )
+    assert up.status_code == 200
+    assert (workspace / ".agent" / "skills" / "demo" / "SKILL.md").read_text() == "# demo"
+
+
+def test_dotfiles_hidden_when_enabled(client, monkeypatch):
+    monkeypatch.setenv("WORKSPACE_HIDE_DOTFILES", "true")
+    r = client.get("/files/list?directory=/", headers={**_AUTH, **_USER})
+    names = [e["name"] for e in r.json()["entries"]]
     assert names == ["sub", "blob.bin", "notes.txt"]
 
 
-def test_hidden_path_not_accessible_by_default(client):
+def test_hidden_path_not_accessible_when_enabled(client, monkeypatch):
+    monkeypatch.setenv("WORKSPACE_HIDE_DOTFILES", "true")
     # Even typing the path directly is blocked (list/read/inside-dir).
     assert client.get("/files/read?path=/.env", headers={**_AUTH, **_USER}).status_code == 404
     assert (
@@ -222,16 +264,6 @@ def test_hidden_path_not_accessible_by_default(client):
         client.get("/files/read?path=/.secret_dir/k.txt", headers={**_AUTH, **_USER}).status_code
         == 404
     )
-
-
-def test_dotfiles_shown_when_disabled(client, monkeypatch):
-    monkeypatch.setenv("WORKSPACE_HIDE_DOTFILES", "false")
-    r = client.get("/files/list?directory=/", headers={**_AUTH, **_USER})
-    names = [e["name"] for e in r.json()["entries"]]
-    assert ".env" in names and ".secret_dir" in names
-    # ...and now readable.
-    rr = client.get("/files/read?path=/.env", headers={**_AUTH, **_USER})
-    assert rr.status_code == 200 and rr.json()["content"] == "TOKEN=abc"
 
 
 # --- write operations ---------------------------------------------------------
@@ -341,9 +373,10 @@ def test_archive_zips_selection(client):
     assert "notes.txt" in names and "sub/inner.md" in names
 
 
-def test_archive_excludes_hidden_entries(client):
-    """Directory downloads must not sweep in dotfiles (e.g. .claude) that the
-    browser hides — the zip mirrors the visible listing."""
+def test_archive_excludes_hidden_entries_when_enabled(client, monkeypatch):
+    """The zip mirrors the visible listing — when the server hides dotfiles, a
+    directory download must not sweep them back in."""
+    monkeypatch.setenv("WORKSPACE_HIDE_DOTFILES", "true")
     r = client.post(
         "/files/archive",
         headers={**_AUTH, **_USER},
@@ -359,8 +392,7 @@ def test_archive_excludes_hidden_entries(client):
     assert not any(n.startswith(".secret_dir/") for n in names)
 
 
-def test_archive_includes_hidden_when_disabled(client, monkeypatch):
-    monkeypatch.setenv("WORKSPACE_HIDE_DOTFILES", "false")
+def test_archive_includes_hidden_by_default(client):
     r = client.post(
         "/files/archive",
         headers={**_AUTH, **_USER},
@@ -372,6 +404,7 @@ def test_archive_includes_hidden_when_disabled(client, monkeypatch):
 
     names = _zip.ZipFile(_io.BytesIO(r.content)).namelist()
     assert ".env" in names and ".secret_dir/k.txt" in names
+    assert "notes.txt" in names
 
 
 def test_search_finds_nested_files(client):
@@ -393,15 +426,14 @@ def test_search_is_case_insensitive_and_matches_dirs(client):
     assert any(e["name"] == "sub" and e["type"] == "directory" for e in results)
 
 
-def test_search_excludes_hidden_entries(client):
+def test_search_excludes_hidden_entries_when_enabled(client, monkeypatch):
+    monkeypatch.setenv("WORKSPACE_HIDE_DOTFILES", "true")
     r = client.get("/files/search?query=secret", headers={**_AUTH, **_USER})
     assert r.status_code == 200
     assert r.json()["results"] == []
-    # ...but finds them when hiding is disabled.
 
 
-def test_search_includes_hidden_when_disabled(client, monkeypatch):
-    monkeypatch.setenv("WORKSPACE_HIDE_DOTFILES", "false")
+def test_search_includes_hidden_by_default(client):
     r = client.get("/files/search?query=secret", headers={**_AUTH, **_USER})
     names = [e["name"] for e in r.json()["results"]]
     assert ".secret_dir" in names
@@ -467,7 +499,8 @@ def test_serve_outside_root_never_leaks(client, workspace):
     assert "SECRET" not in r.text
 
 
-def test_serve_hidden_file_is_404(client, workspace):
+def test_serve_hidden_file_is_404_when_enabled(client, workspace, monkeypatch):
+    monkeypatch.setenv("WORKSPACE_HIDE_DOTFILES", "true")
     d = str(workspace.resolve())
     r = client.get(f"/files/serve{d}/.env", headers={**_AUTH, **_USER})
     assert r.status_code == 404


### PR DESCRIPTION
## 무엇이 바뀌나

### 1. fix(responses): 파킹된 AskUserQuestion 턴이 `completed`를 먼저 쏘던 레이스 (ChatDRAGON_UI [issue #13](https://github.com/Kyutinium/ChatDRAGON_UI/issues/13))

`can_use_tool`이 세션을 세워 두고 답을 기다리는 동안 SDK 메시지 반복자가 먼저 끝날 수 있다(모델이 thinking만 내고 질문한 턴 — 로그의 `assistant_chars=0 thinking_blocks=1`). 그러면 `stream_break_event` 레이스에서 `get_next`가 이겨 스트림 루프가 "정상 종료"로 빠져나오고, 종료 시퀀스가 `status="completed"`를 쏜 뒤 라우트가 `requires_action`을 **한 번 더** 쏜다. 클라이언트는 첫 완료를 보고 턴을 닫으므로 질문 카드가 영영 안 뜨고, 300초 뒤 `AskUserQuestion timed out`으로 끝난다.

기존 가드(`not content_sent and not thinking_seen`)는 **내용의 유무**를 물었다 — thinking이 하나라도 있으면 통과한다. 물어야 할 것은 파킹 여부다. 종료 직전에 세션의 `pending_tool_call`을 본다 — 라우트가 `requires_action`을 쏠지 판단하는 것과 **같은 근거**라 둘이 갈릴 수 없다. 파킹 중이면 열린 항목만 닫고 완료 이벤트는 라우트에 맡긴다.

### 2. feat(admin): 자동 압축 창(auto-compact window)을 런타임에서 조절

CLI가 읽는 `CLAUDE_CODE_AUTO_COMPACT_WINDOW`(자기 `autoCompactWindow` 설정보다 우선 — CLI 2.1.220으로 확인)를 런타임 설정 레지스트리(`EDITABLE_KEYS`)에 올렸다. agent teams와 같은 모양으로 **새 세션 env에만** 투영한다: 오버라이드가 없으면 자식 env를 건드리지 않고, 있으면 프로세스 env를 이긴다. int 키에 `min` 도입(하한 20,000 — 1토큰 창이면 매 턴 압축돼 대화가 안 남는다).

### 3. fix(files): `WORKSPACE_HIDE_DOTFILES` 기본값 false

서버사이드 dotfile 숨김은 보안 경계가 아니다(에이전트는 같은 워크스페이스를 Bash/Read로 자유롭게 읽고 쓴다). 이 스위치가 실제로 한 일은 dot-경로를 `/files/*`에서 mkdir/업로드까지 404로 만든 것 — 목록 정리용 스위치가 쓰기 경로를 부쉈다. 숨김은 표현의 문제라 렌더링하는 쪽 몫으로 옮기고, 플래그는 남기되 기본값만 내린다.

## 검증

- AUQ 회귀 테스트 4종(`tests/test_auq_pause_completion.py`) — `stream_response_chunks`를 직접 태워 파킹 시 완료 이벤트 0개를 못 박는다. 첫 테스트는 고치기 전 코드에서 실패한다.
- 자동 압축: `_build_sdk_options()` env 투영 테스트 3종(오버라이드 없음/있음/하한).
- 전체 스위트 2768 passed. 실패 2건(`test_usage_queries_sqlite.py`)은 `datetime.now()` 의존 ISO 주차 경계의 **기존 결함** — main에서도 동일하게 실패한다.
- `origin/main` 머지 완료 — 충돌 없음.

## 배포 메모

ChatDRAGON UI에는 이 레이스를 받치는 500ms 유예가 별도로 들어갔지만, 그건 받침이다 — 이 수정이 근본이고, 이중 이벤트 자체를 없앤다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfChs8dMHxjsCTrpxitufs

---
_Generated by [Claude Code](https://claude.ai/code/session_01UfChs8dMHxjsCTrpxitufs)_